### PR TITLE
Fix unsafe passing variable name to the callback

### DIFF
--- a/c/tests/check_grounding_space.c
+++ b/c/tests/check_grounding_space.c
@@ -22,7 +22,6 @@ void copy_to_output(char const* str, void* context) {
 
 void query_callback(binding_t const* results, uintptr_t size, void* data) {
 	struct output_t *output = data;
-	char atom_str[1024];
 	for (int i = 0; i < size; ++i) {
 		binding_t const* result = results + i;
 		output->len += snprintf(output->str + output->len, 1024 - output->len, "%s: ", results->var);


### PR DESCRIPTION
Variable name is properly converted to C string and guaranteed to be existing while callback is called. Before this fix the string which was passed to the caller was not zero ended.