### PR TITLE
Add interpreter for symbolic expressions

### DIFF
--- a/rust/src/arithmetics.rs
+++ b/rust/src/arithmetics.rs
@@ -23,6 +23,8 @@ fn bin_op(_ops: &mut Vec<Atom>, data: &mut Vec<Atom>, op: fn(i32, i32) -> i32) -
 
 #[cfg(test)]
 mod tests {
+    #![allow(non_snake_case)]
+
     use super::*;
     use crate::interpreter::*;
 
@@ -50,7 +52,7 @@ mod tests {
         assert_eq!(interpret(space, &expr), Ok(G(12)));
     }
 
-    //#[test]
+    #[test]
     fn test_match_factorial() {
         let mut space = GroundingSpace::new();
         // (= (fac 0) 1)
@@ -60,7 +62,8 @@ mod tests {
             E(&[ G(MUL), V("n"), E(&[ S("fac"), E(&[ G(SUB), V("n"), G(1) ]) ]) ]) ]));
 
         let expr = E(&[ S("fac"), G(3) ]);
-        assert_eq!(space.query(&E(&[ S("="), expr, V("X") ])), vec![]);
+        let expected: Bindings = [(VariableAtom::from("X"), E(&[ G(MUL), G(3), E(&[ S("fac"), E(&[ G(SUB), G(3), G(1) ]) ]) ]) )].iter().cloned().collect();
+        assert_eq!(space.query(&E(&[ S("="), expr, V("X") ])), vec![expected]);
     }
 
     #[test]

--- a/rust/src/arithmetics.rs
+++ b/rust/src/arithmetics.rs
@@ -27,34 +27,19 @@ mod tests {
     #[test]
     fn test_sum_ints() {
         let space = GroundingSpace::new();
-        let mut ops = vec![Atom::gnd(INTERPRET)];
         // (+ 3 5)
-        let mut data = vec![Atom::expr(&[Atom::gnd(SUM), Atom::gnd(3), Atom::gnd(5)])];
+        let expr = Atom::expr(&[Atom::gnd(SUM), Atom::gnd(3), Atom::gnd(5)]);
 
-        assert_eq!(space.interpret(&mut ops, &mut data), Ok(()));
-        assert_eq!(space.interpret(&mut ops, &mut data), Ok(()));
-
-        assert_eq!(ops, vec![]);
-        assert_eq!(data, vec![Atom::gnd(8)]);
+        assert_eq!(interpret(space, &expr), Ok(Atom::gnd(8)));
     }
 
     #[test]
     fn test_sum_ints_recursively() {
         let space = GroundingSpace::new();
-        let mut ops = vec![Atom::gnd(INTERPRET)];
         // (+ 4 (+ 3 5))
-        let mut data = vec![Atom::expr(&[Atom::gnd(SUM), Atom::gnd(4),
-            Atom::expr(&[Atom::gnd(SUM), Atom::gnd(3), Atom::gnd(5)])])];
+        let expr = Atom::expr(&[Atom::gnd(SUM), Atom::gnd(4),
+                Atom::expr(&[Atom::gnd(SUM), Atom::gnd(3), Atom::gnd(5)])]);
 
-        assert_eq!(space.interpret(&mut ops, &mut data), Ok(()));
-        assert_eq!(space.interpret(&mut ops, &mut data), Ok(()));
-        assert_eq!(space.interpret(&mut ops, &mut data), Ok(()));
-        assert_eq!(space.interpret(&mut ops, &mut data), Ok(()));
-        assert_eq!(space.interpret(&mut ops, &mut data), Ok(()));
-        assert_eq!(space.interpret(&mut ops, &mut data), Ok(()));
-        assert_eq!(space.interpret(&mut ops, &mut data), Ok(()));
-
-        assert_eq!(ops, vec![]);
-        assert_eq!(data, vec![Atom::gnd(12)]);
+        assert_eq!(interpret(space, &expr), Ok(Atom::gnd(12)));
     }
 }

--- a/rust/src/interpreter.rs
+++ b/rust/src/interpreter.rs
@@ -3,36 +3,89 @@ use crate::common::*;
 use std::rc::Rc;
 use std::iter::Peekable;
 
-pub static INTERPRET: &Operation = &Operation{ name: "interpret", execute: |ops, data| interpret(ops, data, false) };
+pub static SWAP_DATA: &Operation = &Operation{ name: "swap_data", execute: swap_data };
+pub static INTERPRET: &Operation = &Operation{ name: "interpret", execute: |ops, data| interpret_op(ops, data, false) };
 pub static EXECUTE: &Operation = &Operation{ name: "execute", execute: execute };
 pub static REDUCT: &Operation = &Operation{ name: "reduct", execute: reduct };
 pub static REDUCT_NEXT: &Operation = &Operation{ name: "reduct_next", execute: reduct_next };
-pub static INTERPRET_REDUCTED: &Operation = &Operation{ name: "interpret", execute: |ops, data| interpret(ops, data, true) };
+pub static INTERPRET_REDUCTED: &Operation = &Operation{ name: "interpret_reducted", execute: |ops, data| interpret_op(ops, data, true) };
+pub static MATCH: &Operation = &Operation{ name: "match", execute: match_op };
+
+// FIXME: There should be the way to pass reference to the GroundingSpace
+// instead of moving it into. Trying to pass reference and convert it to
+// to the atom leads to compiler complaining the link doesn't have 'static
+// lifetime.
+pub fn interpret(space: GroundingSpace, expr: &Atom) -> Result<Atom, String> {
+    match expr {
+        Atom::Expression(_) => {
+            let mut ops: Vec<Atom> = Vec::new();
+            let mut data: Vec<Atom> = Vec::new();
+
+            let space = Rc::new(space);
+
+            data.push(expr.clone());
+            data.push(Atom::gnd(Rc::clone(&space)));
+
+            ops.push(Atom::gnd(INTERPRET));
+
+            while !ops.is_empty() {
+                if let Err(res) = space.interpret(&mut ops, &mut data) {
+                    return Err(res);
+                }
+            }
+
+            if data.len() == 1 {
+                Ok(data.pop().unwrap())
+            } else if data.is_empty() {
+                Err("No result".to_string())
+            } else {
+                Err("Too many data in stack".to_string())
+            }
+        },
+        _ => Err(format!("Function supports only interpreting Atom::Expression, found: {}", expr)),
+    }
+}
 
 fn is_grounded(expr: &ExpressionAtom) -> bool {
     matches!(expr.children.get(0), Some(Atom::Grounded(_)))
 }
 
-fn interpret(ops: &mut Vec<Atom>, data: &mut Vec<Atom>, reducted: bool) -> Result<(), String> {
-    let arg = data.last(); 
-    match arg {
-        Some(atom) => match atom {
-            Atom::Expression(expr) => {
-                if is_grounded(expr) {
-                    if (expr.is_plain() || reducted) && is_grounded(expr) {
-                        ops.push(Atom::gnd(EXECUTE));
-                        Ok(())
-                    } else {
-                        ops.push(Atom::gnd(REDUCT));
-                        Ok(())
-                    }
-                } else {
-                    Err("Not implemented".to_string())
-                }
-            },
-            _ => Err("Not implemented".to_string()),
+fn swap_data(_ops: &mut Vec<Atom>, data: &mut Vec<Atom>) -> Result<(), String> {
+    let args = (data.pop(), data.pop()); 
+    match args {
+        (Some(a), Some(b)) => {
+            data.push(a);
+            data.push(b);
+            Ok(())
         },
-        None => Err("No args passed".to_string()),
+        _ => Err(format!("Expected two arguments, found: {:?}", args)),
+    }
+}
+
+fn interpret_op(ops: &mut Vec<Atom>, data: &mut Vec<Atom>, reducted: bool) -> Result<(), String> {
+    let args = (data.pop(), data.pop()); 
+    match args {
+        (Some(space), Some(atom)) => match atom {
+            Atom::Expression(ref expr) => {
+                if !expr.is_plain() && !reducted {
+                    data.push(atom);
+                    data.push(space);
+                    ops.push(Atom::gnd(REDUCT));
+                } else {
+                    if is_grounded(expr) {
+                        data.push(atom);
+                        ops.push(Atom::gnd(EXECUTE));
+                    } else {
+                        data.push(atom);
+                        data.push(space);
+                        ops.push(Atom::gnd(MATCH));
+                    }
+                }
+                Ok(())
+            },
+            _ => Err("Interpret is not implemented for atoms other than Atom::Expression".to_string()),
+        },
+        _ => Err(format!("Expected GroundingSpace and Atom as arguments, found: {:?}", args)),
     }
 }
 
@@ -53,33 +106,44 @@ fn execute(ops: &mut Vec<Atom>, data: &mut Vec<Atom>) -> Result<(), String> {
 }
 
 fn reduct(ops: &mut Vec<Atom>, data: &mut Vec<Atom>) -> Result<(), String> {
-    // TODO: think about leaving data on stack when parameters are wrong
-    let arg = data.pop(); 
-    match arg {
-        Some(Atom::Expression(ref expr)) => {
-            if expr.is_plain() {
-                ops.push(Atom::gnd(INTERPRET));
-                data.push(arg.unwrap());
-                Ok(())
+    // TODO: think about leaving data on stack when parameters are wrong let arg = data.pop(); 
+    let args = (data.pop(), data.pop());
+    match args {
+        (Some(space), Some(expr_atom)) => {
+            if let Atom::Expression(ref expr) = expr_atom {
+                if expr.is_plain() {
+                    data.push(expr_atom);
+                    data.push(space);
+                    ops.push(Atom::gnd(INTERPRET));
+                    Ok(())
+                } else {
+                    let iter = Rc::new(GndRefCell::new(expr.iter().peekable()));
+                    let (sub, ..) = iter.raw().borrow_mut().peek().unwrap().clone();
+
+                    data.push(Atom::gnd(iter));
+                    data.push(space.clone());
+                    ops.push(Atom::gnd(REDUCT_NEXT));
+
+                    ops.push(Atom::gnd(SWAP_DATA));
+                    
+                    data.push(Atom::Expression(sub.clone()));
+                    data.push(space);
+                    ops.push(Atom::gnd(INTERPRET));
+                    Ok(())
+                }
             } else {
-                let iter = Rc::new(GndRefCell::new(expr.iter().peekable()));
-                let (sub, ..) = iter.raw().borrow_mut().peek().unwrap().clone();
-                data.push(Atom::gnd(iter));
-                ops.push(Atom::gnd(REDUCT_NEXT));
-                data.push(Atom::Expression(sub.clone()));
-                ops.push(Atom::gnd(INTERPRET));
-                Ok(())
+                Err(format!("GroundingSpace and Atom::Expression are expected as arguments, found: {}, {}", space, expr_atom))
             }
         },
-        _ => Err(format!("Expression is expected as an argument, found instead: {:?}", arg)),
+        _ => Err(format!("Two arguments are expected, found: {:?}", args)),
     }
 }
 
 fn reduct_next(ops: &mut Vec<Atom>, data: &mut Vec<Atom>) -> Result<(), String> {
-    let args = (data.pop(), data.pop());
+    let args = (data.pop(), data.pop(), data.pop());
     match args {
-        (Some(reducted), Some(gnd)) => {
-            if let Atom::Grounded(ref iter) = gnd {
+        (Some(space), Some(reducted), Some(iter_atom)) => {
+            if let Atom::Grounded(ref iter) = iter_atom {
                 let iter = iter.downcast_ref::<Rc<GndRefCell<Peekable<ExpressionAtomIter<'_>>>>>();
                 if let Some(iter) = iter {
                     let (_, parent, idx) = iter.raw().borrow_mut().next().unwrap();
@@ -87,22 +151,39 @@ fn reduct_next(ops: &mut Vec<Atom>, data: &mut Vec<Atom>) -> Result<(), String> 
                     // FIXME: add method to access children indirectly or move iterator into ExpressionAtom
                     parent.children[idx] = reducted;
                     if let Some((sub, ..)) = iter.raw().borrow_mut().peek() {
-                        data.push(gnd.clone());
+                        // TODO: think about implementing Copy for the GroundedAtom
+                        data.push(iter_atom.clone());
+                        data.push(space.clone());
                         ops.push(Atom::gnd(REDUCT_NEXT));
+
+                        ops.push(Atom::gnd(SWAP_DATA));
+
                         data.push(Atom::Expression((*sub).clone()));
+                        data.push(space);
                         ops.push(Atom::gnd(INTERPRET));
                     } else {
                         data.push(Atom::Expression(parent.clone()));
+                        data.push(space);
                         ops.push(Atom::gnd(INTERPRET_REDUCTED));
                     }
                     Ok(())
                 } else {
-                    Err(format!("Reference to expression being reducted is expected as second argument, found: {}", gnd))
+                    Err(format!("Reference to expression being reducted is expected as second argument, found: {}", iter_atom))
                 }
             } else {
-                Err(format!("Grounded atom is expected as a second argument, found: {}", gnd))
+                Err(format!("Grounded atom is expected as a second argument, found: {}", iter_atom))
             }
         },
         _ => Err(format!("Two arguments expected, found: {:?}", args)),
+    }
+}
+
+fn match_op(_ops: &mut Vec<Atom>, data: &mut Vec<Atom>) -> Result<(), String> {
+    let args = (data.pop(), data.pop());
+    match args {
+        (Some(Atom::Grounded(space)), Some(Atom::Expression(expr))) => {
+            Ok(())
+        },
+        _ => Err(format!("Atom::Grounded and Atom::Expression are expected as arguments, found: {:?}", args)),
     }
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -290,3 +290,14 @@ impl GroundingSpace {
 
 }
 
+impl PartialEq for GroundingSpace {
+    fn eq(&self, other: &Self) -> bool {
+        self == other
+    }
+}
+
+impl Display for GroundingSpace {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "GroundingSpace")
+    }
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -128,7 +128,7 @@ pub struct VariableAtom {
 }
 
 impl VariableAtom {
-    fn from(name: &str) -> Self {
+    pub fn from(name: &str) -> Self {
         VariableAtom{ name: name.to_string() }
     }
 }
@@ -272,7 +272,10 @@ impl GroundingSpace {
         let mut result = Vec::new();
         for next in &self.content {
             match matcher::match_atoms(next, pattern) {
-                Some((_, b_bindings)) => result.push(b_bindings),
+                Some((a_bindings, b_bindings)) => {
+                    let bindings = matcher::apply_bindings_to_bindings(&a_bindings, &b_bindings);
+                    result.push(bindings);
+                },
                 None => continue,
             }
         }

--- a/rust/src/matcher.rs
+++ b/rust/src/matcher.rs
@@ -54,7 +54,7 @@ pub fn apply_bindings_to_atom(atom: &Atom, bindings: &Bindings) -> Atom {
                 Atom::Variable(v.clone())
             }
         },
-        Atom::Expression(ExpressionAtom{ children: children }) => {
+        Atom::Expression(ExpressionAtom{ children }) => {
             let children = children.iter().map(|a| apply_bindings_to_atom(a, bindings)).collect::<Vec<Atom>>();
             Atom::expr(&children[..])
         },


### PR DESCRIPTION
Add MATCH and MATCH_NEXT operations to match a symbolic expression and iterate through match results until expression is successfully interpreted.