### PR TITLE
Add S-expression space

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -30,7 +30,7 @@ Setup build:
 ```
 mkdir -p target/capi
 cd target/capi
-conan install ../../capi
+conan install --build missing ../../capi
 cmake ../../capi
 ```
 

--- a/rust/capi/src/lib.rs
+++ b/rust/capi/src/lib.rs
@@ -31,7 +31,7 @@ pub unsafe extern "C" fn atom_sym(name: *const c_char) -> *mut atom_t {
     // cstr_as_str() keeps pointer ownership, but Atom::sym() copies resulting
     // String into Atom::Symbol::symbol field. atom_to_ptr() moves value to the
     // heap and gives ownership to the caller.
-    atom_to_ptr(Atom::sym(cstr_as_str(name)))
+    atom_to_ptr(Atom::Symbol(cstr_as_str(name).into()))
 }
 
 // TODO: Think about changing the API to make resulting expression taking ownership of passed
@@ -39,14 +39,12 @@ pub unsafe extern "C" fn atom_sym(name: *const c_char) -> *mut atom_t {
 #[no_mangle]
 pub unsafe extern "C" fn atom_expr(children: *const *mut atom_t, size: usize) -> *mut atom_t {
     let children: Vec<Atom> = std::slice::from_raw_parts(children, size).iter().map(|p| (**p).atom.clone()).collect();
-    // TODO: calling Atom::expr will copy expression one more time because of
-    // copying Vec into ExpressionAtom::children field.
-    atom_to_ptr(Atom::expr(children.as_slice()))
+    atom_to_ptr(Atom::Expression(children.into()))
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn atom_var(name: *const c_char) -> *mut atom_t {
-    atom_to_ptr(Atom::var(cstr_as_str(name)))
+    atom_to_ptr(Atom::Variable(cstr_as_str(name).into()))
 }
 
 #[no_mangle]

--- a/rust/lib/Cargo.toml
+++ b/rust/lib/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 mopa = "0.2.2"
+regex = "1.5.4"
 
 [lib]
 name = "hyperon"

--- a/rust/lib/src/interpreter.rs
+++ b/rust/lib/src/interpreter.rs
@@ -260,8 +260,8 @@ fn match_next(ops: &mut Vec<Atom>, data: &mut Vec<Atom>) -> Result<(), String> {
                             // TODO: not used yet, the idea is to return error
                             // expression from INTERPRET to move to the next 
                             // alternative
-                            if let Some(Atom::Symbol{symbol}) = expr.children().get(0) {
-                                if symbol == "error" {
+                            if let Some(atom) = expr.children().get(0) {
+                                if *atom == Atom::sym("error") {
                                     // Return is used here because I would like
                                     // to have one branch which truncates stacks
                                     // instead of two (see code below).

--- a/rust/lib/src/interpreter.rs
+++ b/rust/lib/src/interpreter.rs
@@ -65,6 +65,7 @@ fn choose_stack<'a>(ops: &'a mut Vec<Atom>, data: &'a mut Vec<Atom>, stack: Kind
 fn swap(ops: &mut Vec<Atom>, data: &mut Vec<Atom>, stack: KindOfStack) -> Result<(), String> {
     let stack = choose_stack(ops, data, stack);
     let args = (stack.pop(), stack.pop()); 
+    // TODO: replace println! by logging
     println!("swap{:?}", args);
     match args {
         (Some(a), Some(b)) => {

--- a/rust/lib/src/lib.rs
+++ b/rust/lib/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod text;
 pub mod common;
 pub mod interpreter;
 pub mod arithmetics;
@@ -9,8 +10,10 @@ mod tests;
 #[macro_use]
 extern crate mopa;
 
-use std::collections::HashMap;
+use text::{SExprSpace};
+
 use std::fmt::{Display, Debug};
+use std::collections::HashMap;
 
 // Macros to simplify expression writing
 
@@ -142,9 +145,15 @@ pub struct VariableAtom {
     name: String,
 }
 
-impl VariableAtom {
-    pub fn from(name: &str) -> Self {
+impl From<&str> for VariableAtom {
+    fn from(name: &str) -> Self {
         VariableAtom{ name: name.to_string() }
+    }
+}
+
+impl From<String> for VariableAtom {
+    fn from(name: String) -> Self {
+        VariableAtom{ name }
     }
 }
 
@@ -276,7 +285,7 @@ pub struct GroundingSpace {
 impl GroundingSpace {
 
     pub fn new() -> Self {
-        GroundingSpace{ content: Vec::new() }
+        Self{ content: Vec::new() }
     }
     
     pub fn add(&mut self, atom: Atom) {
@@ -306,6 +315,9 @@ impl GroundingSpace {
         }
     }
 
+    pub fn atom_iter(&self) -> std::slice::Iter<Atom>{
+        self.content.iter()
+    }
 }
 
 impl PartialEq for GroundingSpace {
@@ -317,5 +329,13 @@ impl PartialEq for GroundingSpace {
 impl Display for GroundingSpace {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "GroundingSpace")
+    }
+}
+
+impl From<&SExprSpace> for GroundingSpace {
+    fn from(other: &SExprSpace) -> Self {
+        let mut space = GroundingSpace::new();
+        other.into_grounding_space(&mut space);
+        space
     }
 }

--- a/rust/lib/src/lib.rs
+++ b/rust/lib/src/lib.rs
@@ -32,6 +32,30 @@ macro_rules! bind {
         .iter().cloned().collect() };
 }
 
+// Symbol atom
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SymbolAtom {
+    name: String,
+}
+
+impl From<String> for SymbolAtom {
+    fn from(name: String) -> Self {
+        SymbolAtom{ name }
+    }
+}
+
+impl From<&str> for SymbolAtom {
+    fn from(name: &str) -> Self {
+        SymbolAtom::from(name.to_string())
+    }
+}
+
+impl Display for SymbolAtom {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name)
+    }
+}
 
 // Expression atom
 
@@ -41,10 +65,6 @@ pub struct ExpressionAtom {
 }
 
 impl ExpressionAtom {
-    fn from(children: &[Atom]) -> Self {
-        ExpressionAtom{ children: children.to_vec() }
-    }
-
     pub fn is_plain(&self) -> bool {
         self.children.iter().all(|atom| ! matches!(atom, Atom::Expression(_)))
     }
@@ -61,6 +81,18 @@ impl ExpressionAtom {
 
     pub fn children_mut(&mut self) -> &mut Vec<Atom> {
         &mut self.children
+    }
+}
+
+impl From<Vec<Atom>> for ExpressionAtom {
+    fn from(children: Vec<Atom>) -> Self {
+        ExpressionAtom{ children }
+    }
+}
+
+impl From<&[Atom]> for ExpressionAtom {
+    fn from(children: &[Atom]) -> Self {
+        ExpressionAtom::from(children.to_vec())
     }
 }
 
@@ -145,15 +177,15 @@ pub struct VariableAtom {
     name: String,
 }
 
-impl From<&str> for VariableAtom {
-    fn from(name: &str) -> Self {
-        VariableAtom{ name: name.to_string() }
-    }
-}
-
 impl From<String> for VariableAtom {
     fn from(name: String) -> Self {
         VariableAtom{ name }
+    }
+}
+
+impl From<&str> for VariableAtom {
+    fn from(name: &str) -> Self {
+        VariableAtom::from(name.to_string())
     }
 }
 
@@ -200,7 +232,7 @@ impl<T: 'static + Clone + PartialEq + Display> GroundedAtom for T {
 
 #[derive(Debug)]
 pub enum Atom {
-    Symbol{ symbol: String },
+    Symbol(SymbolAtom),
     Expression(ExpressionAtom),
     Variable(VariableAtom),
     // We need using Box here because if we use reference then we cannot keep
@@ -210,7 +242,7 @@ pub enum Atom {
 
 impl Atom {
     pub fn sym(name: &str) -> Self {
-        Self::Symbol{ symbol: name.to_string() }
+        Self::Symbol(SymbolAtom::from(name))
     }
 
     pub fn expr(children: &[Atom]) -> Self {
@@ -243,7 +275,7 @@ impl Atom {
 impl PartialEq for Atom {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (Atom::Symbol{ symbol: sym1 }, Atom::Symbol{ symbol: sym2 }) => sym1 == sym2,
+            (Atom::Symbol(sym1), Atom::Symbol(sym2)) => sym1 == sym2,
             (Atom::Expression(expr1), Atom::Expression(expr2)) => expr1 == expr2,
             (Atom::Variable(var1), Atom::Variable(var2)) => var1 == var2,
             (Atom::Grounded(gnd1), Atom::Grounded(gnd2)) => gnd1.eq_gnd(&**gnd2),
@@ -255,7 +287,7 @@ impl PartialEq for Atom {
 impl Clone for Atom {
     fn clone(&self) -> Self {
         match self {
-            Atom::Symbol{ symbol: sym } => Atom::Symbol{ symbol: sym.clone() },
+            Atom::Symbol(sym) => Atom::Symbol(sym.clone()),
             Atom::Expression(expr) => Atom::Expression(expr.clone()),
             Atom::Variable(var) => Atom::Variable(var.clone()),
             Atom::Grounded(gnd) => Atom::Grounded((*gnd).clone_gnd()),
@@ -266,7 +298,7 @@ impl Clone for Atom {
 impl Display for Atom {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Atom::Symbol{ symbol: sym } => Display::fmt(sym, f),
+            Atom::Symbol(sym) => Display::fmt(sym, f),
             Atom::Expression(expr) => Display::fmt(expr, f),
             Atom::Variable(var) => Display::fmt(var, f),
             Atom::Grounded(gnd) => Display::fmt(gnd, f),

--- a/rust/lib/src/matcher.rs
+++ b/rust/lib/src/matcher.rs
@@ -16,7 +16,7 @@ fn check_and_insert_binding(bindings: &mut Bindings, var: &VariableAtom,
 fn match_atoms_recursively(atom: &Atom, pattern: &Atom,
         a_bindings: &mut Bindings, b_bindings: &mut Bindings) -> bool {
     match (atom, pattern) {
-        (Atom::Symbol{ symbol: a }, Atom::Symbol{ symbol: b }) => a == b,
+        (Atom::Symbol(a), Atom::Symbol(b)) => a == b,
         (Atom::Grounded(a), Atom::Grounded(b)) => a.eq_gnd(&**b),
         (a, Atom::Variable(v)) => check_and_insert_binding(b_bindings, v, a),
         (Atom::Variable(v), b) => check_and_insert_binding(a_bindings, v, b),
@@ -45,8 +45,7 @@ pub fn match_atoms(atom: &Atom, pattern: &Atom) -> Option<(Bindings, Bindings)> 
 
 pub fn apply_bindings_to_atom(atom: &Atom, bindings: &Bindings) -> Atom {
     match atom {
-        Atom::Symbol{ symbol: _ } => atom.clone(),
-        Atom::Grounded(_) => atom.clone(),
+        Atom::Symbol(_)|Atom::Grounded(_) => atom.clone(),
         Atom::Variable(v) => {
             if let Some(binding) = bindings.get(v) {
                 binding.clone()

--- a/rust/lib/src/text.rs
+++ b/rust/lib/src/text.rs
@@ -116,8 +116,8 @@ mod tests {
     #[test]
     fn test_text_var() {
         let mut text = SExprSpace::new();
-        text.add_str("$n").unwrap();
 
+        text.add_str("$n").unwrap();
         let space = GroundingSpace::from(&text);
 
         assert_eq!(vec![expr!(n)], space.atom_iter().cloned().collect::<Vec<_>>());
@@ -126,8 +126,8 @@ mod tests {
     #[test]
     fn test_text_sym() {
         let mut text = SExprSpace::new();
-        text.add_str("test").unwrap();
 
+        text.add_str("test").unwrap();
         let space = GroundingSpace::from(&text);
 
         assert_eq!(vec![expr!("test")], space.atom_iter().cloned().collect::<Vec<_>>());
@@ -138,8 +138,8 @@ mod tests {
         let mut text = SExprSpace::new();
         text.register_token(Regex::new(r"\d+").unwrap(),
             |token| Atom::gnd(token.parse::<i32>().unwrap()));
-        text.add_str("(3d 42)").unwrap();
 
+        text.add_str("(3d 42)").unwrap();
         let space = GroundingSpace::from(&text);
 
         assert_eq!(vec![Atom::expr(&[Atom::sym("3d"), Atom::gnd(42)])], space.atom_iter().cloned().collect::<Vec<_>>());
@@ -148,8 +148,8 @@ mod tests {
     #[test]
     fn test_text_expr() {
         let mut text = SExprSpace::new();
-        text.add_str("(= (fac $n) (* $n (fac (- $n 1))))").unwrap();
 
+        text.add_str("(= (fac $n) (* $n (fac (- $n 1))))").unwrap();
         let space = GroundingSpace::from(&text);
 
         assert_eq!(vec![expr!("=", ("fac", n), ("*", n, ("fac", ("-", n, "1"))))],
@@ -159,6 +159,7 @@ mod tests {
     #[test]
     fn test_next_token() {
         let mut it = "n)".chars().peekable();
+
         assert_eq!("n".to_string(), next_token(&mut it));
         assert_eq!(Some(')'), it.next());
     }

--- a/rust/lib/src/text.rs
+++ b/rust/lib/src/text.rs
@@ -1,0 +1,129 @@
+use crate::*;
+
+use std::io::Read;
+
+pub struct SExprSpace {
+    content: Vec<String>,
+}
+
+impl SExprSpace {
+
+    pub fn new() -> Self {
+        Self{ content: Vec::new() }
+    }
+
+    pub fn add_str(&mut self, text: &str) {
+        self.add_reader(&mut text.as_bytes()).unwrap()
+    }
+
+    pub fn add_reader(&mut self, reader: &mut dyn Read) -> Result<(), String> {
+        let mut buffer = String::new();
+        reader.read_to_string(&mut buffer)
+            .map_err(|e| format!("Could not read text: {}", e))?;
+        self.content.push(buffer);
+        // TODO: add a check that buffer contains valid Metta code and 
+        // return proper Result
+        Ok(())
+    }
+
+    pub fn into_grounding_space(&self, other: &mut GroundingSpace) {
+        for text in &self.content {
+            parse(&mut text.chars(), &mut |atom| other.add(atom));
+        }
+    }
+
+}
+
+fn parse(it: &mut dyn Iterator<Item=char>, add: &mut dyn FnMut(Atom)) {
+    println!("parse");
+    let mut it = it.peekable();
+    'outer: while let Some(c) = it.peek() {
+        match c {
+            _ if c.is_whitespace() => { it.next(); },
+            '$' => {
+                it.next();
+                let token = next_token(&mut it);
+                println!("token: {}", token);
+                add(Atom::Variable(VariableAtom::from(token)));
+            },
+            '(' => {
+                let mut children: Vec<Atom> = Vec::new();
+                it.next();
+                parse(&mut it, &mut |atom| children.push(atom));
+                // FIXME: add From trait implementations for all atoms
+                let expr = Atom::Expression(ExpressionAtom{ children: children });
+                println!("add expression: {}", expr);
+                add(expr);
+            },
+            ')' => {
+                it.next();
+                break 'outer;
+            }
+            _ => {
+                let token = next_token(&mut it);
+                println!("token: {}", token);
+                add(Atom::Symbol{ symbol: token });
+            },
+        }
+    }
+    println!("parse return");
+}
+
+fn next_token<I: Iterator<Item=char>>(it: &mut std::iter::Peekable<I>) -> String {
+    let mut token = String::new();
+    while let Some(&c) = it.peek() {
+        if c.is_whitespace() || c == '(' || c == ')' {
+            break;
+        }
+        // TODO: it would be cool to not push chars one by one into token but
+        // create a string from two iterators (begin, end) as in C++. But it looks
+        // like Rust standard library doesn't allow it.
+        token.push(c);
+        it.next();
+    }
+    token 
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_text_var() {
+        let mut text = SExprSpace::new();
+        text.add_str("$n");
+
+        let space = GroundingSpace::from(&text);
+
+        assert_eq!(vec![expr!(n)], space.atom_iter().cloned().collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn test_text_sym() {
+        let mut text = SExprSpace::new();
+        text.add_str("test");
+
+        let space = GroundingSpace::from(&text);
+
+        assert_eq!(vec![expr!("test")], space.atom_iter().cloned().collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn test_next_token() {
+        let mut it = "n)".chars().peekable();
+        assert_eq!("n".to_string(), next_token(&mut it));
+        assert_eq!(Some(')'), it.next());
+    }
+
+    #[test]
+    fn test_text_expr() {
+        let mut text = SExprSpace::new();
+        text.add_str("(= (fac $n) (* $n (fac (- $n 1))))");
+
+        let space = GroundingSpace::from(&text);
+
+        assert_eq!(vec![expr!("=", ("fac", n), ("*", n, ("fac", ("-", n, "1"))))],
+            space.atom_iter().cloned().collect::<Vec<_>>());
+    }
+}

--- a/rust/lib/src/text.rs
+++ b/rust/lib/src/text.rs
@@ -44,14 +44,14 @@ fn parse(it: &mut dyn Iterator<Item=char>, add: &mut dyn FnMut(Atom)) {
                 it.next();
                 let token = next_token(&mut it);
                 println!("token: {}", token);
-                add(Atom::Variable(VariableAtom::from(token)));
+                add(Atom::Variable(token.into()));
             },
             '(' => {
                 let mut children: Vec<Atom> = Vec::new();
                 it.next();
                 parse(&mut it, &mut |atom| children.push(atom));
                 // FIXME: add From trait implementations for all atoms
-                let expr = Atom::Expression(ExpressionAtom{ children: children });
+                let expr = Atom::Expression(children.into());
                 println!("add expression: {}", expr);
                 add(expr);
             },
@@ -62,7 +62,7 @@ fn parse(it: &mut dyn Iterator<Item=char>, add: &mut dyn FnMut(Atom)) {
             _ => {
                 let token = next_token(&mut it);
                 println!("token: {}", token);
-                add(Atom::Symbol{ symbol: token });
+                add(Atom::Symbol(token.into()))
             },
         }
     }

--- a/rust/lib/src/text.rs
+++ b/rust/lib/src/text.rs
@@ -1,19 +1,28 @@
 use crate::*;
 
 use std::io::Read;
+use regex::Regex;
 
 pub struct SExprSpace {
     content: Vec<String>,
+    tokens: Vec<TokenDescr>,
 }
+
+struct TokenDescr {
+    regex: Regex,
+    constr: AtomConstr,
+}
+
+type AtomConstr = fn(&str) -> Atom;
 
 impl SExprSpace {
 
     pub fn new() -> Self {
-        Self{ content: Vec::new() }
+        Self{ content: Vec::new(), tokens: Vec::new() }
     }
 
-    pub fn add_str(&mut self, text: &str) {
-        self.add_reader(&mut text.as_bytes()).unwrap()
+    pub fn add_str(&mut self, text: &str) -> Result<(), String> {
+        self.add_reader(&mut text.as_bytes())
     }
 
     pub fn add_reader(&mut self, reader: &mut dyn Read) -> Result<(), String> {
@@ -26,48 +35,63 @@ impl SExprSpace {
         Ok(())
     }
 
+    pub fn register_token(&mut self, regex: Regex, constr: AtomConstr) {
+        self.tokens.push(TokenDescr{ regex, constr });
+    }
+
     pub fn into_grounding_space(&self, other: &mut GroundingSpace) {
         for text in &self.content {
-            parse(&mut text.chars(), &mut |atom| other.add(atom));
+            self.parse(&mut text.chars(), &mut |atom| other.add(atom));
         }
     }
 
-}
-
-fn parse(it: &mut dyn Iterator<Item=char>, add: &mut dyn FnMut(Atom)) {
-    println!("parse");
-    let mut it = it.peekable();
-    'outer: while let Some(c) = it.peek() {
-        match c {
-            _ if c.is_whitespace() => { it.next(); },
-            '$' => {
-                it.next();
-                let token = next_token(&mut it);
-                println!("token: {}", token);
-                add(Atom::Variable(token.into()));
-            },
-            '(' => {
-                let mut children: Vec<Atom> = Vec::new();
-                it.next();
-                parse(&mut it, &mut |atom| children.push(atom));
-                // FIXME: add From trait implementations for all atoms
-                let expr = Atom::Expression(children.into());
-                println!("add expression: {}", expr);
-                add(expr);
-            },
-            ')' => {
-                it.next();
-                break 'outer;
+    // TODO: can we replace FnMut by fn() here?
+    fn parse(&self, it: &mut dyn Iterator<Item=char>, add: &mut dyn FnMut(Atom)) {
+        let mut it = it.peekable();
+        'outer: while let Some(c) = it.peek() {
+            match c {
+                _ if c.is_whitespace() => { it.next(); },
+                '$' => {
+                    it.next();
+                    let token = next_token(&mut it);
+                    add(Atom::Variable(token.into()));
+                },
+                '(' => {
+                    let mut children: Vec<Atom> = Vec::new();
+                    it.next();
+                    self.parse(&mut it, &mut |atom| children.push(atom));
+                    // FIXME: add From trait implementations for all atoms
+                    let expr = Atom::Expression(children.into());
+                    add(expr);
+                },
+                ')' => {
+                    it.next();
+                    break 'outer;
+                }
+                _ => {
+                    let token = next_token(&mut it);
+                    let constr = self.find_token(token.as_str());
+                    if let Some(constr) = constr {
+                        add(constr(token.as_str()));
+                    } else {
+                        add(Atom::Symbol(token.into()))
+                    }
+                },
             }
-            _ => {
-                let token = next_token(&mut it);
-                println!("token: {}", token);
-                add(Atom::Symbol(token.into()))
-            },
         }
     }
-    println!("parse return");
+
+    fn find_token(&self, token: &str) -> Option<AtomConstr> {
+        self.tokens.iter().find(|descr| {
+            match descr.regex.find_at(token, 0) {
+                Some(m) => m.end() == token.len(),
+                None => false,
+            }
+        }).map(|descr| descr.constr)
+    }
+
 }
+
 
 fn next_token<I: Iterator<Item=char>>(it: &mut std::iter::Peekable<I>) -> String {
     let mut token = String::new();
@@ -92,7 +116,7 @@ mod tests {
     #[test]
     fn test_text_var() {
         let mut text = SExprSpace::new();
-        text.add_str("$n");
+        text.add_str("$n").unwrap();
 
         let space = GroundingSpace::from(&text);
 
@@ -102,7 +126,7 @@ mod tests {
     #[test]
     fn test_text_sym() {
         let mut text = SExprSpace::new();
-        text.add_str("test");
+        text.add_str("test").unwrap();
 
         let space = GroundingSpace::from(&text);
 
@@ -110,20 +134,32 @@ mod tests {
     }
 
     #[test]
-    fn test_next_token() {
-        let mut it = "n)".chars().peekable();
-        assert_eq!("n".to_string(), next_token(&mut it));
-        assert_eq!(Some(')'), it.next());
+    fn test_text_gnd() {
+        let mut text = SExprSpace::new();
+        text.register_token(Regex::new(r"\d+").unwrap(),
+            |token| Atom::gnd(token.parse::<i32>().unwrap()));
+        text.add_str("(3d 42)").unwrap();
+
+        let space = GroundingSpace::from(&text);
+
+        assert_eq!(vec![Atom::expr(&[Atom::sym("3d"), Atom::gnd(42)])], space.atom_iter().cloned().collect::<Vec<_>>());
     }
 
     #[test]
     fn test_text_expr() {
         let mut text = SExprSpace::new();
-        text.add_str("(= (fac $n) (* $n (fac (- $n 1))))");
+        text.add_str("(= (fac $n) (* $n (fac (- $n 1))))").unwrap();
 
         let space = GroundingSpace::from(&text);
 
         assert_eq!(vec![expr!("=", ("fac", n), ("*", n, ("fac", ("-", n, "1"))))],
             space.atom_iter().cloned().collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn test_next_token() {
+        let mut it = "n)".chars().peekable();
+        assert_eq!("n".to_string(), next_token(&mut it));
+        assert_eq!(Some(')'), it.next());
     }
 }


### PR DESCRIPTION
The same functionality as in C++ Hyperon prototype:
- one can register the custom tokens
- tokens recognized as registered are converted into grounded atoms
- otherwise tokens are converted into symbols or variables
- expressions are embraced by brackets