### PR TITLE
Add dependent types

### DIFF
--- a/lib/src/metta/types.rs
+++ b/lib/src/metta/types.rs
@@ -91,13 +91,13 @@ fn get_args(expr: &ExpressionAtom) -> &[Atom] {
 fn get_reducted_types(space: &GroundingSpace, atom: &Atom) -> Vec<Atom> {
     log::trace!("get_reducted_types: atom: {}", atom);
     let types = match atom {
-        Atom::Variable(_) | Atom::Grounded(_) => vec![Atom::sym("Undefined")],
+        Atom::Variable(_) | Atom::Grounded(_) => vec![Atom::sym("%Undefined%")],
         Atom::Symbol(_) => {
             let types = query_types(space, atom);
             if !types.is_empty() {
                 types
             } else {
-                vec![Atom::sym("Undefined")]
+                vec![Atom::sym("%Undefined%")]
             }
         },
         Atom::Expression(expr) => {
@@ -149,7 +149,7 @@ pub fn match_reducted_types(type1: &Atom, type2: &Atom, bindings: &mut Bindings)
         (Atom::Variable(_), Atom::Variable(_)) => false,
         (Atom::Grounded(_), _) | (_, Atom::Grounded(_)) => false,
         (Atom::Symbol(sym1), Atom::Symbol(sym2)) => {
-            type1 == type2 || sym1.name() == "Undefined" || sym2.name() == "Undefined"
+            type1 == type2 || sym1.name() == "%Undefined%" || sym2.name() == "%Undefined%"
         },
         (Atom::Variable(var), typ) | (typ, Atom::Variable(var)) => {
             bindings.check_and_insert_binding(var, typ)
@@ -162,7 +162,7 @@ pub fn match_reducted_types(type1: &Atom, type2: &Atom, bindings: &mut Bindings)
         },
         (Atom::Expression(_), Atom::Symbol(sym))
             | (Atom::Symbol(sym), Atom::Expression(_))
-            if sym.name() == "Undefined" => true,
+            if sym.name() == "%Undefined%" => true,
         _ => false,
     };
     log::trace!("match_reducted_types: type1: {}, type2: {}, bindings: {} return {}", type1, type2, bindings, result);
@@ -182,7 +182,7 @@ fn get_matched_types(space: &GroundingSpace, atom: &Atom, typ: &Atom) -> Vec<(At
 }
 
 pub fn check_type(space: &GroundingSpace, atom: &Atom, typ: &AtomType) -> bool {
-    let undefined = Atom::sym("Undefined");
+    let undefined = Atom::sym("%Undefined%");
     let typ = match typ {
         AtomType::Undefined => &undefined,
         AtomType::Specific(atom) => atom,

--- a/lib/src/metta/types.rs
+++ b/lib/src/metta/types.rs
@@ -393,6 +393,7 @@ mod tests {
         assert!(check_type(&space, &atom("(Human Socrates)"), t));
         assert!(check_type(&space, &atom("(Human Plato)"), t));
         assert!(!check_type(&space, &atom("(Human Time)"), t));
+        assert!(!validate_atom(&space, &atom("(Human Time)")));
         assert!(!check_type(&space, &atom("(Human Time)"), &AtomType::Specific(atom("((-> Entity Prop) NotEntity)"))));
         assert!(check_type(&space, &atom("(= Socrates Socrates)"), t));
         assert!(check_type(&space, &atom("(= Socrates Plato)"), t));

--- a/lib/src/metta/types.rs
+++ b/lib/src/metta/types.rs
@@ -157,7 +157,7 @@ pub fn match_reducted_types(type1: &Atom, type2: &Atom, bindings: &mut Bindings)
         (Atom::Expression(expr1), Atom::Expression(expr2)) => {
             std::iter::zip(expr1.children().iter(), expr2.children().iter())
                 .map(|(child1, child2)| match_reducted_types(child1, child2, bindings))
-                .reduce(|a, b| a || b)
+                .reduce(|a, b| a && b)
                 .unwrap_or(true)
         },
         (Atom::Expression(_), Atom::Symbol(sym))
@@ -404,7 +404,7 @@ mod tests {
         assert!(!validate_atom(&space, &atom("(HumansAreMortal (Human Socrates))")));
         assert!(!validate_atom(&space, &atom("(HumansAreMortal (Human Plato))")));
         assert!(!validate_atom(&space, &atom("(HumansAreMortal (Human Time))")));
-        //assert!(!validate_atom(&space, &atom("(HumansAreMortal Human)")));
+        assert!(!validate_atom(&space, &atom("(HumansAreMortal Human)")));
         assert!(!check_type(&space, &atom("(HumansAreMortal (Human Socrates))"),
                            &AtomType::Specific(atom("(Mortal Socrates)"))));
         assert!(check_type(&space, &atom("(HumansAreMortal SocratesIsHuman)"),

--- a/lib/src/metta/types.rs
+++ b/lib/src/metta/types.rs
@@ -430,4 +430,16 @@ mod tests {
 
         assert!(validate_atom(&space, &atom("(a b)")));
     }
+
+    #[test]
+    fn check_type_non_functional_expression() {
+        init_logger();
+        let space = metta_space("
+            (: a (-> C D))
+            (: a A)
+            (: b B)
+        ");
+
+        assert!(check_type(&space, &atom("(a b)"), &AtomType::Specific(atom("(A B)"))));
+    }
 }

--- a/python/tests/common.py
+++ b/python/tests/common.py
@@ -1,5 +1,4 @@
 from hyperon import *
-import itertools
 
 def interpret_until_result(target, kb):
     return interpret(kb, target)
@@ -222,7 +221,7 @@ class Atomese:
         return list(self._parse_all(program))
 
     def parse_single(self, program):
-        return next(itertools.islice(self._parse_all(program), 1))
+        return next(self._parse_all(program))
 
     def parse(self, program, kb=None):
         if not kb:


### PR DESCRIPTION
Rewrote type checking procedure to support dependent types. As a side effect all tuples are always validated because they always have the product type. There is a question should we explicitly forbid this and require types like `(Pair ...)` for representing tuples or allow validating any tuple. I also have small questions on some `asserts` in tests on dependent types, but it is simpler to check one by one. 