### PR TITLE
Custom matching

### DIFF
--- a/lib/src/atom/matcher.rs
+++ b/lib/src/atom/matcher.rs
@@ -126,12 +126,14 @@ impl From<(Bindings, Bindings)> for MatchResult {
     }
 }
 
+pub type MatchResultIter = Box<dyn Iterator<Item=matcher::MatchResult>>;
+
 pub trait WithMatch {
-    fn do_match<'a>(&self, other: &Atom) -> Box<dyn Iterator<Item=MatchResult> + 'a>;
+    fn do_match(&self, other: &Atom) -> MatchResultIter;
 }
 
 impl WithMatch for Atom {
-    fn do_match<'a>(&self, other: &Atom) -> Box<dyn Iterator<Item=MatchResult> + 'a> {
+    fn do_match(&self, other: &Atom) -> MatchResultIter {
         match (self, other) {
             (Atom::Symbol(a), Atom::Symbol(b)) if a == b => Box::new(std::iter::once(MatchResult::new())),
             (Atom::Grounded(a), Atom::Grounded(_)) => a.match_gnd(other),
@@ -162,8 +164,7 @@ impl WithMatch for Atom {
     }
 }
 
-pub fn product_iter<'a>(prev: Box<dyn Iterator<Item=MatchResult>>,
-    next: Box<dyn Iterator<Item=MatchResult>>) -> Box<dyn Iterator<Item=MatchResult> + 'a> {
+pub fn product_iter(prev: MatchResultIter, next: MatchResultIter) -> MatchResultIter {
     let next : Vec<MatchResult> = next.collect();
     log::trace!("product_iter, next: {:?}", next);
     Box::new(prev.flat_map(move |p| -> Vec<Option<MatchResult>> {

--- a/lib/src/atom/mod.rs
+++ b/lib/src/atom/mod.rs
@@ -129,6 +129,15 @@ pub trait GroundedAtom : Debug + mopa::Any {
     }
     fn eq_gnd(&self, other: &dyn GroundedAtom) -> bool;
     fn clone_gnd(&self) -> Box<dyn GroundedAtom>;
+    fn match_gnd(&self, other: &Atom) -> Box<dyn Iterator<Item=matcher::MatchResult>> {
+        if let Atom::Grounded(other) = other {
+            if self.eq_gnd(&**other) {
+                return Box::new(std::iter::once(matcher::MatchResult::new()))
+            }
+        }
+        Box::new(std::iter::empty())
+    }
+
 }
 
 mopafy!(GroundedAtom);
@@ -136,7 +145,7 @@ mopafy!(GroundedAtom);
 // FIXME: one cannot implement custom execute() for the type which
 // have derived Clone, PartialEq and Debug at the same time because
 // it automatically have GroundedAtom implemented from the impl below.
-// This is a Rust restriction: there is not method overriding and
+// This is a Rust restriction: there is no method overriding and
 // trait can be implemented only once for each type.
 
 // GroundedAtom implementation for all "regular" types


### PR DESCRIPTION
Add ability to define custom matching for GroundedAtoms. Implement an example of custom matching for simple dictionary implementation in Rust.