### PR TITLE
Add type checking examples

### DIFF
--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -5,7 +5,6 @@ use std::ffi::*;
 use std::os::raw::*;
 use std::fmt::Debug;
 use regex::Regex;
-use std::rc::Rc;
 
 #[no_mangle]
 pub extern "C" fn init_logger() {
@@ -255,7 +254,7 @@ pub unsafe extern "C" fn vec_atom_get(vec: *mut vec_atom_t, idx: usize) -> *mut 
 #[no_mangle]
 pub extern "C" fn interpret(space: *mut grounding_space_t, expr: *const atom_t,
         callback: atoms_callback_t, data: *mut c_void) {
-    let res = unsafe { hyperon::interpreter::interpret(Rc::new((*space).space.clone()), &(*expr).atom) };
+    let res = unsafe { hyperon::interpreter::interpret((*space).space.clone(), &(*expr).atom) };
     match res {
         Ok(vec) => return_atoms(&vec, callback, data),
         Err(_) => return_atoms(&vec![], callback, data),

--- a/lib/src/arithmetics.rs
+++ b/lib/src/arithmetics.rs
@@ -23,38 +23,36 @@ mod tests {
 
     use super::*;
     use crate::interpreter::*;
-    use std::rc::Rc;
-
     // Aliases to have a shorter notation
     fn G<T: GroundedAtom>(value: T) -> Atom { Atom::gnd(value) }
 
-    fn init() {
+    fn init_logger() {
         let _ = env_logger::builder().is_test(true).try_init();
     }
 
     #[test]
     fn test_sum_ints() {
-        init();
+        init_logger();
         let space = GroundingSpace::new();
         // (+ 3 5)
         let expr = expr!({SUM}, {3}, {5});
 
-        assert_eq!(interpret(Rc::new(space), &expr), Ok(vec![G(8)]));
+        assert_eq!(interpret(space, &expr), Ok(vec![G(8)]));
     }
 
     #[test]
     fn test_sum_ints_recursively() {
-        init();
+        init_logger();
         let space = GroundingSpace::new();
         // (+ 4 (+ 3 5))
         let expr = expr!({SUM}, {4}, ({SUM}, {3}, {5}));
 
-        assert_eq!(interpret(Rc::new(space), &expr), Ok(vec![G(12)]));
+        assert_eq!(interpret(space, &expr), Ok(vec![G(12)]));
     }
 
     #[test]
     fn test_match_factorial() {
-        init();
+        init_logger();
         let mut space = GroundingSpace::new();
         // (= (fac 0) 1)
         space.add(expr!("=", ("fac", {0}), {1}));
@@ -69,7 +67,7 @@ mod tests {
     // TODO: reimplement using grounded if to prevent infinite loop
     //#[test]
     fn test_factorial() {
-        init();
+        init_logger();
         let mut space = GroundingSpace::new();
         // (= (fac n) (* n (fac (- n 1))))
         space.add(expr!("=", ("fac", n), ({MUL}, n, ("fac", ({SUB}, n, {1})))));
@@ -77,6 +75,6 @@ mod tests {
         space.add(expr!("=", ("fac", {0}), {1}));
 
         let expr = expr!("fac", {3});
-        assert_eq!(interpret(Rc::new(space), &expr), Ok(vec![G(6)]));
+        assert_eq!(interpret(space, &expr), Ok(vec![G(6)]));
     }
 }

--- a/lib/src/interpreter/mod.rs
+++ b/lib/src/interpreter/mod.rs
@@ -1,6 +1,7 @@
 mod plan;
 mod subexpr;
 mod matching;
+mod types;
 
 pub use plan::*;
 pub use subexpr::*;

--- a/lib/src/interpreter/types.rs
+++ b/lib/src/interpreter/types.rs
@@ -1,0 +1,188 @@
+use crate::*;
+use std::ops::Not;
+
+#[derive(Debug, PartialEq, Eq)]
+enum AtomType {
+    Undefined,
+    Specific(Atom),
+}
+
+fn type_query(atom: &Atom, typ: &Atom) -> Atom {
+    Atom::expr(&[Atom::sym(":"), atom.clone(), typ.clone()])
+}
+
+fn query_super_type(space: &GroundingSpace, sub: &Atom, sup: &Atom) -> Vec<Bindings> {
+    space.query(&type_query(sub, sup))
+}
+
+fn query_sub_type(space: &GroundingSpace, typ: &Atom) -> Vec<Atom> {
+    // TODO: query should check that sub type is a type and not another typed symbol
+    let var_x = VariableAtom::from("X");
+    let mut types = space.query(&type_query(&Atom::Variable(var_x.clone()), &typ));
+    types.drain(0..).map(|mut bindings| bindings.remove(&var_x).unwrap()).collect()
+}
+
+fn match_type_slice(space: &GroundingSpace, atoms: &[Atom], types: &[Atom]) -> bool {
+    match (atoms, types) {
+        ([atom, atoms @ ..], [typ, types @ ..]) =>
+            check_specific_type(space, atom, typ)
+                && match_type_slice(space, atoms, types),
+        ([], []) => true,
+        _ => false,
+    }
+}
+
+fn check_sub_types(space: &GroundingSpace, atom: &Atom, typ: &Atom) -> bool {
+    query_sub_type(space, typ).iter()
+        .map(|typ| check_specific_type(space, atom, &typ))
+        .any(std::convert::identity)
+}
+
+fn check_specific_type(space: &GroundingSpace, atom: &Atom, typ: &Atom) -> bool {
+    log::debug!("check_specific_type: atom: {:?}, typ: {:?}", atom, typ);
+    let result = match (atom, typ) {
+        (_, Atom::Symbol(_)) =>
+            query_super_type(space, atom, typ).is_empty().not()
+                || check_sub_types(space, atom, typ),
+        (Atom::Expression(expr), Atom::Expression(typ_expr)) =>
+            match_type_slice(space, expr.children.as_slice(), typ_expr.children.as_slice()),
+        _ => false,
+    };
+    log::debug!("check_specific_type: result: {}", result);
+    result
+}
+
+fn check_type(space: &GroundingSpace, atom: &Atom, typ: &AtomType) -> bool {
+    match typ {
+        AtomType::Undefined => true,
+        AtomType::Specific(typ) => check_specific_type(space, atom, typ),
+    }
+}
+
+fn first_arg_typ(fn_typ: &Atom) -> (AtomType, Option<&Atom>) {
+    match fn_typ {
+        Atom::Expression(expr) => {
+            let children = &expr.children;
+            assert_eq!(children[0], Atom::sym("->"));
+            let typ = children[1].clone();
+            let fn_typ = if children.len() == 3 { Option::from(&children[2]) } else { None };
+            (AtomType::Specific(typ), fn_typ)
+        },
+        _ => panic!("Non function type")
+    }
+}
+
+fn check_arg_types(space: &GroundingSpace, args: &[Atom], fn_typ: &Atom) -> bool {
+    log::debug!("check_args_type:, args: {:?}, fn_typ: {:?}", args, fn_typ);
+    let is_expr = matches!(fn_typ, Atom::Expression(_));
+    let args_empty = args.is_empty();
+    if is_expr && !args_empty {
+        let (typ, fn_typ) = first_arg_typ(fn_typ);
+        check_type(space, &args[0], &typ) && check_arg_types(space, &args[1..], fn_typ.unwrap_or(&Atom::expr(&[])))
+    } else {
+        !is_expr && args_empty
+    }
+}
+
+fn get_types(space: &GroundingSpace, atom: &Atom) -> Vec<Atom> {
+    let var_x = VariableAtom::from("X");
+    let mut types = query_super_type(space, atom, &Atom::Variable(var_x.clone()));
+    types.drain(0..).map(|mut bindings| bindings.remove(&var_x).unwrap()).collect()
+}
+
+fn get_op(expr: &ExpressionAtom) -> &Atom {
+    expr.children.get(0).expect("Non-empty expression is expected")
+}
+
+fn validate_expr(space: &GroundingSpace, atom: &Atom) -> bool {
+    match atom {
+        Atom::Expression(expr) => {
+            let op = get_op(expr);
+            let args = &expr.children.as_slice()[1..];
+            get_types(space, op).iter().map(|typ| check_arg_types(space, args, typ))
+                .any(std::convert::identity)
+        },
+        _ => panic!("Atom::Expression is expected as an argument"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    fn init_logger() {
+        let _ = env_logger::builder().is_test(true).try_init();
+    }
+
+    fn grammar_space() -> GroundingSpace {
+        let mut space = GroundingSpace::new();
+        space.add(expr!(":", "answer", ("->", "Sent", "Sent")));
+        space.add(expr!(":", "Quest", "Sent"));
+        space.add(expr!(":", ("Aux", "Subj", "Verb", "Obj"), "Quest"));
+        space.add(expr!(":", "Pron", "Subj"));
+        space.add(expr!(":", "NG", "Subj"));
+        space.add(expr!(":", "Pron", "Obj"));
+        space.add(expr!(":", "NG", "Obj"));
+        space.add(expr!(":", ("Det", "Noun"), "NG"));
+        space.add(expr!(":", "you", "Pron"));
+        space.add(expr!(":", "do", "Aux"));
+        space.add(expr!(":", "do", "Verb"));
+        space.add(expr!(":", "like", "Verb"));
+        space.add(expr!(":", "a", "Det"));
+        space.add(expr!(":", "pizza", "Noun"));
+        space
+    }
+
+    #[test]
+    fn test_check_type() {
+        let mut space = GroundingSpace::new();
+        space.add(expr!(":", "do", "Verb"));
+        space.add(expr!(":", "do", "Aux"));
+        space.add(expr!(":", var, "Verb"));
+
+        let aux = AtomType::Specific(Atom::sym("Aux"));
+        let verb = AtomType::Specific(Atom::sym("Verb"));
+
+        let nonsense = Atom::sym("nonsense");
+        assert_eq!(check_type(&space, &nonsense, &AtomType::Undefined), true);
+        assert_eq!(check_type(&space, &nonsense, &aux), false);
+
+        let _do = Atom::sym("do");
+        assert_eq!(check_type(&space, &_do, &AtomType::Undefined), true);
+        assert_eq!(check_type(&space, &_do, &aux), true);
+        assert_eq!(check_type(&space, &_do, &verb), true);
+        assert_eq!(check_type(&space, &_do, &AtomType::Specific(Atom::sym("Noun"))), false);
+
+        let var = Atom::var("var");
+        assert_eq!(check_type(&space, &var, &AtomType::Undefined), true);
+        assert_eq!(check_type(&space, &var, &aux), true);
+        assert_eq!(check_type(&space, &var, &verb), true);
+    }
+
+    #[test]
+    fn test_check_expr_type() {
+        let mut space = GroundingSpace::new();
+        space.add(expr!(":", "i", "Pron"));
+        space.add(expr!(":", "like", "Verb"));
+        space.add(expr!(":", "music", "Noun"));
+        space.add(expr!(":", ("do", "you", "like", "music"), "Quest"));
+        space.add(expr!(":", ("Pron", "Verb", "Noun"), "Statement"));
+
+        let i_like_music = expr!("i", "like", "music");
+        assert_eq!(check_type(&space, &i_like_music, &AtomType::Undefined), true);
+        assert_eq!(check_type(&space, &i_like_music, &AtomType::Specific(expr!("Pron", "Verb", "Noun"))), true);
+        assert_eq!(check_type(&space, &i_like_music, &AtomType::Specific(Atom::sym("Statement"))), true);
+
+        assert_eq!(check_type(&space, &expr!("do", "you", "like", "music"), &AtomType::Specific(Atom::sym("Quest"))), true);
+    }
+
+    #[test]
+    fn test_validate_expr() {
+        init_logger();
+
+        let space = grammar_space();
+        let expr = expr!("answer", ("do", "you", "like", ("a", "pizza")));
+
+        assert_eq!(validate_expr(&space, &expr), true);
+    }
+}


### PR DESCRIPTION
Small improve of `GroundingSpace` passing move `Rc` inside `GroundingSpace`.
Add functions to check atom types using types information saved in atomspace. Add unit tests.