### PR TITLE
Refactor grounded atom

### DIFF
--- a/c/src/atom.rs
+++ b/c/src/atom.rs
@@ -65,7 +65,17 @@ pub unsafe extern "C" fn atom_var(name: *const c_char) -> *mut atom_t {
 
 #[no_mangle]
 pub extern "C" fn atom_gnd(gnd: *mut gnd_t) -> *mut atom_t {
-    atom_to_ptr(Atom::gnd(CGroundedAtom(AtomicPtr::new(gnd))))
+    unsafe {
+        if let Some(func) = (*(*gnd).api).execute {
+            let ctx = AtomicPtr::new(gnd);
+            atom_to_ptr(Atom::Grounded(
+                    GroundedAtom::new_function(CGroundedValue(AtomicPtr::new(gnd)),
+                        move |args| execute(&ctx, func, args))
+            ))
+        } else {
+            atom_to_ptr(Atom::value(CGroundedValue(AtomicPtr::new(gnd))))
+        }
+    }
 }
 
 #[no_mangle]
@@ -98,7 +108,7 @@ pub unsafe extern "C" fn atom_get_name(atom: *const atom_t, callback: c_str_call
 #[no_mangle]
 pub unsafe extern "C" fn atom_get_object(atom: *const atom_t) -> *mut gnd_t {
     if let Atom::Grounded(ref g) = (*atom).atom {
-        match (*g).downcast_ref::<CGroundedAtom>() {
+        match (*g).downcast_ref::<CGroundedValue>() {
             Some(g) => g.get_mut_ptr(),
             None => panic!("Returning non C grounded objects is not implemented yet!"),
         }
@@ -196,9 +206,9 @@ pub fn return_atoms(atoms: &Vec<Atom>, callback: atoms_callback_t, data: *mut c_
 
 // C grounded atom wrapper
 
-struct CGroundedAtom(AtomicPtr<gnd_t>);
+struct CGroundedValue(AtomicPtr<gnd_t>);
 
-impl CGroundedAtom {
+impl CGroundedValue {
 
     fn get_mut_ptr(&self) -> *mut gnd_t {
         self.0.load(Ordering::Acquire)
@@ -214,30 +224,12 @@ impl CGroundedAtom {
         }
     }
 
-    unsafe fn execute(&self, args: &mut Vec<Atom>) -> Result<Vec<Atom>, String> {
-        let execute = self.api().execute;
-        match execute {
-            Some(execute) => {
-                let mut ret = Vec::new();
-                let res = execute(self.get_ptr(),
-                    (args as *mut Vec<Atom>).cast::<vec_atom_t>(),
-                    (&mut ret as *mut Vec<Atom>).cast::<vec_atom_t>());
-                if res.is_null() {
-                    Ok(ret)
-                } else {
-                    Err(cstr_as_str(res).to_string())
-                }
-            },
-            None => Err(format!("{:?} is not executable", self)),
-        }
-    }
-
     fn eq(&self, other: &Self) -> bool {
         (self.api().eq)(self.get_ptr(), other.get_ptr())
     }
 
     fn clone(&self) -> Self {
-        CGroundedAtom(AtomicPtr::new((self.api().clone)(self.get_ptr())))
+        CGroundedValue(AtomicPtr::new((self.api().clone)(self.get_ptr())))
     }
 
     unsafe fn display(&self) -> String {
@@ -252,28 +244,34 @@ impl CGroundedAtom {
 
 }
 
-impl GroundedAtom for CGroundedAtom {
-
-    fn execute(&self, args: &mut Vec<Atom>) -> Result<Vec<Atom>, String> {
-        unsafe {
-            self.execute(args)
-        }
+unsafe fn execute(gnd: &AtomicPtr<gnd_t>, execute: extern "C" fn(*const gnd_t, *mut vec_atom_t, *mut vec_atom_t) -> *const c_char, args: &mut Vec<Atom>) -> Result<Vec<Atom>, String> {
+    let mut ret = Vec::new();
+    let gnd = gnd.load(Ordering::Acquire);
+    let res = execute(gnd, (args as *mut Vec<Atom>).cast::<vec_atom_t>(),
+    (&mut ret as *mut Vec<Atom>).cast::<vec_atom_t>());
+    if res.is_null() {
+        Ok(ret)
+    } else {
+        Err(cstr_as_str(res).to_string())
     }
+}
 
-    fn eq_gnd(&self, other: &dyn GroundedAtom) -> bool {
-        match other.downcast_ref::<CGroundedAtom>() {
+impl GroundedValue for CGroundedValue {
+
+    fn eq_gnd(&self, other: &dyn GroundedValue) -> bool {
+        match other.downcast_ref::<CGroundedValue>() {
             Some(o) => self.eq(o),
             None => false,
         }
     }
 
-    fn clone_gnd(&self) -> Box<dyn GroundedAtom> {
+    fn clone_gnd(&self) -> Box<dyn GroundedValue> {
         Box::new(self.clone())
     }
 
 }
 
-impl Debug for CGroundedAtom {
+impl Debug for CGroundedValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         unsafe {
             write!(f, "{}", self.display())
@@ -281,7 +279,7 @@ impl Debug for CGroundedAtom {
     }
 }
 
-impl Drop for CGroundedAtom {
+impl Drop for CGroundedValue {
     fn drop(&mut self) {
         self.free();
     }

--- a/c/src/atom.rs
+++ b/c/src/atom.rs
@@ -293,7 +293,14 @@ impl CGroundedFunction {
 }
 
 impl GroundedFunction for CGroundedFunction {
-    fn clone_gnd(&self) -> Box<dyn GroundedFunction> {
+    fn eq_trait(&self, other: &dyn GroundedFunction) -> bool {
+        match other.downcast_ref::<CGroundedFunction>() {
+            Some(other) => self.api().execute == other.api().execute,
+            _ => false,
+        }
+    }
+
+    fn clone_trait(&self) -> Box<dyn GroundedFunction> {
         Box::new(self.clone())
     }
 

--- a/lib/src/atom/matcher.rs
+++ b/lib/src/atom/matcher.rs
@@ -136,7 +136,7 @@ impl WithMatch for Atom {
     fn do_match(&self, other: &Atom) -> MatchResultIter {
         match (self, other) {
             (Atom::Symbol(a), Atom::Symbol(b)) if a == b => Box::new(std::iter::once(MatchResult::new())),
-            (Atom::Grounded(a), Atom::Grounded(_)) => a.match_gnd(other),
+            (Atom::Grounded(a), Atom::Grounded(_)) => a.do_match(other),
             (Atom::Variable(_), Atom::Variable(v)) => {
                 // We stick to prioritize pattern bindings in this case
                 // because otherwise the $X in (= (...) $X) will not be matched with
@@ -175,7 +175,7 @@ pub fn product_iter(prev: MatchResultIter, next: MatchResultIter) -> MatchResult
 fn match_atoms_recursively(candidate: &Atom, pattern: &Atom, res: &mut MatchResult) -> bool {
     match (candidate, pattern) {
         (Atom::Symbol(a), Atom::Symbol(b)) => a == b,
-        (Atom::Grounded(a), Atom::Grounded(b)) => a.eq_gnd(&**b),
+        (Atom::Grounded(a), Atom::Grounded(b)) => a == b,
         (Atom::Variable(_), Atom::Variable(v)) => {
             // We stick to prioritize pattern bindings in this case
             // because otherwise the $X in (= (...) $X) will not be matched with
@@ -247,7 +247,7 @@ impl UnifyResult {
 fn unify_atoms_recursively(candidate: &Atom, pattern: &Atom, res: &mut UnifyResult, depth: u32) -> bool {
     match (candidate, pattern) {
         (Atom::Symbol(a), Atom::Symbol(b)) => a == b,
-        (Atom::Grounded(a), Atom::Grounded(b)) => a.eq_gnd(&**b),
+        (Atom::Grounded(a), Atom::Grounded(b)) => a == b,
         (Atom::Variable(_), Atom::Variable(v)) => {
             // We stick to prioritize pattern bindings in this case
             // because otherwise the $X in (= (...) $X) will not be matched with
@@ -296,7 +296,7 @@ pub fn unify_atoms(candidate: &Atom, pattern: &Atom) -> Option<UnifyResult> {
 
 pub fn apply_bindings_to_atom(atom: &Atom, bindings: &Bindings) -> Atom {
     match atom {
-        Atom::Symbol(_)|Atom::Grounded(_)|Atom::Value(_)|Atom::Function(_) => atom.clone(),
+        Atom::Symbol(_)|Atom::Grounded(_) => atom.clone(),
         Atom::Variable(v) => {
             if let Some(binding) = bindings.get(v) {
                 binding.clone()

--- a/lib/src/atom/matcher.rs
+++ b/lib/src/atom/matcher.rs
@@ -296,7 +296,7 @@ pub fn unify_atoms(candidate: &Atom, pattern: &Atom) -> Option<UnifyResult> {
 
 pub fn apply_bindings_to_atom(atom: &Atom, bindings: &Bindings) -> Atom {
     match atom {
-        Atom::Symbol(_)|Atom::Grounded(_) => atom.clone(),
+        Atom::Symbol(_)|Atom::Grounded(_)|Atom::Value(_)|Atom::Function(_) => atom.clone(),
         Atom::Variable(v) => {
             if let Some(binding) = bindings.get(v) {
                 binding.clone()

--- a/lib/src/common/arithmetics.rs
+++ b/lib/src/common/arithmetics.rs
@@ -34,24 +34,24 @@ pub static IS_INT: &Operation = &Operation{ name: "int", execute: |args| check_t
 
 fn check_type(args: &mut Vec<Atom>, op: fn(&Atom) -> bool) -> Result<Vec<Atom>, String> {
     let arg = args.get(0).ok_or_else(|| format!("Unary operation called without arguments"))?; 
-    Ok(vec![Atom::gnd(op(arg))])
+    Ok(vec![Atom::value(op(arg))])
 }
 
 fn is_instance<T>(arg: &Atom) -> bool
 where
-    T: GroundedAtom,
+    T: GroundedValue,
 {
     matches!(arg.as_gnd::<T>(), Some(_))
 }
 
 fn unary_op<T, R>(args: &mut Vec<Atom>, op: fn(T) -> R) -> Result<Vec<Atom>, String>
 where
-    T: GroundedAtom + Copy,
-    R: GroundedAtom,
+    T: GroundedValue + Copy,
+    R: GroundedValue,
 {
     let arg = args.get(0).ok_or_else(|| format!("Unary operation called without arguments"))?; 
     if let Some(arg) = arg.as_gnd::<T>() {
-        Ok(vec![Atom::gnd(op(*arg))])
+        Ok(vec![Atom::value(op(*arg))])
     } else {
         Err(format!("Incorrect type of the unary operation argument: ({})", arg))
     }
@@ -59,14 +59,14 @@ where
 
 fn bin_op<T1, T2, R>(args: &mut Vec<Atom>, op: fn(T1, T2) -> R) -> Result<Vec<Atom>, String>
 where
-    T1: GroundedAtom + Copy,
-    T2: GroundedAtom + Copy,
-    R: GroundedAtom,
+    T1: GroundedValue + Copy,
+    T2: GroundedValue + Copy,
+    R: GroundedValue,
 {
     let arg1 = args.get(0).ok_or_else(|| format!("Binary operation called without arguments"))?; 
     let arg2 = args.get(1).ok_or_else(|| format!("Binary operation called with only argument"))?;
     if let (Some(arg1), Some(arg2)) = (arg1.as_gnd::<T1>(), arg2.as_gnd::<T2>()) {
-        Ok(vec![Atom::gnd(op(*arg1, *arg2))])
+        Ok(vec![Atom::value(op(*arg1, *arg2))])
     } else {
         Err(format!("Incorrect type of the binary operation argument: ({}, {})", arg1, arg2))
     }
@@ -82,7 +82,7 @@ mod tests {
     use crate::space::grounding::GroundingSpace;
 
     // Aliases to have a shorter notation
-    fn G<T: GroundedAtom>(value: T) -> Atom { Atom::gnd(value) }
+    fn G<T: GroundedValue>(value: T) -> Atom { Atom::value(value) }
 
     fn init_logger() {
         let _ = env_logger::builder().is_test(true).try_init();

--- a/lib/src/common/mod.rs
+++ b/lib/src/common/mod.rs
@@ -12,24 +12,18 @@ use std::fmt::Debug;
 // The instance has 'static lifetime and not copied when cloned.
 pub struct Operation {
     pub name: &'static str,
-    pub execute: ExecuteFunc,
+    pub execute: ExecuteFn,
 }
 
-pub type ExecuteFunc = fn(&mut Vec<Atom>) -> Result<Vec<Atom>, String>;
-
-impl GroundedAtom for &'static Operation {
-    fn execute(&self, args: &mut Vec<Atom>) -> Result<Vec<Atom>, String> {
-        (self.execute)(args)
-    }
-
-    fn eq_gnd(&self, other: &dyn GroundedAtom) -> bool {
+impl GroundedValue for &'static Operation {
+    fn eq_gnd(&self, other: &dyn GroundedValue) -> bool {
         match other.downcast_ref::<&Operation>() {
             Some(o) => self.name.eq(o.name),
             None => false,
         }
     }
 
-    fn clone_gnd(&self) -> Box<dyn GroundedAtom> {
+    fn clone_gnd(&self) -> Box<dyn GroundedValue> {
         Box::new(*self)
     }
 }
@@ -37,6 +31,12 @@ impl GroundedAtom for &'static Operation {
 impl Debug for &'static Operation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.name)
+    }
+}
+
+impl From<&'static Operation> for Atom {
+    fn from(op: &'static Operation) -> Self {
+        Atom::Grounded(GroundedAtom::new_function(op, op.execute))
     }
 }
 
@@ -79,25 +79,25 @@ mod tests {
     #[test]
     fn test_operation_display() {
         let op = &Operation{ name: "test", execute: test };
-        assert_eq!(format!("{}", Atom::gnd(op)), "test");
+        assert_eq!(format!("{}", Atom::from(op)), "test");
     }
 
     #[test]
     fn test_operation_eq() {
-        let a = Atom::gnd(&Operation{ name: "a", execute: test });
-        let aa = Atom::gnd(&Operation{ name: "a", execute: test });
-        let b = Atom::gnd(&Operation{ name: "b", execute: test });
+        let a = Atom::from(&Operation{ name: "a", execute: test });
+        let aa = Atom::from(&Operation{ name: "a", execute: test });
+        let b = Atom::from(&Operation{ name: "b", execute: test });
         assert!(a == aa);
         assert!(a != b);
     }
 
     #[test]
     fn test_operation_clone() {
-        let opa = Atom::gnd(&Operation{ name: "a", execute: test });
+        let opa = Atom::from(&Operation{ name: "a", execute: test });
         let opc = opa.clone();
         if let (Atom::Grounded(boxa), Atom::Grounded(boxc)) = (opa, opc) {
-            let ptra: *const Operation = *(boxa.downcast::<&Operation>().unwrap());
-            let ptrc: *const Operation = *(boxc.downcast::<&Operation>().unwrap());
+            let ptra: *const Operation = *(boxa.downcast_ref::<&Operation>().unwrap());
+            let ptrc: *const Operation = *(boxc.downcast_ref::<&Operation>().unwrap());
             assert_eq!(ptra, ptrc);
         } else {
             assert!(false);

--- a/lib/src/common/mod.rs
+++ b/lib/src/common/mod.rs
@@ -12,7 +12,7 @@ use std::fmt::Debug;
 // The instance has 'static lifetime and not copied when cloned.
 pub struct Operation {
     pub name: &'static str,
-    pub execute: ExecuteFn,
+    pub execute: fn(&mut Vec<Atom>) -> Result<Vec<Atom>, String>,
 }
 
 impl GroundedValue for &'static Operation {

--- a/lib/src/metta/text.rs
+++ b/lib/src/metta/text.rs
@@ -187,7 +187,7 @@ mod tests {
     fn test_text_recognize_full_token() {
         let mut text = SExprSpace::new();
         text.register_token(Regex::new(r"b").unwrap(),
-            |_| Atom::gnd("b"));
+            |_| Atom::value("b"));
 
         text.add_str("ab").unwrap();
         let space = GroundingSpace::from(&text);
@@ -199,12 +199,12 @@ mod tests {
     fn test_text_gnd() {
         let mut text = SExprSpace::new();
         text.register_token(Regex::new(r"\d+").unwrap(),
-            |token| Atom::gnd(token.parse::<i32>().unwrap()));
+            |token| Atom::value(token.parse::<i32>().unwrap()));
 
         text.add_str("(3d 42)").unwrap();
         let space = GroundingSpace::from(&text);
 
-        assert_eq!(vec![Atom::expr(&[Atom::sym("3d"), Atom::gnd(42)])],
+        assert_eq!(vec![Atom::expr(&[Atom::sym("3d"), Atom::value(42)])],
             *space.borrow_vec());
     }
 

--- a/lib/src/metta/types.rs
+++ b/lib/src/metta/types.rs
@@ -98,7 +98,7 @@ fn get_args(expr: &ExpressionAtom) -> &[Atom] {
 fn get_reducted_types(space: &GroundingSpace, atom: &Atom) -> Vec<Atom> {
     log::trace!("get_reducted_types: atom: {}", atom);
     let types = match atom {
-        Atom::Variable(_) | Atom::Grounded(_) | Atom::Value(_) | Atom::Function(_) => vec![Atom::sym("%Undefined%")],
+        Atom::Variable(_) | Atom::Grounded(_) => vec![Atom::sym("%Undefined%")],
         Atom::Symbol(_) => {
             let types = query_types(space, atom);
             if !types.is_empty() {

--- a/lib/src/metta/types.rs
+++ b/lib/src/metta/types.rs
@@ -98,7 +98,7 @@ fn get_args(expr: &ExpressionAtom) -> &[Atom] {
 fn get_reducted_types(space: &GroundingSpace, atom: &Atom) -> Vec<Atom> {
     log::trace!("get_reducted_types: atom: {}", atom);
     let types = match atom {
-        Atom::Variable(_) | Atom::Grounded(_) => vec![Atom::sym("%Undefined%")],
+        Atom::Variable(_) | Atom::Grounded(_) | Atom::Value(_) | Atom::Function(_) => vec![Atom::sym("%Undefined%")],
         Atom::Symbol(_) => {
             let types = query_types(space, atom);
             if !types.is_empty() {


### PR DESCRIPTION
Split grounded function and grounded value. I kept them in the same atom for now to not change API significally, but internally implementation has three different constructors for now:
- grounded value;
- grounded value with match;
- grounded function.
From this moment splitting GroundedFunction and GroundedValue is a trivial task but it requires API rework and Python rework so I am raising this PR as an intermediate step.