### PR TITLE
Add old examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 
 # Overview
 
-This is reimplementation of the [C++ Hyperon prototype](https://github.com/trueagi-io/hyperon) from scratch in a Rust programming language.
-The goal of the project is to replace the previous prototype. Work is in progress so some features are absent.
-Please see [Python examples](./python/tests) and [Python examples of previous version](https://github.com/trueagi-io/hyperon/tree/master/python/tests) to become familiar with Hyperon features.
+This is reimplementation of the [C++ Hyperon
+prototype](https://github.com/trueagi-io/hyperon) from scratch in a Rust
+programming language. The goal of the project is to replace the previous
+prototype. Work is in progress so some features are absent.  Please see [Python
+examples](./python/tests) and [Python examples of previous
+version](https://github.com/trueagi-io/hyperon/tree/master/python/tests) to
+become familiar with Hyperon features.
 
 # Prerequisites
 

--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -216,6 +216,11 @@ pub unsafe extern "C" fn vec_atom_free(vec: *mut vec_atom_t) {
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn vec_atom_size(vec: *mut vec_atom_t) -> usize {
+    (*vec).0.len()
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn vec_atom_pop(vec: *mut vec_atom_t) -> *mut atom_t {
     atom_to_ptr((*vec).0.pop().expect("Vector is empty"))
 }

--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -31,6 +31,7 @@ pub struct atom_t {
 #[allow(non_camel_case_types)]
 #[repr(C)]
 pub struct gnd_api_t {
+    // TODO: replace args by C array and ret by callback
     // One can assign NULL to this field, it means the atom is not executable
     execute: Option<extern "C" fn(*const gnd_t, *mut vec_atom_t, *mut vec_atom_t) -> *const c_char>,
     eq: extern "C" fn(*const gnd_t, *const gnd_t) -> bool,
@@ -342,15 +343,16 @@ impl CGroundedAtom {
         }
     }
 
-    unsafe fn execute(&self, ops: &mut Vec<Atom>, data: &mut Vec<Atom>) -> Result<(), String> {
+    unsafe fn execute(&self, args: &mut Vec<Atom>) -> Result<Vec<Atom>, String> {
         let execute = self.api().execute;
         match execute {
             Some(execute) => {
+                let mut ret = Vec::new();
                 let res = execute(self.as_ptr(),
-                    (ops as *mut Vec<Atom>).cast::<vec_atom_t>(),
-                    (data as *mut Vec<Atom>).cast::<vec_atom_t>());
+                    (args as *mut Vec<Atom>).cast::<vec_atom_t>(),
+                    (&mut ret as *mut Vec<Atom>).cast::<vec_atom_t>());
                 if res.is_null() {
-                    Ok(())
+                    Ok(ret)
                 } else {
                     Err(cstr_as_str(res).to_string())
                 }
@@ -381,9 +383,9 @@ impl CGroundedAtom {
 
 impl GroundedAtom for CGroundedAtom {
 
-    fn execute(&self, ops: &mut Vec<Atom>, data: &mut Vec<Atom>) -> Result<(), String> {
+    fn execute(&self, args: &mut Vec<Atom>) -> Result<Vec<Atom>, String> {
         unsafe {
-            self.execute(ops, data)
+            self.execute(args)
         }
     }
 

--- a/lib/src/arithmetics.rs
+++ b/lib/src/arithmetics.rs
@@ -67,6 +67,7 @@ mod tests {
         assert_eq!(space.query(&expr!("=", ("fac", {3}), X)), vec![expected]);
     }
 
+    // TODO: reimplement using grounded if to prevent infinite loop
     //#[test]
     fn test_factorial() {
         init();

--- a/lib/src/arithmetics.rs
+++ b/lib/src/arithmetics.rs
@@ -1,18 +1,17 @@
 use crate::*;
 use crate::common::*;
 
-pub static SUM: &Operation = &Operation{ name: "+", execute: |ops, data| bin_op(ops, data, |a, b| a + b) };
-pub static SUB: &Operation = &Operation{ name: "-", execute: |ops, data| bin_op(ops, data, |a, b| a - b) };
-pub static MUL: &Operation = &Operation{ name: "*", execute: |ops, data| bin_op(ops, data, |a, b| a * b) };
+pub static SUM: &Operation = &Operation{ name: "+", execute: |args| bin_op(args, |a, b| a + b) };
+pub static SUB: &Operation = &Operation{ name: "-", execute: |args| bin_op(args, |a, b| a - b) };
+pub static MUL: &Operation = &Operation{ name: "*", execute: |args| bin_op(args, |a, b| a * b) };
 
-fn bin_op(_ops: &mut Vec<Atom>, data: &mut Vec<Atom>, op: fn(i32, i32) -> i32) -> Result<(), String> {
+fn bin_op(args: &mut Vec<Atom>, op: fn(i32, i32) -> i32) -> Result<Vec<Atom>, String> {
     // TODO: getting arguments from stack and checking their type can be
     // done in separate helper function or macros.
-    let arg1 = data.pop().expect("Sum operation called without arguments"); 
-    let arg2 = data.pop().expect("Sum operation called with only argument");
+    let arg1 = args.get(0).ok_or_else(|| format!("Sum operation called without arguments"))?; 
+    let arg2 = args.get(1).ok_or_else(|| format!("Sum operation called with only argument"))?;
     if let (Some(arg1), Some(arg2)) = (arg1.as_gnd::<i32>(), arg2.as_gnd::<i32>()) {
-        data.push(Atom::gnd(op(*arg1, *arg2)));
-        Ok(())
+        Ok(vec![Atom::gnd(op(*arg1, *arg2))])
     } else {
         Err(format!("One of the arguments is not integer: ({}, {})", arg1, arg2))
     }

--- a/lib/src/common.rs
+++ b/lib/src/common.rs
@@ -37,11 +37,11 @@ pub struct Operation {
     pub execute: ExecuteFunc,
 }
 
-pub type ExecuteFunc = fn(&mut Vec<Atom>, &mut Vec<Atom>) -> Result<(), String>;
+pub type ExecuteFunc = fn(&mut Vec<Atom>) -> Result<Vec<Atom>, String>;
 
 impl GroundedAtom for &'static Operation {
-    fn execute(&self, ops: &mut Vec<Atom>, data: &mut Vec<Atom>) -> Result<(), String> {
-        (self.execute)(ops, data)
+    fn execute(&self, args: &mut Vec<Atom>) -> Result<Vec<Atom>, String> {
+        (self.execute)(args)
     }
 
     fn eq_gnd(&self, other: &dyn GroundedAtom) -> bool {
@@ -66,8 +66,8 @@ impl Debug for &'static Operation {
 mod tests {
     use super::*;
 
-    fn test(_ops: &mut Vec<Atom>, _data: &mut Vec<Atom>) -> Result<(), String> {
-        Ok(())
+    fn test(_args: &mut Vec<Atom>) -> Result<Vec<Atom>, String> {
+        Ok(vec![])
     }
 
     #[test]

--- a/lib/src/interpreter/matching.rs
+++ b/lib/src/interpreter/matching.rs
@@ -233,12 +233,9 @@ fn execute_op((atom, bindings): (Atom, Bindings)) -> StepResult<(), InterpreterR
     if let Atom::Expression(mut expr) = atom {
         let op = expr.children().get(0).cloned();
         if let Some(Atom::Grounded(op)) = op {
-            // TODO: change API, remove boilerplate
-            let mut ops: Vec<Atom> = Vec::new();
-            let mut data :Vec<Atom> = Vec::new();
-            expr.children_mut().drain(1..).into_iter().rev().for_each(|atom| data.push(atom));
-            match op.execute(&mut ops, &mut data) {
-                Ok(()) => StepResult::ret(Ok(data.drain(0..).map(|atom| (atom, bindings.clone())).collect())),
+            let mut args = expr.children_mut().drain(1..).collect();
+            match op.execute(&mut args) {
+                Ok(mut vec) => StepResult::ret(Ok(vec.drain(0..).map(|atom| (atom, bindings.clone())).collect())),
                 Err(msg) => StepResult::ret(Err(msg)),
             }
         } else {

--- a/lib/src/interpreter/matching.rs
+++ b/lib/src/interpreter/matching.rs
@@ -83,7 +83,7 @@ fn reduct_first_if_not_matched_op(((space, expr, bindings), match_result): ((Rc<
 fn reduct_first_op((space, expr, bindings): (Rc<GroundingSpace>, Atom, Bindings)) -> StepResult<(), InterpreterResult> {
     log::debug!("reduct_first_op: {}", expr);
     if let Atom::Expression(expr) = expr {
-        let mut iter = SubexpressionStream::from(expr);
+        let mut iter = BottomSubexprStream::from(expr);
         let sub;
         {
             iter.next();
@@ -98,7 +98,7 @@ fn reduct_first_op((space, expr, bindings): (Rc<GroundingSpace>, Atom, Bindings)
     }
 }
 
-fn interpret_if_reducted_op(((space, mut iter), reduction_result): ((Rc<GroundingSpace>, SubexpressionStream), InterpreterResult)) -> StepResult<(), InterpreterResult> {
+fn interpret_if_reducted_op(((space, mut iter), reduction_result): ((Rc<GroundingSpace>, BottomSubexprStream), InterpreterResult)) -> StepResult<(), InterpreterResult> {
     log::debug!("interpret_if_reducted_op: reduction_result: {:?}", reduction_result);
     match reduction_result {
         Err(_) => StepResult::ret(reduction_result),
@@ -140,7 +140,7 @@ fn interpret_if_reducted_op(((space, mut iter), reduction_result): ((Rc<Groundin
 fn reduct_op((space, expr, bindings): (Rc<GroundingSpace>, Atom, Bindings)) -> StepResult<(), InterpreterResult> {
     log::debug!("reduct_op: {}", expr);
     if let Atom::Expression(expr) = expr {
-        let mut iter = SubexpressionStream::from(expr);
+        let mut iter = BottomSubexprStream::from(expr);
         let sub;
         {
             iter.next();
@@ -155,7 +155,7 @@ fn reduct_op((space, expr, bindings): (Rc<GroundingSpace>, Atom, Bindings)) -> S
     }
 }
 
-fn reduct_next_op(((space, iter), prev_result): ((Rc<GroundingSpace>, SubexpressionStream), InterpreterResult)) -> StepResult<(), InterpreterResult> {
+fn reduct_next_op(((space, iter), prev_result): ((Rc<GroundingSpace>, BottomSubexprStream), InterpreterResult)) -> StepResult<(), InterpreterResult> {
     match prev_result {
         Err(_) => StepResult::ret(prev_result),
         Ok(mut results) => {

--- a/lib/src/interpreter/mod.rs
+++ b/lib/src/interpreter/mod.rs
@@ -1,5 +1,7 @@
 mod plan;
+mod subexpr;
 mod matching;
 
 pub use plan::*;
+pub use subexpr::*;
 pub use matching::interpret;

--- a/lib/src/interpreter/subexpr.rs
+++ b/lib/src/interpreter/subexpr.rs
@@ -1,12 +1,89 @@
 use crate::*;
 
-#[derive(Clone)]
-pub struct BottomSubexprStream {
-    expr: Atom,
-    levels: Vec<usize>,
+fn get_expr<'a>(levels: &Vec<usize>, expr: &'a ExpressionAtom, level: usize) -> &'a ExpressionAtom {
+    as_expr(&expr.children()[levels[level] - 1])
 }
 
-impl BottomSubexprStream {
+fn find_next_sibling_expr(levels: &mut Vec<usize>, expr: &ExpressionAtom, level: usize) -> bool {
+    let mut idx = levels[level];
+    while idx < expr.children().len() {
+        let child = &expr.children()[idx];
+        if let Atom::Expression(_) = child {
+            levels[level] = idx + 1;
+            log::trace!("find_next_sibling_expr: return: {}", child);
+            return true;
+        }
+        idx += 1;
+    }
+    levels.pop();
+    return false;
+}
+
+fn move_top_down_depth(levels: &mut Vec<usize>, expr: &ExpressionAtom, level: usize) -> bool {
+    log::trace!("move_top_down_depth: expr: {}, level: {}, levels.len(): {}, idx: {}", expr, level, levels.len(), levels[level]);
+    if level < levels.len() - 1 {
+        let found = move_top_down_depth(levels, get_expr(levels, expr, level), level + 1);
+        return found || find_next_sibling_expr(levels, expr, level);
+    } else {
+        let idx = levels[level];
+        if idx == 0 {
+            return find_next_sibling_expr(levels, expr, level);
+        } else {
+            levels.push(0);
+            let child = as_expr(&expr.children()[idx - 1]);
+            let found = move_top_down_depth(levels, child, level + 1);
+            return found || find_next_sibling_expr(levels, expr, level);
+        }
+    }
+}
+
+fn move_bottom_up_depth(levels: &mut Vec<usize>, expr: &ExpressionAtom, level: usize) -> bool {
+    if level < levels.len() - 1 {
+        return move_bottom_up_depth(levels, as_expr(&expr.children()[levels[level] - 1]), level + 1);
+    }
+    loop {
+        let idx = levels[level];
+        if idx >= expr.children().len() {
+            levels.pop();
+            return level > 0;
+        }
+        let child = &expr.children()[idx];
+        levels[level] = idx + 1;
+        if let Atom::Expression(ref child_expr) = child {
+            levels.push(0);
+            return move_bottom_up_depth(levels, child_expr, level + 1);
+        }
+    }
+}
+
+type WalkStrategy = fn(&mut Vec<usize>, &ExpressionAtom, usize) -> bool;
+
+pub static BOTTOM_UP_DEPTH_WALK: WalkStrategy = move_bottom_up_depth;
+pub static TOP_DOWN_DEPTH_WALK: WalkStrategy = move_top_down_depth;
+
+#[derive(Clone)]
+pub struct SubexprStream {
+    expr: Atom,
+    levels: Vec<usize>,
+    walk: WalkStrategy,
+}
+
+impl SubexprStream {
+    pub fn from_expr(expr: Atom, walk: WalkStrategy) -> Self {
+        Self{
+            expr: expr,
+            levels: vec![0],
+            walk: walk,
+        }
+    }
+    pub fn next(&mut self) -> bool {
+        (self.walk)(&mut self.levels, as_expr(&self.expr), 0)
+    }
+
+    pub fn has_next(&self) -> bool {
+        self.levels.len() > 0
+    }
+
     pub fn as_atom(&self) -> &Atom {
         &self.expr
     }
@@ -15,38 +92,7 @@ impl BottomSubexprStream {
         self.expr
     }
 
-    fn next_rec(levels: &mut Vec<usize>, expr: &ExpressionAtom, level: usize) {
-        if level < levels.len() - 1 {
-            Self::next_rec(levels, as_expr(&expr.children()[levels[level] - 1]), level + 1);
-            return;
-        }
-        loop {
-            let idx = levels[level];
-            if idx >= expr.children().len() {
-                levels.pop();
-                return;
-            }
-            let child = &expr.children()[idx];
-            levels[level] = idx + 1;
-            if let Atom::Expression(ref child_expr) = child {
-                levels.push(0);
-                Self::next_rec(levels, child_expr, level + 1);
-                return;
-            }
-        }
-    }
-
-    pub fn next(&mut self) {
-        if let Atom::Expression(ref expr) = self.expr {
-            Self::next_rec(&mut self.levels, expr, 0);
-        }
-    }
-
-    pub fn has_next(&self) -> bool {
-        self.levels.len() > 0
-    }
-
-    fn get_mut_rec<'a>(levels: &'a Vec<usize>, atom: &'a mut Atom, level: usize) -> &'a mut Atom {
+    fn get_mut_rec<'a>(levels: &Vec<usize>, atom: &'a mut Atom, level: usize) -> &'a mut Atom {
         if level >= levels.len() {
             atom
         } else {
@@ -58,24 +104,18 @@ impl BottomSubexprStream {
     pub fn get_mut(&mut self) -> &mut Atom {
         Self::get_mut_rec(&self.levels, &mut self.expr, 0)
     }
+
 }
 
-impl Iterator for BottomSubexprStream {
+impl Iterator for SubexprStream {
     type Item = Atom;
     
     fn next(&mut self) -> Option<Self::Item> {
-        if !self.has_next() {
-            None
-        } else {
-            self.next();
+        if self.next() {
             Some(self.get_mut().clone())
+        } else {
+            None
         }
-    }
-}
-
-impl From<ExpressionAtom> for BottomSubexprStream {
-    fn from(expr: ExpressionAtom) -> Self {
-        Self{ expr: Atom::Expression(expr), levels: vec![0] }
     }
 }
 
@@ -93,43 +133,67 @@ fn as_expr_mut(atom: &mut Atom) -> &mut ExpressionAtom {
     }
 }
 
+#[derive(Clone)]
+pub struct TopSubexprStream {
+    expr: Atom,
+    levels: Vec<usize>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn into_expr_atom(atom: Atom) -> ExpressionAtom {
-        match atom {
-            Atom::Expression(expr) => expr,
-            _ => panic!("Atom::Expression is expected"),
-        }
-    }
-
     #[test]
-    fn test_subexpression_iterator() {
+    fn bottom_up_depth_walk() {
         let expr = expr!("+", ("*", "3", ("+", "1", n)), ("-", "4", "3"));
 
-        let iter = BottomSubexprStream::from(into_expr_atom(expr));
+        let iter = SubexprStream::from_expr(expr, BOTTOM_UP_DEPTH_WALK);
 
         assert_eq!(iter.collect::<Vec<_>>(),
         vec![
         expr!("+", "1", n),
         expr!("*", "3", ("+", "1", n)),
         expr!("-", "4", "3"),
-        expr!("+", ("*", "3", ("+", "1", n)), ("-", "4", "3")),
         ]);
     }
 
     #[test]
-    fn test_subexpression_iterator_two_sub_expr() {
+    fn bottom_up_depth_walk_two_sub_expr() {
         let expr = expr!("*", ("+", "3", "4"), ("-", "5", "2"));
 
-        let iter = BottomSubexprStream::from(into_expr_atom(expr));
+        let iter = SubexprStream::from_expr(expr, BOTTOM_UP_DEPTH_WALK);
 
         assert_eq!(iter.collect::<Vec<_>>(),
         vec![
         expr!("+", "3", "4"),
         expr!("-", "5", "2"),
-        expr!("*", ("+", "3", "4"), ("-", "5", "2")),
+        ]);
+    }
+
+    #[test]
+    fn top_down_depth_walk() {
+        let expr = expr!("+", ("*", "3", ("+", "1", n)), ("-", "4", "3"));
+
+        let iter = SubexprStream::from_expr(expr, TOP_DOWN_DEPTH_WALK);
+
+        assert_eq!(iter.collect::<Vec<_>>(),
+        vec![
+        expr!("*", "3", ("+", "1", n)),
+        expr!("+", "1", n),
+        expr!("-", "4", "3"),
+        ]);
+    }
+
+    #[test]
+    fn top_down_depth_walk_two_sub_expr() {
+        let expr = expr!("*", ("+", "3", "4"), ("-", "5", "2"));
+
+        let iter = SubexprStream::from_expr(expr, TOP_DOWN_DEPTH_WALK);
+
+        assert_eq!(iter.collect::<Vec<_>>(),
+        vec![
+        expr!("+", "3", "4"),
+        expr!("-", "5", "2"),
         ]);
     }
 }

--- a/lib/src/interpreter/subexpr.rs
+++ b/lib/src/interpreter/subexpr.rs
@@ -53,30 +53,24 @@ fn move_bottom_up_depth<'a>(levels: &mut Vec<usize>, expr: &'a ExpressionAtom, l
         let found = move_bottom_up_depth(levels, as_expr(subexpr), level + 1);
         if found == None {
             log::trace!("move_bottom_up_depth: return: {}", subexpr);
-            return Some(subexpr)
+            Some(subexpr)
         } else {
-            return found
+            found
         }
-    }
-    loop {
-        let idx = levels[level];
-        if idx >= expr.children().len() {
-            levels.pop();
-            if level == 0 {
-                log::trace!("move_bottom_up_depth: return: None");
-            }
-            return None;
-        }
-        let child = &expr.children()[idx];
-        levels[level] = idx + 1;
-        if let Atom::Expression(ref child_expr) = child {
-            levels.push(0);
-            let found = move_bottom_up_depth(levels, child_expr, level + 1);
-            if found == None {
-                log::trace!("move_bottom_up_depth: return: {}", child);
-                return Some(child)
+    } else {
+        loop {
+            let found = find_next_sibling_expr(levels, expr, level);
+            if let Some(child) = found {
+                levels.push(0);
+                let found = move_bottom_up_depth(levels, as_expr(child), level + 1);
+                if found == None {
+                    log::trace!("move_bottom_up_depth: return: {}, levels.len(): {}", child, levels.len());
+                    return Some(child)
+                } else {
+                    return found
+                }
             } else {
-                return found
+                return None;
             }
         }
     }

--- a/lib/src/interpreter/subexpr.rs
+++ b/lib/src/interpreter/subexpr.rs
@@ -78,6 +78,7 @@ fn move_bottom_up_depth<'a>(levels: &mut Vec<usize>, expr: &'a ExpressionAtom, l
 
 type WalkStrategy = for<'a> fn(&mut Vec<usize>, &'a ExpressionAtom, usize) -> Option<&'a Atom>;
 
+pub static FIND_NEXT_SIBLING_WALK: WalkStrategy = find_next_sibling_expr;
 pub static BOTTOM_UP_DEPTH_WALK: WalkStrategy = move_bottom_up_depth;
 pub static TOP_DOWN_DEPTH_WALK: WalkStrategy = move_top_down_depth;
 

--- a/lib/src/interpreter/subexpr.rs
+++ b/lib/src/interpreter/subexpr.rs
@@ -1,0 +1,114 @@
+use crate::*;
+
+#[derive(Clone)]
+pub struct SubexpressionStream {
+    expr: Atom,
+    levels: Vec<usize>,
+}
+
+impl SubexpressionStream {
+    pub fn as_atom(&self) -> &Atom {
+        &self.expr
+    }
+
+    pub fn into_atom(self) -> Atom {
+        self.expr
+    }
+
+    fn next_rec(levels: &mut Vec<usize>, expr: &ExpressionAtom, level: usize) {
+        if level < levels.len() - 1 {
+            Self::next_rec(levels, expr.children()[levels[level] - 1].as_expr().unwrap(), level + 1);
+            return;
+        }
+        loop {
+            let idx = levels[level];
+            if idx >= expr.children().len() {
+                levels.pop();
+                return;
+            }
+            let child = &expr.children()[idx];
+            levels[level] = idx + 1;
+            if let Atom::Expression(ref child_expr) = child {
+                levels.push(0);
+                Self::next_rec(levels, child_expr, level + 1);
+                return;
+            }
+        }
+    }
+
+    pub fn next(&mut self) {
+        if let Atom::Expression(ref expr) = self.expr {
+            Self::next_rec(&mut self.levels, expr, 0);
+        }
+    }
+
+    pub fn has_next(&self) -> bool {
+        self.levels.len() > 0
+    }
+
+    fn get_mut_rec<'a>(levels: &'a Vec<usize>, atom: &'a mut Atom, level: usize) -> &'a mut Atom {
+        if level >= levels.len() {
+            atom
+        } else {
+            let child = &mut (atom.as_expr_mut().unwrap().children_mut()[levels[level] - 1]);
+            Self::get_mut_rec(levels, child, level + 1)
+        }
+    }
+
+    pub fn get_mut(&mut self) -> &mut Atom {
+        Self::get_mut_rec(&self.levels, &mut self.expr, 0)
+    }
+}
+
+impl Iterator for SubexpressionStream {
+    type Item = Atom;
+    
+    fn next(&mut self) -> Option<Self::Item> {
+        if !self.has_next() {
+            None
+        } else {
+            self.next();
+            Some(self.get_mut().clone())
+        }
+    }
+}
+
+impl From<ExpressionAtom> for SubexpressionStream {
+    fn from(expr: ExpressionAtom) -> Self {
+        Self{ expr: Atom::Expression(expr), levels: vec![0] }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_subexpression_iterator() {
+        let expr = expr!("+", ("*", "3", ("+", "1", n)), ("-", "4", "3"));
+
+        let iter = SubexpressionStream::from(expr.into_expr().unwrap());
+
+        assert_eq!(iter.collect::<Vec<_>>(),
+        vec![
+        expr!("+", "1", n),
+        expr!("*", "3", ("+", "1", n)),
+        expr!("-", "4", "3"),
+        expr!("+", ("*", "3", ("+", "1", n)), ("-", "4", "3")),
+        ]);
+    }
+
+    #[test]
+    fn test_subexpression_iterator_two_sub_expr() {
+        let expr = expr!("*", ("+", "3", "4"), ("-", "5", "2"));
+
+        let iter = SubexpressionStream::from(expr.into_expr().unwrap());
+
+        assert_eq!(iter.collect::<Vec<_>>(),
+        vec![
+        expr!("+", "3", "4"),
+        expr!("-", "5", "2"),
+        expr!("*", ("+", "3", "4"), ("-", "5", "2")),
+        ]);
+    }
+}

--- a/lib/src/interpreter/subexpr.rs
+++ b/lib/src/interpreter/subexpr.rs
@@ -4,59 +4,85 @@ fn get_expr<'a>(levels: &Vec<usize>, expr: &'a ExpressionAtom, level: usize) -> 
     as_expr(&expr.children()[levels[level] - 1])
 }
 
-fn find_next_sibling_expr(levels: &mut Vec<usize>, expr: &ExpressionAtom, level: usize) -> bool {
+fn find_next_sibling_expr<'a>(levels: &mut Vec<usize>, expr: &'a ExpressionAtom, level: usize) -> Option<&'a Atom> {
     let mut idx = levels[level];
     while idx < expr.children().len() {
         let child = &expr.children()[idx];
         if let Atom::Expression(_) = child {
             levels[level] = idx + 1;
             log::trace!("find_next_sibling_expr: return: {}", child);
-            return true;
+            return Some(child);
         }
         idx += 1;
     }
     levels.pop();
-    return false;
+    log::trace!("find_next_sibling_expr: return None");
+    return None;
 }
 
-fn move_top_down_depth(levels: &mut Vec<usize>, expr: &ExpressionAtom, level: usize) -> bool {
+fn move_top_down_depth<'a>(levels: &mut Vec<usize>, expr: &'a ExpressionAtom, level: usize) -> Option<&'a Atom> {
     log::trace!("move_top_down_depth: expr: {}, level: {}, levels.len(): {}, idx: {}", expr, level, levels.len(), levels[level]);
     if level < levels.len() - 1 {
         let found = move_top_down_depth(levels, get_expr(levels, expr, level), level + 1);
-        return found || find_next_sibling_expr(levels, expr, level);
+        if found == None {
+            find_next_sibling_expr(levels, expr, level)
+        } else {
+            found
+        }
     } else {
         let idx = levels[level];
         if idx == 0 {
-            return find_next_sibling_expr(levels, expr, level);
+            find_next_sibling_expr(levels, expr, level)
         } else {
             levels.push(0);
             let child = as_expr(&expr.children()[idx - 1]);
             let found = move_top_down_depth(levels, child, level + 1);
-            return found || find_next_sibling_expr(levels, expr, level);
+            if found == None {
+                find_next_sibling_expr(levels, expr, level)
+            } else {
+                found
+            }
         }
     }
 }
 
-fn move_bottom_up_depth(levels: &mut Vec<usize>, expr: &ExpressionAtom, level: usize) -> bool {
+fn move_bottom_up_depth<'a>(levels: &mut Vec<usize>, expr: &'a ExpressionAtom, level: usize) -> Option<&'a Atom> {
+    log::trace!("move_bottom_up_depth: expr: {}, level: {}, levels.len(): {}, idx: {}", expr, level, levels.len(), levels[level]);
     if level < levels.len() - 1 {
-        return move_bottom_up_depth(levels, as_expr(&expr.children()[levels[level] - 1]), level + 1);
+        let subexpr = &expr.children()[levels[level] - 1];
+        let found = move_bottom_up_depth(levels, as_expr(subexpr), level + 1);
+        if found == None {
+            log::trace!("move_bottom_up_depth: return: {}", subexpr);
+            return Some(subexpr)
+        } else {
+            return found
+        }
     }
     loop {
         let idx = levels[level];
         if idx >= expr.children().len() {
             levels.pop();
-            return level > 0;
+            if level == 0 {
+                log::trace!("move_bottom_up_depth: return: None");
+            }
+            return None;
         }
         let child = &expr.children()[idx];
         levels[level] = idx + 1;
         if let Atom::Expression(ref child_expr) = child {
             levels.push(0);
-            return move_bottom_up_depth(levels, child_expr, level + 1);
+            let found = move_bottom_up_depth(levels, child_expr, level + 1);
+            if found == None {
+                log::trace!("move_bottom_up_depth: return: {}", child);
+                return Some(child)
+            } else {
+                return found
+            }
         }
     }
 }
 
-type WalkStrategy = fn(&mut Vec<usize>, &ExpressionAtom, usize) -> bool;
+type WalkStrategy = for<'a> fn(&mut Vec<usize>, &'a ExpressionAtom, usize) -> Option<&'a Atom>;
 
 pub static BOTTOM_UP_DEPTH_WALK: WalkStrategy = move_bottom_up_depth;
 pub static TOP_DOWN_DEPTH_WALK: WalkStrategy = move_top_down_depth;
@@ -76,7 +102,7 @@ impl SubexprStream {
             walk: walk,
         }
     }
-    pub fn next(&mut self) -> bool {
+    pub fn next(&mut self) -> Option<&Atom> {
         (self.walk)(&mut self.levels, as_expr(&self.expr), 0)
     }
 
@@ -107,11 +133,7 @@ impl Iterator for SubexprStream {
     type Item = Atom;
     
     fn next(&mut self) -> Option<Self::Item> {
-        if self.next() {
-            Some(self.get_mut().clone())
-        } else {
-            None
-        }
+        self.next().cloned()
     }
 }
 

--- a/lib/src/interpreter/subexpr.rs
+++ b/lib/src/interpreter/subexpr.rs
@@ -1,12 +1,12 @@
 use crate::*;
 
 #[derive(Clone)]
-pub struct SubexpressionStream {
+pub struct BottomSubexprStream {
     expr: Atom,
     levels: Vec<usize>,
 }
 
-impl SubexpressionStream {
+impl BottomSubexprStream {
     pub fn as_atom(&self) -> &Atom {
         &self.expr
     }
@@ -60,7 +60,7 @@ impl SubexpressionStream {
     }
 }
 
-impl Iterator for SubexpressionStream {
+impl Iterator for BottomSubexprStream {
     type Item = Atom;
     
     fn next(&mut self) -> Option<Self::Item> {
@@ -73,7 +73,7 @@ impl Iterator for SubexpressionStream {
     }
 }
 
-impl From<ExpressionAtom> for SubexpressionStream {
+impl From<ExpressionAtom> for BottomSubexprStream {
     fn from(expr: ExpressionAtom) -> Self {
         Self{ expr: Atom::Expression(expr), levels: vec![0] }
     }
@@ -108,7 +108,7 @@ mod tests {
     fn test_subexpression_iterator() {
         let expr = expr!("+", ("*", "3", ("+", "1", n)), ("-", "4", "3"));
 
-        let iter = SubexpressionStream::from(into_expr_atom(expr));
+        let iter = BottomSubexprStream::from(into_expr_atom(expr));
 
         assert_eq!(iter.collect::<Vec<_>>(),
         vec![
@@ -123,7 +123,7 @@ mod tests {
     fn test_subexpression_iterator_two_sub_expr() {
         let expr = expr!("*", ("+", "3", "4"), ("-", "5", "2"));
 
-        let iter = SubexpressionStream::from(into_expr_atom(expr));
+        let iter = BottomSubexprStream::from(into_expr_atom(expr));
 
         assert_eq!(iter.collect::<Vec<_>>(),
         vec![

--- a/lib/src/interpreter/subexpr.rs
+++ b/lib/src/interpreter/subexpr.rs
@@ -80,10 +80,6 @@ impl SubexprStream {
         (self.walk)(&mut self.levels, as_expr(&self.expr), 0)
     }
 
-    pub fn has_next(&self) -> bool {
-        self.levels.len() > 0
-    }
-
     pub fn as_atom(&self) -> &Atom {
         &self.expr
     }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -142,7 +142,7 @@ impl Display for VariableAtom {
 // Grounded atom
 
 pub trait GroundedAtom : Debug + mopa::Any {
-    fn execute(&self, _ops: &mut Vec<Atom>, _data: &mut Vec<Atom>) -> Result<(), String> {
+    fn execute(&self, _args: &mut Vec<Atom>) -> Result<Vec<Atom>, String> {
         Err(format!("{:?} is not executable", self))
     }
     fn eq_gnd(&self, other: &dyn GroundedAtom) -> bool;

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -199,27 +199,6 @@ impl Atom {
         Self::Grounded(Box::new(gnd))
     }
 
-    pub fn as_expr(&self) -> Option<&ExpressionAtom> {
-        match self {
-            Atom::Expression(ref expr) => Some(expr),
-            _ => None,
-        }
-    }
-
-    pub fn into_expr(self) -> Option<ExpressionAtom> {
-        match self {
-            Atom::Expression(expr) => Some(expr),
-            _ => None,
-        }
-    }
-
-    pub fn as_expr_mut(&mut self) -> Option<&mut ExpressionAtom> {
-        match self {
-            Atom::Expression(ref mut expr) => Some(expr),
-            _ => None,
-        }
-    }
-
     pub fn as_gnd<T: GroundedAtom>(&self) -> Option<&T> {
         match self {
             Atom::Grounded(gnd) => gnd.downcast_ref::<T>(),

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -76,10 +76,6 @@ impl ExpressionAtom {
         self.children.iter().all(|atom| ! matches!(atom, Atom::Expression(_)))
     }
 
-    pub fn sub_expr_iter(&self) -> SubexpressionStream {
-        SubexpressionStream::from(self)
-    }
-
     pub fn children(&self) -> &Vec<Atom> {
         &self.children
     }
@@ -109,75 +105,6 @@ impl Display for ExpressionAtom {
             .and_then(|_| self.children.iter().skip(1).fold(Ok(()),
                 |res, atom| res.and_then(|_| write!(f, " {}", atom))))
             .and_then(|_| write!(f, ")"))
-    }
-}
-
-#[derive(Clone)]
-pub struct SubexpressionStream {
-    expr: Atom,
-    levels: Vec<usize>,
-}
-
-impl SubexpressionStream {
-    fn from(expr: &ExpressionAtom) -> Self {
-        Self{ expr: Atom::Expression((*expr).clone()), levels: vec![0] }
-    }
-
-    fn next_rec(levels: &mut Vec<usize>, expr: &ExpressionAtom, level: usize) {
-        if level < levels.len() - 1 {
-            Self::next_rec(levels, expr.children()[levels[level] - 1].as_expr().unwrap(), level + 1);
-            return;
-        }
-        loop {
-            let idx = levels[level];
-            if idx >= expr.children().len() {
-                levels.pop();
-                return;
-            }
-            let child = &expr.children()[idx];
-            levels[level] = idx + 1;
-            if let Atom::Expression(ref child_expr) = child {
-                levels.push(0);
-                Self::next_rec(levels, child_expr, level + 1);
-                return;
-            }
-        }
-    }
-
-    fn next(&mut self) {
-        if let Atom::Expression(ref expr) = self.expr {
-            Self::next_rec(&mut self.levels, expr, 0);
-        }
-    }
-
-    fn has_next(&self) -> bool {
-        self.levels.len() > 0
-    }
-
-    fn get_mut_rec<'a>(levels: &'a Vec<usize>, atom: &'a mut Atom, level: usize) -> &'a mut Atom {
-        if level >= levels.len() {
-            atom
-        } else {
-            let child = &mut (atom.as_expr_mut().unwrap().children_mut()[levels[level] - 1]);
-            Self::get_mut_rec(levels, child, level + 1)
-        }
-    }
-
-    fn get_mut(&mut self) -> &mut Atom {
-        Self::get_mut_rec(&self.levels, &mut self.expr, 0)
-    }
-}
-
-impl Iterator for SubexpressionStream {
-    type Item = Atom;
-    
-    fn next(&mut self) -> Option<Self::Item> {
-        if !self.has_next() {
-            None
-        } else {
-            self.next();
-            Some(self.get_mut().clone())
-        }
     }
 }
 
@@ -275,6 +202,13 @@ impl Atom {
     pub fn as_expr(&self) -> Option<&ExpressionAtom> {
         match self {
             Atom::Expression(ref expr) => Some(expr),
+            _ => None,
+        }
+    }
+
+    pub fn into_expr(self) -> Option<ExpressionAtom> {
+        match self {
+            Atom::Expression(expr) => Some(expr),
             _ => None,
         }
     }
@@ -418,3 +352,4 @@ impl From<&SExprSpace> for GroundingSpace {
         space
     }
 }
+

--- a/lib/src/tests.rs
+++ b/lib/src/tests.rs
@@ -126,32 +126,3 @@ fn test_match_if_then_with_X() {
     assert_eq!(space.query(&expr!("=", ("if", "True", "42"), X)),
         vec![bind!{X: expr!("42")}]);
 }
-
-#[test]
-fn test_subexpression_iterator() {
-    let expr = expr!("+", ("*", "3", ("+", "1", n)), ("-", "4", "3"));
-
-    let iter = expr.as_expr().unwrap().sub_expr_iter();
-
-    assert_eq!(iter.collect::<Vec<_>>(),
-        vec![
-            expr!("+", "1", n),
-            expr!("*", "3", ("+", "1", n)),
-            expr!("-", "4", "3"),
-            expr!("+", ("*", "3", ("+", "1", n)), ("-", "4", "3")),
-        ]);
-}
-
-#[test]
-fn test_subexpression_iterator_two_sub_expr() {
-    let expr = expr!("*", ("+", "3", "4"), ("-", "5", "2"));
-
-    let iter = expr.as_expr().unwrap().sub_expr_iter();
-
-    assert_eq!(iter.collect::<Vec<_>>(),
-        vec![
-            expr!("+", "3", "4"),
-            expr!("-", "5", "2"),
-            expr!("*", ("+", "3", "4"), ("-", "5", "2")),
-        ]);
-}

--- a/python/hyperon/__init__.py
+++ b/python/hyperon/__init__.py
@@ -80,6 +80,12 @@ class BaseVecAtom:
     def __init__(self, cvec):
         self.cvec = cvec
 
+    def size(self):
+        return hp.vec_atom_size(self.cvec)
+
+    def is_empty(self):
+        return self.size() == 0
+
     def push(self, atom):
         hp.vec_atom_push(self.cvec, atom.catom)
 

--- a/python/hyperon/__init__.py
+++ b/python/hyperon/__init__.py
@@ -8,6 +8,7 @@ class Atom:
         self.catom = catom
 
     def __del__(self):
+        #import sys; sys.stderr.write("Atom._del_(" + str(self) + ")\n"); sys.stderr.flush()
         hp.atom_free(self.catom)
 
     def __eq__(self, other):
@@ -74,6 +75,10 @@ class GroundedAtom(Atom):
 
 def G(object):
     return GroundedAtom(hp.atom_gnd(object))
+
+def call_execute_on_grounded_atom(gnd, args):
+    args = [Atom._from_catom(catom) for catom in args]
+    return gnd.execute(*args)
 
 class BaseVecAtom:
 

--- a/python/hyperonpy.cpp
+++ b/python/hyperonpy.cpp
@@ -66,7 +66,8 @@ const char *py_execute(const struct gnd_t* _cgnd, struct vec_atom_t* _ops, struc
 		return nullptr;	
 	} catch (py::error_already_set &e) {
 		// TODO: implement returning error description without static buffer
-		static char error[4096] = "Exception caught";
+		static char error[4096];
+ 	 	strcpy(error, "Exception caught:\n");
 		strncat(error, e.what(), sizeof(error) / sizeof(error[0]) - 1);
 		return error;
 	}

--- a/python/hyperonpy.cpp
+++ b/python/hyperonpy.cpp
@@ -167,6 +167,7 @@ PYBIND11_MODULE(hyperonpy, m) {
 	py::class_<CVecAtom>(m, "CVecAtom");
 	m.def("vec_atom_new", []() { return CVecAtom(vec_atom_new()); }, "New vector of atoms");
 	m.def("vec_atom_free", [](CVecAtom vec) { vec_atom_free(vec.ptr); }, "Free vector of atoms");
+	m.def("vec_atom_size", [](CVecAtom vec) { return vec_atom_size(vec.ptr); }, "Return size of the vector");
 	m.def("vec_atom_push", [](CVecAtom vec, CAtom atom) { vec_atom_push(vec.ptr, atom_copy(atom.ptr)); }, "Push atom into vector");
 	m.def("vec_atom_pop", [](CVecAtom vec) { return CAtom(vec_atom_pop(vec.ptr)); }, "Push atom into vector");
 

--- a/python/tests/common.py
+++ b/python/tests/common.py
@@ -128,7 +128,9 @@ class CallAtom(OpGroundedAtom):
 
     def execute(self, ops, data):
         obj = data.pop().get_object().value
-        args = data.pop().get_children()
+        args = []
+        while not data.is_empty():
+            args.append(data.pop().get_objec().value)
         method = getattr(obj, self.method_name)
         method(*args)
 

--- a/python/tests/common.py
+++ b/python/tests/common.py
@@ -12,9 +12,8 @@ class SpaceCollection(ConstGroundedAtom):
         super().__init__()
         self.spaces = spaces
 
-    def execute(self, ops, data):
-        name = data.pop().get_symbol()
-        data.push(ValueAtom(self.spaces[name]))
+    def execute(self, name):
+        return [ValueAtom(self.spaces[name.get_symbol()])]
 
     def __eq__(self, other):
         return isinstance(other, SpacesAtom) and self.spaces == other.spaces
@@ -27,11 +26,9 @@ class MatchAtom(OpGroundedAtom):
     def __init__(self):
         super().__init__()
 
-    def execute(self, ops, data):
-        space = data.pop().get_object().value
-        pattern = data.pop()
+    def execute(self, space, pattern, templ_op):
+        space = space.get_object().value
         # TODO: hack to make both quoted and unquoted expression work
-        templ_op = data.pop()
         if (templ_op.get_type() == AtomType.EXPR and
             templ_op.get_children()[0].get_type() == AtomType.SYMBOL and
             templ_op.get_children()[0].get_symbol() == 'q'):
@@ -39,8 +36,7 @@ class MatchAtom(OpGroundedAtom):
             templ = E(*quoted)
         else:
             templ = templ_op
-        for m in space.subst(pattern, templ):
-            data.push(m)
+        return space.subst(pattern, templ)
 
     def __repr__(self):
         return "match"
@@ -52,9 +48,8 @@ class UnaryOpAtom(OpGroundedAtom):
         self.name = name
         self.op = op
 
-    def execute(self, ops, data):
-        arg = data.pop().get_object()
-        data.push(ValueAtom(self.op(arg.value)))
+    def execute(self, arg):
+        return [ValueAtom(self.op(arg.get_object().value))]
 
     def __eq__(self, other):
         return isinstance(other, UnaryOpAtom) and self.name == self.name
@@ -69,10 +64,9 @@ class BinaryOpAtom(OpGroundedAtom):
         self.name = name
         self.op = op
 
-    def execute(self, ops, data):
-        a = data.pop().get_object()
-        b = data.pop().get_object()
-        data.push(ValueAtom(self.op(a.value, b.value)))
+    def execute(self, a, b):
+        return [ValueAtom(self.op(a.get_object().value,
+            b.get_object().value))]
 
     def __eq__(self, other):
         return isinstance(other, BinaryOpAtom) and self.name == self.name
@@ -126,13 +120,11 @@ class CallAtom(OpGroundedAtom):
         super().__init__()
         self.method_name = method_name
 
-    def execute(self, ops, data):
-        obj = data.pop().get_object().value
-        args = []
-        while not data.is_empty():
-            args.append(data.pop().get_objec().value)
+    def execute(self, obj, *args):
+        obj = obj.get_object().value
         method = getattr(obj, self.method_name)
         method(*args)
+        return []
 
     def __eq__(self, other):
         if isinstance(other, CallAtom):
@@ -147,16 +139,10 @@ class LetAtom(OpGroundedAtom):
     def __init__(self):
         super().__init__()
 
-    def execute(self, ops, data):
-        pattern = data.pop()
-        atom = data.pop()
-        templ = data.pop()
-        print("pattern:", pattern, "atom:", atom, "templ:", templ)
+    def execute(self, pattern, atom, templ):
         space = GroundingSpace()
         space.add_atom(atom)
-        for res in space.subst(pattern, templ):
-            print("result:", res)
-            data.push(res)
+        return space.subst(pattern, templ)
 
     def __repr__(self):
         return "let"
@@ -166,10 +152,8 @@ class CommaAtom(OpGroundedAtom):
     def __init__(self):
         super().__init__()
 
-    def execute(self, ops, data):
-        args = data.pop().get_children()
-        for arg in args:
-            data.push(arg)
+    def execute(self, args):
+        return args.get_children()
 
     def __repr__(self):
         return ","

--- a/python/tests/common.py
+++ b/python/tests/common.py
@@ -142,6 +142,25 @@ class CallAtom(OpGroundedAtom):
     def __repr__(self):
         return "call:" + self.method_name
 
+class LetAtom(OpGroundedAtom):
+
+    def __init__(self):
+        super().__init__()
+
+    def execute(self, ops, data):
+        pattern = data.pop()
+        atom = data.pop()
+        templ = data.pop()
+        print("pattern:", pattern, "atom:", atom, "templ:", templ)
+        space = GroundingSpace()
+        space.add_atom(atom)
+        for res in space.subst(pattern, templ):
+            print("result:", res)
+            data.push(res)
+
+    def __repr__(self):
+        return "let"
+
 class CommaAtom(OpGroundedAtom):
 
     def __init__(self):
@@ -188,7 +207,7 @@ class Atomese:
         parser.register_token(r"match", lambda token: G(MatchAtom()))
         parser.register_token(r"call:[^\\s)]+", lambda token: G(CallAtom(token[5:])))
         parser.register_token(r",", lambda token: G(CommaAtom()))
-        #parser.register_token(r"let", lambda token: IFMATCH)
+        parser.register_token(r"let", lambda token: G(LetAtom()))
         for regexp in self.tokens.keys():
             parser.register_token(regexp, self.tokens[regexp])
         return parser
@@ -217,3 +236,5 @@ class Atomese:
 
     def add_atom(self, name, symbol):
         self.add_token(name, lambda _: symbol)
+
+

--- a/python/tests/test_atom.py
+++ b/python/tests/test_atom.py
@@ -48,10 +48,8 @@ class AtomTest(unittest.TestCase):
             # VecAtom()), "1.0 is not executable")
 
     def test_grounded_execute(self):
-        data = VecAtom()
-        data.push(ValueAtom(1.0))
-        X2Atom().get_object().execute(VecAtom(), data)
-        self.assertEqual(data.pop(), ValueAtom(2.0))
+        res = X2Atom().get_object().execute(ValueAtom(1.0))
+        self.assertEqual(res, [ValueAtom(2.0)])
 
     def test_expr_equals(self):
         self.assertEqual(E(S("+"), S("1"), S("2")),
@@ -121,10 +119,8 @@ class X2(OpGroundedAtom):
     def __init__(self):
         super().__init__()
 
-    def execute(self, ops, data):
-        arg = data.pop()
-        data.push(ValueAtom(2 * arg.get_object().value))
-        return None
+    def execute(self, arg):
+        return [ValueAtom(2 * arg.get_object().value)]
 
     def __str__(self):
         return "*2"

--- a/python/tests/test_examples.py
+++ b/python/tests/test_examples.py
@@ -145,6 +145,7 @@ class ExamplesTest(unittest.TestCase):
 
         kb = atomese.parse('''
            (= (if True $then) $then)
+           (= (if False $then) nop)
 
            (= (bin) 0)
            (= (bin) 1)
@@ -158,7 +159,8 @@ class ExamplesTest(unittest.TestCase):
         target = atomese.parse_single('''(let $t (gen 3)
             (if (== (subsum (:: 3 (:: 5 (:: 7 nil))) $t) 8) $t))''')
         output = interpret(kb, target)
-        self.assertEqual(output, atomese.parse_single('(:: 1 (:: 1 (:: 0 nil)))'))
+        expected = atomese.parse_single('(:: 1 (:: 1 (:: 0 nil)))')
+        self.assertEqual(output, [expected])
 
     def test_infer_function_application_type(self):
         atomese = Atomese()

--- a/python/tests/test_examples.py
+++ b/python/tests/test_examples.py
@@ -57,13 +57,16 @@ class ExamplesTest(unittest.TestCase):
         # self.assertEqual(ValueAtom('Hello world'),
                 # interpret(kb, atomese.parse_single("(+ 'Hello ' 'world')")))
 
-    def _test_grounded_functions(self):
+    def test_grounded_functions(self):
         atomese = Atomese()
+        obj = SomeObject()
+        atomese.add_atom("obj", ValueAtom(obj))
 
-        atomese.add_atom("obj", ValueAtom(SomeObject()))
-        target = atomese.parse('(call:foo obj)')
+        target = atomese.parse_single('(call:foo obj)')
+        result = interpret(GroundingSpace(), target)
 
-        interpret_and_print_results(target, GroundingSpace())
+        self.assertTrue(obj.called)
+        self.assertEqual(result, [])
 
     def test_frog_reasoning(self):
         atomese = Atomese()
@@ -258,8 +261,11 @@ class ExamplesTest(unittest.TestCase):
 
 class SomeObject():
 
+    def __init__(self):
+        self.called = False
+
     def foo(self):
-        print("foo called")
+        self.called = True
 
 init_logger()
 if __name__ == "__main__":

--- a/python/tests/test_minecraft.py
+++ b/python/tests/test_minecraft.py
@@ -10,9 +10,8 @@ class InInventoryAtom(OpGroundedAtom):
         super().__init__()
         self.inventory = inventory
 
-    def execute(self, ops, data):
-        obj = data.pop()
-        data.push(ValueAtom(obj in self.inventory))
+    def execute(self, obj):
+        return [ValueAtom(obj in self.inventory)]
 
     def __repr__(self):
         return "in-inventory"
@@ -23,13 +22,10 @@ class CraftAtom(OpGroundedAtom):
         super().__init__()
         self.inventory = inventory
 
-    def execute(self, ops, data):
-        obj = data.pop()
-        where = data.pop()
-        comp = data.pop()
+    def execute(self, obj, where, comp):
         print(str(obj) + " crafted in " + str(where) + " from " + str(comp))
         self.inventory.append(obj)
-        data.push(obj)
+        return [obj]
 
     def __repr__(self):
         return "craft"
@@ -40,12 +36,10 @@ class MineAtom(OpGroundedAtom):
         super().__init__()
         self.inventory = inventory
 
-    def execute(self, ops, data):
-        obj = data.pop()
-        tool = data.pop()
+    def execute(self, obj, tool):
         print(str(obj) + " mined by " + str(tool))
         self.inventory.append(obj)
-        data.push(obj)
+        return [obj]
 
     def __repr__(self):
         return "mine"


### PR DESCRIPTION
Add old method calling example. Rework interpreter significantly to simplify the logic and almost pass sub-sum example without introducing unification. Simplify GroundedAtom.execute() API to allow implementing it in Python using common arguments and return values.