### PR TITLE
Simplify interpreter, remove non-clear steps from plan

### DIFF
--- a/c/src/metta.rs
+++ b/c/src/metta.rs
@@ -183,12 +183,13 @@ pub extern "C" fn step_has_next(step: *const step_result_t) -> bool {
 pub extern "C" fn step_get_result(step: *mut step_result_t,
         callback: c_atoms_callback_t, context: *mut c_void) {
     let step = unsafe{ Box::from_raw(step) };
-    let result = step.result.get_result();
-    assert!(result.is_ok());
-    let res = result.unwrap().map(|mut res| res.drain(0..).map(|(atom, _)| atom).collect());
-    match res {
-        Ok(vec) => return_atoms(&vec, callback, context),
-        Err(_) => return_atoms(&vec![], callback, context),
+    match step.result {
+        StepResult::Return(mut res) => {
+            let res = res.drain(0..).map(|(atom, _)| atom).collect();
+            return_atoms(&res, callback, context);
+        },
+        StepResult::Error(_) => return_atoms(&vec![], callback, context),
+        _ => panic!("Not expected step result: {:?}", step.result),
     }
 }
 

--- a/c/src/metta.rs
+++ b/c/src/metta.rs
@@ -183,7 +183,9 @@ pub extern "C" fn step_has_next(step: *const step_result_t) -> bool {
 pub extern "C" fn step_get_result(step: *mut step_result_t,
         callback: c_atoms_callback_t, context: *mut c_void) {
     let step = unsafe{ Box::from_raw(step) };
-    let res = step.result.get_result().map(|mut res| res.drain(0..).map(|(atom, _)| atom).collect());
+    let result = step.result.get_result();
+    assert!(result.is_ok());
+    let res = result.unwrap().map(|mut res| res.drain(0..).map(|(atom, _)| atom).collect());
     match res {
         Ok(vec) => return_atoms(&vec, callback, context),
         Err(_) => return_atoms(&vec![], callback, context),

--- a/lib/src/common/arithmetics.rs
+++ b/lib/src/common/arithmetics.rs
@@ -25,7 +25,7 @@ def_op!(NOT, !, |args| unary_op(args, |a: bool| !a));
 def_op!(NOP, nop, |_| Ok(vec![]));
 def_op!(ERR, err, |_| Err("Error".into()));
 
-pub static IS_INT: &Operation = &Operation{ name: "int", execute: |args| check_type(args,
+pub static IS_INT: &Operation = &Operation{ name: "is_int", execute: |args| check_type(args,
     // TODO: it is ugly, but I cannot do something more clear without downcasting
     |a| is_instance::<i32>(a) || is_instance::<u32>(a)
     || is_instance::<i64>(a) || is_instance::<u64>(a)

--- a/lib/src/metta/interpreter.rs
+++ b/lib/src/metta/interpreter.rs
@@ -9,7 +9,6 @@ static MATCH_OP: FunctionPlan<(GroundingSpace, Atom, Bindings), InterpreterResul
 static EXECUTE_OP: FunctionPlan<(Atom, Bindings), InterpreterResult> = FunctionPlan{ func: execute_op, name: "execute_op" };
 static INTERPRET_RESULTS_FURTHER_OP: FunctionPlan<(GroundingSpace, InterpreterResult), InterpreterResult> = FunctionPlan{ func: interpret_results_further_op, name: "interpret_results_further_op" };
 
-static REDUCT_ARGS_OP: FunctionPlan<(GroundingSpace, Atom, Bindings), InterpreterResult> = FunctionPlan{ func: reduct_args_op, name: "reduct_args_op" };
 static REDUCT_NEXT_ARG_OP: FunctionPlan<((GroundingSpace, SubexprStream), InterpreterResult), InterpreterResult> = FunctionPlan{ func: reduct_next_arg_op, name: "reduct_next_arg_op" };
 static TRY_REDUCT_NEXT_ARG_OP: FunctionPlan<(GroundingSpace, SubexprStream, Bindings), InterpreterResult> = FunctionPlan{ func: try_reduct_next_arg_op, name: "try_reduct_next_arg_op" };
 static REPLACE_ARG_AND_INTERPRET_OP: FunctionPlan<((GroundingSpace, SubexprStream), InterpreterResult), InterpreterResult> = FunctionPlan{ func: replace_arg_and_interpret_op, name: "replace_arg_and_interpret_op" };
@@ -68,7 +67,7 @@ fn interpret_expression_plan(space: GroundingSpace, atom: Atom, bindings: Bindin
         Atom::Expression(ref expr) if expr.is_plain() => 
             interpret_reducted_plan(space,  atom, bindings),
         Atom::Expression(ref expr) if is_grounded(expr) => 
-            StepResult::execute(ApplyPlan::new(REDUCT_ARGS_OP, (space,  atom, bindings))),
+            reduct_args_plan(space, atom, bindings),
         Atom::Expression(_) => {
             StepResult::execute(SequencePlan::new(
                     OrPlan::new(
@@ -169,8 +168,8 @@ fn find_next_sibling_skip_last<'a>(levels: &mut Vec<usize>, expr: &'a Expression
 }
 
 
-fn reduct_args_op((space, expr, bindings): (GroundingSpace, Atom, Bindings)) -> StepResult<InterpreterResult> {
-    log::debug!("reduct_args_op: {}", expr);
+fn reduct_args_plan(space: GroundingSpace, expr: Atom, bindings: Bindings) -> StepResult<InterpreterResult> {
+    log::debug!("reduct_args_plan: {}", expr);
     if let Atom::Expression(ref e) = expr {
         // TODO: remove this hack when it is possible to use types in order
         // to prevent reducing of the last argument of the match

--- a/lib/src/metta/interpreter.rs
+++ b/lib/src/metta/interpreter.rs
@@ -57,6 +57,7 @@ pub fn interpret_step(step: StepResult<InterpreterResult>) -> StepResult<Interpr
     match step {
         StepResult::Execute(plan) => plan.step(()),
         StepResult::Return(_) => panic!("Plan execution is finished already"),
+        StepResult::Error(_) => panic!("Plan execution is finished with error"),
     }
 }
 
@@ -66,7 +67,10 @@ pub fn interpret(space: GroundingSpace, expr: &Atom) -> Result<Vec<Atom>, String
         log::debug!("current plan:\n{:?}", step);
         step = interpret_step(step);
     }
-    step.get_result().map(|mut res| res.drain(0..).map(|(atom, _)| atom).collect())
+    match step.get_result() {
+        Ok(result) => result.map(|mut res| res.drain(0..).map(|(atom, _)| atom).collect()),
+        Err(message) => Err(message),
+    }
 }
 
 fn is_grounded(expr: &ExpressionAtom) -> bool {

--- a/python/tests/test_atom.py
+++ b/python/tests/test_atom.py
@@ -115,7 +115,7 @@ class AtomTest(unittest.TestCase):
         space = GroundingSpace()
         interpreter = Interpreter(space, E(x2Atom, ValueAtom(1)))
         self.assertEqual(str(interpreter.get_step_result()),
-                "interpret_or_default_op((GroundingSpace, (*2 1), {}))")
+                "interpret_op((GroundingSpace, (*2 1), {}))")
 
 # No unwrap
 def x2_op(atom):


### PR DESCRIPTION
Error state is added to the API of the plan library. New plan to select non error alternative is added. Interpreter code is reworked to keep only necessary steps and remove all steps which doesn't make sense from plan execution perspective. Interpreter code now is more compact and clear.

Next step: work on text plan representation to make plans more human readable.