### PR TITLE
Make plans more readable

### DIFF
--- a/lib/src/atom/subexpr.rs
+++ b/lib/src/atom/subexpr.rs
@@ -139,7 +139,6 @@ impl SubexprStream {
 
     fn fmt_rec(levels: &Vec<usize>, atom: &Atom, level: usize, current: bool, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let emphasize = current && level == levels.len();
-        log::debug!("emphasize: {}, current: {}, level: {}, levels: {:?}", emphasize, current, level, levels);
         let mut res = Ok(());
         res = res.and_then(|_| write!(f, "{}", if emphasize { ">" } else { "" }));
         res = match atom {
@@ -150,7 +149,6 @@ impl SubexprStream {
                         res = res.and_then(|_| write!(f, " "));
                     }
                     let current = current && level < levels.len() && levels[level] == i + 1;
-                    log::debug!("child: emphasize: {}, current: {}, level: {}, levels.len(): {}, i: {}", emphasize, current, level, levels.len(), i);
                     res = res.and_then(|_| Self::fmt_rec(levels, child, level + 1, current, f));
                 }
                 res.and_then(|_| write!(f, ")"))

--- a/lib/src/common/plan.rs
+++ b/lib/src/common/plan.rs
@@ -76,7 +76,7 @@ impl<R: Debug> Plan<(), R> for StepResult<R> {
 impl<R: Debug> Debug for StepResult<R> {  
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
         match self {
-            Self::Execute(plan) => write!(f, "execute {:?}", plan),
+            Self::Execute(plan) => write!(f, "{:?}", plan),
             Self::Return(result) => write!(f, "return {:?}", result),
             Self::Error(message) => write!(f, "error {:?}", message),
         }
@@ -216,12 +216,12 @@ impl<T1: 'static, T2: 'static + Debug, R: 'static> Plan<T1, R> for SequencePlan<
 
 impl<T1, T2, R> Debug for SequencePlan<T1, T2, R> {  
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
-        write!(f, "{:?}, {:?}", self.first, self.second)
+        write!(f, "{:?} then {:?}", self.first, self.second)
     }
 }
 
-/// The plan to execute two underlying plans and return the pair formed from
-/// their their results.
+/// The plan to execute two underlying plans and return a pair formed from
+/// their results.
 pub struct ParallelPlan<T1, T2> {
     first: Box<dyn Plan<(), T1>>,
     second: Box<dyn Plan<(), T2>>,
@@ -231,7 +231,7 @@ impl<T1, T2> ParallelPlan<T1, T2> {
     pub fn new<P1, P2>(first: P1, second: P2) -> Self
         where P1: 'static + Plan<(), T1>,
               P2: 'static + Plan<(), T2> {
-        ParallelPlan{
+        Self{
             first: Box::new(first),
             second: Box::new(second)
         }

--- a/lib/src/common/plan.rs
+++ b/lib/src/common/plan.rs
@@ -76,9 +76,9 @@ impl<R: Debug> Plan<(), R> for StepResult<R> {
 impl<R: Debug> Debug for StepResult<R> {  
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
         match self {
-            Self::Execute(plan) => write!(f, "{:?}", plan),
-            Self::Return(result) => write!(f, "{:?}", result),
-            Self::Error(message) => write!(f, "{:?}", message),
+            Self::Execute(plan) => write!(f, "execute {:?}", plan),
+            Self::Return(result) => write!(f, "return {:?}", result),
+            Self::Error(message) => write!(f, "error {:?}", message),
         }
     }
 }
@@ -216,7 +216,7 @@ impl<T1: 'static, T2: 'static + Debug, R: 'static> Plan<T1, R> for SequencePlan<
 
 impl<T1, T2, R> Debug for SequencePlan<T1, T2, R> {  
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
-        write!(f, "{:?} -> {:?}", self.first, self.second)
+        write!(f, "{:?}, {:?}", self.first, self.second)
     }
 }
 
@@ -372,7 +372,7 @@ impl<R: 'static> Plan<(), R> for OrPlan<R> {
 
 impl<R> Debug for OrPlan<R> {  
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
-        write!(f, "({:?} or {:?})", self.first, self.second)
+        write!(f, "{:?} (or {:?})", self.first, self.second)
     }
 }
 

--- a/lib/src/common/plan.rs
+++ b/lib/src/common/plan.rs
@@ -372,7 +372,7 @@ impl<R: 'static> Plan<(), R> for OrPlan<R> {
 
 impl<R> Debug for OrPlan<R> {  
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
-        write!(f, "{:?} or {:?}", self.first, self.second)
+        write!(f, "({:?} or {:?})", self.first, self.second)
     }
 }
 

--- a/lib/src/metta/interpreter.rs
+++ b/lib/src/metta/interpreter.rs
@@ -11,6 +11,7 @@ pub fn interpret_init(space: GroundingSpace, expr: &Atom) -> StepResult<Interpre
 }
 
 pub fn interpret_step(step: StepResult<InterpreterResult>) -> StepResult<InterpreterResult> {
+    log::debug!("current plan:\n{:?}", step);
     match step {
         StepResult::Execute(plan) => plan.step(()),
         StepResult::Return(_) => panic!("Plan execution is finished already"),
@@ -21,7 +22,6 @@ pub fn interpret_step(step: StepResult<InterpreterResult>) -> StepResult<Interpr
 pub fn interpret(space: GroundingSpace, expr: &Atom) -> Result<Vec<Atom>, String> {
     let mut step = interpret_init(space, expr);
     while step.has_next() {
-        log::debug!("current plan:\n{:?}", step);
         step = interpret_step(step);
     }
     match step {

--- a/lib/src/metta/interpreter.rs
+++ b/lib/src/metta/interpreter.rs
@@ -67,7 +67,7 @@ fn interpret_expression_plan(space: GroundingSpace, atom: Atom, bindings: Bindin
         Atom::Expression(_) => {
             Box::new(OrPlan::new(
                     match_plan(space.clone(), atom.clone(), bindings.clone()),
-                    reduct_arg_by_arg_plan((space, atom, bindings))
+                    reduct_arg_by_arg_plan(space, atom, bindings)
             ))
         }
         _ => panic!("Only expression is expected, received: {}", atom),
@@ -87,8 +87,13 @@ fn interpret_reducted_plan(space: GroundingSpace, atom: Atom, bindings: Bindings
     }
 }
 
-fn reduct_arg_by_arg_plan((space, expr, bindings): (GroundingSpace, Atom, Bindings)) -> StepResult<InterpreterResult> {
-    log::debug!("reduct_arg_by_arg_plan: {}", expr);
+fn reduct_arg_by_arg_plan(space: GroundingSpace, expr: Atom, bindings: Bindings) -> OperatorPlan<(), InterpreterResult> {
+    let descr = format!("reduct expression arg by arg {}", expr);
+    OperatorPlan::new(|_| reduct_arg_by_arg_op(space, expr, bindings), descr)
+}
+
+fn reduct_arg_by_arg_op(space: GroundingSpace, expr: Atom, bindings: Bindings) -> StepResult<InterpreterResult> {
+    log::debug!("reduct_arg_by_arg_op: {}", expr);
     if let Atom::Expression(_) = expr {
         let iter = SubexprStream::from_expr(expr, BOTTOM_UP_DEPTH_WALK);
         try_reduct_next_arg_op(space, iter, bindings)

--- a/python/tests/test_atom.py
+++ b/python/tests/test_atom.py
@@ -115,7 +115,7 @@ class AtomTest(unittest.TestCase):
         space = GroundingSpace()
         interpreter = Interpreter(space, E(x2Atom, ValueAtom(1)))
         self.assertEqual(str(interpreter.get_step_result()),
-                "interpret (*2 1)")
+                "execute interpret (*2 1)")
 
 # No unwrap
 def x2_op(atom):

--- a/python/tests/test_atom.py
+++ b/python/tests/test_atom.py
@@ -115,7 +115,7 @@ class AtomTest(unittest.TestCase):
         space = GroundingSpace()
         interpreter = Interpreter(space, E(x2Atom, ValueAtom(1)))
         self.assertEqual(str(interpreter.get_step_result()),
-                "interpret_op((GroundingSpace, (*2 1), {}))")
+                "interpret (*2 1)")
 
 # No unwrap
 def x2_op(atom):

--- a/python/tests/test_atom.py
+++ b/python/tests/test_atom.py
@@ -115,7 +115,7 @@ class AtomTest(unittest.TestCase):
         space = GroundingSpace()
         interpreter = Interpreter(space, E(x2Atom, ValueAtom(1)))
         self.assertEqual(str(interpreter.get_step_result()),
-                "execute interpret (*2 1)")
+                "interpret (*2 1)")
 
 # No unwrap
 def x2_op(atom):


### PR DESCRIPTION
Make additional plans to improve text representation of the plan.
Example of the complex plan after refactoring:
```
    interpret alternatives for (:? (= SocratesIsMortal (HumansAreMortal SocratesIsHuman))):
      > interpret alternatives for (:= (= (:? SocratesIsMortal) (:? (HumansAreMortal SocratesIsHuman))) $t):
          > interpret alternatives for (:? (HumansAreMortal SocratesIsHuman)):
              > match (HumansAreMortal SocratesIsHuman) then interpret after reduction of (:= >(HumansAreMortal SocratesIsHuman)< $t) (or try reducting next arg in (:= >(HumansAreMortal SocratesIsHuman)< $t)) (or return [((:= (HumansAreMortal SocratesIsHuman) $t), {})]) then reduct next arg in (match &self >(:= (HumansAreMortal SocratesIsHuman) $t)< $t) (or return [((match &self (:= (HumansAreMortal SocratesIsHuman) $t) $t), {})])
              - interpret (match &self (:= (HumansAreMortal (:? SocratesIsHuman)) $t) $t)
             then interpret after reduction of (:= (= (Mortal Socrates) >(:? (HumansAreMortal SocratesIsHuman))<) $t) (or try reducting next arg in (:= (= (Mortal Socrates) >(:? (HumansAreMortal SocratesIsHuman))<) $t)) (or return [((:= (= (Mortal Socrates) (:? (HumansAreMortal SocratesIsHuman))) $t), {})])
         (or try reducting next arg in (:= (= >(:? SocratesIsMortal)< (:? (HumansAreMortal SocratesIsHuman))) $t)) (or return [((:= (= (:? SocratesIsMortal) (:? (HumansAreMortal SocratesIsHuman))) $t), {})]) then reduct next arg in (match &self >(:= (= (:? SocratesIsMortal) (:? (HumansAreMortal SocratesIsHuman))) $t)< $t) (or return [((match &self (:= (= (:? SocratesIsMortal) (:? (HumansAreMortal SocratesIsHuman))) $t) $t), {})])
     (or reduct expression arg by arg (:? (= SocratesIsMortal (HumansAreMortal SocratesIsHuman)))) (or return [((:? (= SocratesIsMortal (HumansAreMortal SocratesIsHuman))), {})])

```