### PR TITLE
Allow passing atoms with undefined type as argument to the function expression

### DIFF
--- a/c/src/metta.rs
+++ b/c/src/metta.rs
@@ -144,6 +144,6 @@ pub unsafe extern "C" fn check_type(space: *const grounding_space_t, atom: *cons
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn validate_expr(space: *const grounding_space_t, atom: *const atom_t) -> bool {
-    hyperon::metta::types::validate_expr(&(*space).space, &(*atom).atom)
+pub unsafe extern "C" fn validate_atom(space: *const grounding_space_t, atom: *const atom_t) -> bool {
+    hyperon::metta::types::validate_atom(&(*space).space, &(*atom).atom)
 }

--- a/c/tests/check_types.c
+++ b/c/tests/check_types.c
@@ -25,7 +25,7 @@ START_TEST (test_check_type)
 }
 END_TEST
 
-START_TEST (test_validate_expr)
+START_TEST (test_validate_atom)
 {
 	grounding_space_t* space = grounding_space_new();
 	grounding_space_add(space, expr(atom_sym(":"), atom_sym("a"), atom_sym("A"), 0));
@@ -33,7 +33,7 @@ START_TEST (test_validate_expr)
 	grounding_space_add(space, expr(atom_sym(":"), atom_sym("foo"), expr(atom_sym("->"), atom_sym("A"), atom_sym("B"), 0), 0));
 
     atom_t* foo = expr(atom_sym("foo"), atom_sym("a"), 0);
-    ck_assert(validate_expr(space, foo));
+    ck_assert(validate_atom(space, foo));
     atom_free(foo);
 }
 END_TEST
@@ -41,7 +41,7 @@ END_TEST
 void init_test(TCase* test_case) {
     tcase_add_checked_fixture(test_case, setup, teardown);
     tcase_add_test(test_case, test_check_type);
-    tcase_add_test(test_case, test_validate_expr);
+    tcase_add_test(test_case, test_validate_atom);
 }
 
 TEST_MAIN(init_test);

--- a/lib/src/atom/subexpr.rs
+++ b/lib/src/atom/subexpr.rs
@@ -176,13 +176,6 @@ pub fn split_expr(expr: &Atom) -> Option<(&Atom, std::slice::Iter<Atom>)> {
     }
 }
 
-
-#[derive(Clone)]
-pub struct TopSubexprStream {
-    expr: Atom,
-    levels: Vec<usize>,
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/lib/src/metta/mod.rs
+++ b/lib/src/metta/mod.rs
@@ -3,3 +3,24 @@ pub mod interpreter;
 pub mod types;
 
 mod examples;
+
+use crate::Atom;
+use crate::space::grounding::GroundingSpace;
+use text::SExprSpace;
+
+pub fn metta_space(text: &str) -> GroundingSpace {
+    let mut parser = SExprSpace::new();
+    parser.add_str(text).unwrap();
+    GroundingSpace::from(&parser)
+}
+
+pub fn metta_atom(atom: &str) -> Atom {
+    let space = metta_space(atom);
+    if space.borrow_vec().len() != 1 {
+        panic!("Single atom is expected");
+    } else {
+        space.leak().pop().unwrap()
+    }
+}
+
+

--- a/lib/src/metta/types.rs
+++ b/lib/src/metta/types.rs
@@ -90,7 +90,7 @@ fn get_args(expr: &ExpressionAtom) -> &[Atom] {
     &expr.children().as_slice()[1..]
 }
 
-pub fn validate_expr(space: &GroundingSpace, atom: &Atom) -> bool {
+pub fn validate_atom(space: &GroundingSpace, atom: &Atom) -> bool {
     match atom {
         Atom::Expression(expr) => {
             let op = get_op(expr);
@@ -184,12 +184,12 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_expr() {
+    fn test_validate_atom() {
         init_logger();
         let space = grammar_space();
         let expr = expr!("answer", ("do", "you", "like", ("a", "pizza")));
 
-        assert_eq!(validate_expr(&space, &expr), true);
+        assert_eq!(validate_atom(&space, &expr), true);
     }
 
     #[test]
@@ -222,7 +222,7 @@ mod tests {
             (: b B)
         ");
 
-        assert!(validate_expr(&space, &atom("(a b)")));
+        assert!(validate_atom(&space, &atom("(a b)")));
     }
 
     #[test]
@@ -232,7 +232,7 @@ mod tests {
             (: a (-> B A))
         ");
 
-        assert!(validate_expr(&space, &atom("(a b)")));
+        assert!(validate_atom(&space, &atom("(a b)")));
     }
 
     #[ignore]
@@ -255,6 +255,6 @@ mod tests {
             (: h (-> (-> B A) C))
         ");
 
-        assert!(validate_expr(&space, &atom("(h a)")));
+        assert!(validate_atom(&space, &atom("(h a)")));
     }
 }

--- a/lib/src/metta/types.rs
+++ b/lib/src/metta/types.rs
@@ -107,7 +107,7 @@ pub fn validate_atom(space: &GroundingSpace, atom: &Atom) -> bool {
                 }
             }).any(std::convert::identity)
         },
-        _ => panic!("Atom::Expression is expected as an argument"),
+        _ => true,
     }
 }
 
@@ -193,6 +193,12 @@ mod tests {
     }
 
     #[test]
+    fn validate_symbol() {
+        let space = GroundingSpace::new();
+        assert!(validate_atom(&space, &Atom::sym("a")));
+    }
+
+    #[test]
     fn simple_types() {
         init_logger();
         let space = metta_space("
@@ -257,4 +263,5 @@ mod tests {
 
         assert!(validate_atom(&space, &atom("(h a)")));
     }
+
 }

--- a/lib/src/space/grounding.rs
+++ b/lib/src/space/grounding.rs
@@ -117,6 +117,10 @@ impl GroundingSpace {
     pub fn borrow_vec(&self) -> Ref<Vec<Atom>> {
         self.content.borrow()
     }
+
+    pub fn leak(self) -> Vec<Atom> {
+        self.content.take()
+    }
 }
 
 impl PartialEq for GroundingSpace {

--- a/python/hyperon/__init__.py
+++ b/python/hyperon/__init__.py
@@ -246,5 +246,5 @@ class AtomType:
 def check_type(gnd_space, atom, type):
     return hp.check_type(gnd_space.cspace, atom.catom, type.ctype)
 
-def validate_expr(gnd_space, expr):
-    return hp.validate_expr(gnd_space.cspace, expr.catom)
+def validate_atom(gnd_space, expr):
+    return hp.validate_atom(gnd_space.cspace, expr.catom)

--- a/python/hyperonpy.cpp
+++ b/python/hyperonpy.cpp
@@ -273,8 +273,8 @@ PYBIND11_MODULE(hyperonpy, m) {
 	m.def("check_type", [](CGroundingSpace space, CAtom atom, CAtomType type) { 
 			return check_type(space.ptr, atom.ptr, type.ptr);
 		}, "Check if atom is an instance of the passed type");
-	m.def("validate_expr", [](CGroundingSpace space, CAtom expr) { 
-			return validate_expr(space.ptr, expr.ptr);
+	m.def("validate_atom", [](CGroundingSpace space, CAtom expr) { 
+			return validate_atom(space.ptr, expr.ptr);
 		}, "Validate expression arguments correspond to the operation type");
 }
 

--- a/python/tests/test_atom_type.py
+++ b/python/tests/test_atom_type.py
@@ -12,10 +12,10 @@ class AtomTest(unittest.TestCase):
         self.assertTrue(check_type(space, S("a"), AtomType.specific(S("A"))))
         self.assertFalse(check_type(space, S("a"), AtomType.specific(S("B"))))
 
-    def test_validate_expr(self):
+    def test_validate_atom(self):
         space = GroundingSpace()
         space.add_atom(E(S(":"), S("a"), S("A")))
         space.add_atom(E(S(":"), S("b"), S("B")))
         space.add_atom(E(S(":"), S("foo"), E(S("->"), S("A"), S("B"))))
 
-        self.assertTrue(validate_expr(space, E(S("foo"), S("a"))))
+        self.assertTrue(validate_atom(space, E(S("foo"), S("a"))))


### PR DESCRIPTION
Rename `validate_expr` to `validate_atom`, allow validating single atoms. Allow atoms with undefined types as arguments. Add unit tests for type check functions.