### PR TITLE
Add C and Python API to interpret expressions step by step

### DIFF
--- a/c/src/metta.rs
+++ b/c/src/metta.rs
@@ -1,5 +1,8 @@
 use hyperon::metta::text::*;
 use hyperon::metta::types::AtomType;
+use hyperon::metta::interpreter;
+use hyperon::metta::interpreter::InterpreterResult;
+use hyperon::common::plan::StepResult;
 
 use crate::util::*;
 use crate::atom::*;
@@ -146,4 +149,55 @@ pub unsafe extern "C" fn check_type(space: *const grounding_space_t, atom: *cons
 #[no_mangle]
 pub unsafe extern "C" fn validate_atom(space: *const grounding_space_t, atom: *const atom_t) -> bool {
     hyperon::metta::types::validate_atom(&(*space).space, &(*atom).atom)
+}
+
+// MeTTa interpreter API
+
+#[no_mangle]
+pub extern "C" fn interpret(space: *mut grounding_space_t, expr: *const atom_t,
+        callback: atoms_callback_t, data: *mut c_void) {
+    let res = unsafe { hyperon::metta::interpreter::interpret((*space).space.clone(), &(*expr).atom) };
+    match res {
+        Ok(vec) => return_atoms(&vec, callback, data),
+        Err(_) => return_atoms(&vec![], callback, data),
+    }
+}
+
+#[allow(non_camel_case_types)]
+pub struct step_result_t {
+    result: StepResult<InterpreterResult>,
+}
+
+#[no_mangle]
+pub extern "C" fn interpret_init(space: *mut grounding_space_t, expr: *const atom_t) -> *mut step_result_t {
+    let step = unsafe { interpreter::interpret_init((*space).space.clone(), &(*expr).atom) };
+    Box::into_raw(Box::new(step_result_t{ result: step }))
+}
+
+#[no_mangle]
+pub extern "C" fn interpret_step(step: *mut step_result_t) -> *mut step_result_t {
+    let step = unsafe { Box::from_raw(step) };
+    let next = interpreter::interpret_step(step.result);
+    Box::into_raw(Box::new(step_result_t{ result: next }))
+}
+
+#[no_mangle]
+pub extern "C" fn interpret_has_next(step: *const step_result_t) -> bool {
+    match unsafe{ &(*step).result } {
+        StepResult::Execute(_) => true,
+        StepResult::Return(_) => false,
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn interpret_return(step: *mut step_result_t,
+        callback: atoms_callback_t, data: *mut c_void) {
+    let step = unsafe{ Box::from_raw(step) };
+    if let StepResult::Return(result) = step.result {
+        let res = result.map(|mut res| res.drain(0..).map(|(atom, _)| atom).collect());
+        match res {
+            Ok(vec) => return_atoms(&vec, callback, data),
+            Err(_) => return_atoms(&vec![], callback, data),
+        }
+    }
 }

--- a/c/src/space.rs
+++ b/c/src/space.rs
@@ -94,14 +94,4 @@ pub extern "C" fn grounding_space_subst(space: *const grounding_space_t,
     return_atoms(&results, callback, data);
 }
 
-#[no_mangle]
-pub extern "C" fn interpret(space: *mut grounding_space_t, expr: *const atom_t,
-        callback: atoms_callback_t, data: *mut c_void) {
-    let res = unsafe { hyperon::metta::interpreter::interpret((*space).space.clone(), &(*expr).atom) };
-    match res {
-        Ok(vec) => return_atoms(&vec, callback, data),
-        Err(_) => return_atoms(&vec![], callback, data),
-    }
-}
-
 

--- a/lib/src/common/plan.rs
+++ b/lib/src/common/plan.rs
@@ -20,6 +20,20 @@ impl<R> StepResult<R> {
     pub fn ret(result: R) -> Self {
         Self::Return(result)
     }
+
+    pub fn has_next(&self) -> bool {
+        match self {
+            StepResult::Execute(_) => true,
+            StepResult::Return(_) => false,
+        }
+    }
+
+    pub fn get_result(self) -> R {
+        match self {
+            StepResult::Execute(_) => panic!("Plan is not finished yet"),
+            StepResult::Return(result) => result,
+        }
+    }
 }
 
 /// Plan which gets a value of T type as an input and returns a result of

--- a/lib/src/common/plan.rs
+++ b/lib/src/common/plan.rs
@@ -46,18 +46,6 @@ pub trait Plan<T, R> : Debug {
     fn step(self: Box<Self>, arg: T) -> StepResult<R>;
 }
 
-/// Execute the plan using given input value and return result
-pub fn execute_plan<T: Debug, R, P>(plan: P, arg: T) -> R where P: 'static + Plan<T, R> {
-    let mut step: Box<dyn Plan<(), R>>  = Box::new(ApplyPlan::new(plan, arg));
-    loop {
-        log::debug!("current plan:\n{:?}", step);
-        match step.step(()) {
-            StepResult::Execute(next) => step = next,
-            StepResult::Return(result) => return result,
-        }
-    }
-}
-
 // Specific plans to form calculations graph
 
 /// StepResult itself is a trivial plan which returns itself when executed
@@ -304,6 +292,18 @@ impl<I, T, R> FoldIntoParallelPlan<I, T, R> for I
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Execute the plan using given input value and return result
+    pub fn execute_plan<T: Debug, R, P>(plan: P, arg: T) -> R where P: 'static + Plan<T, R> {
+        let mut step: Box<dyn Plan<(), R>>  = Box::new(ApplyPlan::new(plan, arg));
+        loop {
+            log::debug!("current plan:\n{:?}", step);
+            match step.step(()) {
+                StepResult::Execute(next) => step = next,
+                StepResult::Return(result) => return result,
+            }
+        }
+    }
 
     #[test]
     fn parallel_plan() {

--- a/lib/src/metta/interpreter.rs
+++ b/lib/src/metta/interpreter.rs
@@ -55,20 +55,17 @@ pub fn interpret_init(space: GroundingSpace, expr: &Atom) -> StepResult<Interpre
 
 pub fn interpret_step(step: StepResult<InterpreterResult>) -> StepResult<InterpreterResult> {
     match step {
-        StepResult::Execute(step) => step.step(()),
+        StepResult::Execute(plan) => plan.step(()),
         StepResult::Return(_) => panic!("Plan execution is finished already"),
     }
 }
 
 pub fn interpret(space: GroundingSpace, expr: &Atom) -> Result<Vec<Atom>, String> {
-    let mut next = interpret_init(space, expr);
-    loop {
-        match next {
-            StepResult::Execute(step) => next = step.step(()),
-            StepResult::Return(result) => return result
-                .map(|mut res| res.drain(0..).map(|(atom, _)| atom).collect()),
-        }
+    let mut step = interpret_init(space, expr);
+    while step.has_next() {
+        step = interpret_step(step);
     }
+    step.get_result().map(|mut res| res.drain(0..).map(|(atom, _)| atom).collect())
 }
 
 fn is_grounded(expr: &ExpressionAtom) -> bool {

--- a/python/hyperon/__init__.py
+++ b/python/hyperon/__init__.py
@@ -220,8 +220,11 @@ class SExprSpace:
         hp.sexpr_space_into_grounding_space(self.cspace, gspace.cspace)
 
 def interpret(gnd_space, expr):
+    step = hp.interpret_init(gnd_space.cspace, expr.catom)
+    while (hp.interpret_has_next(step)):
+        step = hp.interpret_step(step)
     return [Atom._from_catom(catom) for catom in
-            hp.interpret(gnd_space.cspace, expr.catom)]
+            hp.interpret_return(step)]
 
 class AtomType:
 

--- a/python/hyperon/__init__.py
+++ b/python/hyperon/__init__.py
@@ -221,10 +221,10 @@ class SExprSpace:
 
 def interpret(gnd_space, expr):
     step = hp.interpret_init(gnd_space.cspace, expr.catom)
-    while (hp.interpret_has_next(step)):
+    while (hp.step_has_next(step)):
         step = hp.interpret_step(step)
     return [Atom._from_catom(catom) for catom in
-            hp.interpret_return(step)]
+            hp.step_get_result(step)]
 
 class AtomType:
 

--- a/python/hyperonpy.cpp
+++ b/python/hyperonpy.cpp
@@ -18,6 +18,7 @@ using CGroundingSpace = CPtr<grounding_space_t>;
 using CTokenizer = CPtr<tokenizer_t>;
 using CSExprSpace = CPtr<sexpr_space_t>;
 using CAtomType = CPtr<const atom_type_t>;
+using CStepResult = CPtr<step_result_t>;
 
 void copy_to_string(char const* cstr, void* context) {
 	std::string* cppstr = static_cast<std::string*>(context);
@@ -272,6 +273,21 @@ PYBIND11_MODULE(hyperonpy, m) {
 			interpret(space.ptr, expr.ptr, &copy_atoms_to_list, &results);
 			return results;
 		}, "Run interpreter on expression and return result");
+	py::class_<CStepResult>(m, "CStepResult");
+	m.def("interpret_init", [](CGroundingSpace space, CAtom expr) {
+			return CStepResult(interpret_init(space.ptr, expr.ptr));
+		}, "Initialize interpreter of the expression");
+	m.def("interpret_step", [](CStepResult step) {
+			return CStepResult(interpret_step(step.ptr));
+		}, "Do next step of the interpretataion");
+	m.def("interpret_has_next", [](CStepResult step) {
+			return interpret_has_next(step.ptr);
+		}, "Check whether next step of interpretation is posible");
+	m.def("interpret_return", [](CStepResult step) {
+			py::list results;
+			interpret_return(step.ptr, &copy_atoms_to_list, &results);
+			return results;
+		}, "Return result of the interpretation");
 
 	py::class_<CAtomType>(m, "CAtomType")
 		.def_property_readonly_static("UNDEFINED", [](py::object) { return CAtomType(ATOM_TYPE_UNDEFINED); }, "Undefined type instance");

--- a/python/hyperonpy.cpp
+++ b/python/hyperonpy.cpp
@@ -280,12 +280,12 @@ PYBIND11_MODULE(hyperonpy, m) {
 	m.def("interpret_step", [](CStepResult step) {
 			return CStepResult(interpret_step(step.ptr));
 		}, "Do next step of the interpretataion");
-	m.def("interpret_has_next", [](CStepResult step) {
-			return interpret_has_next(step.ptr);
+	m.def("step_has_next", [](CStepResult step) {
+			return step_has_next(step.ptr);
 		}, "Check whether next step of interpretation is posible");
-	m.def("interpret_return", [](CStepResult step) {
+	m.def("step_get_result", [](CStepResult step) {
 			py::list results;
-			interpret_return(step.ptr, &copy_atoms_to_list, &results);
+			step_get_result(step.ptr, &copy_atoms_to_list, &results);
 			return results;
 		}, "Return result of the interpretation");
 


### PR DESCRIPTION
Add C to interpret expressions step by step.
What is not done:
- no API to print and explore intermediate step
- no Python friendly functions to use C API