### PR TITLE
Add interpreter cache

### DIFF
--- a/lib/src/common/collections.rs
+++ b/lib/src/common/collections.rs
@@ -1,0 +1,28 @@
+#[derive(Clone)]
+pub struct ListMap<K, V> {
+    list: Vec<(K, V)>,
+}
+
+impl<K: PartialEq, V> ListMap<K, V> {
+    pub fn new() -> Self {
+        Self{ list: vec![] }
+    }
+
+    pub fn get(&self, key: &K) -> Option<&V> {
+        for (k, v) in &self.list {
+            if *k == *key {
+                return Some(&v)
+            }
+        }
+        None
+    }
+
+    pub fn insert(&mut self, key: K, value: V) {
+        self.list.push((key, value))
+    }
+
+    pub fn clear(&mut self) {
+        self.list.clear()
+    }
+}
+

--- a/lib/src/common/mod.rs
+++ b/lib/src/common/mod.rs
@@ -1,4 +1,5 @@
 pub mod plan;
+pub mod collections;
 mod arithmetics;
 
 pub use arithmetics::*;

--- a/lib/src/metta/interpreter.rs
+++ b/lib/src/metta/interpreter.rs
@@ -37,6 +37,8 @@ pub fn interpret(space: GroundingSpace, expr: &Atom) -> Result<Vec<Atom>, String
     }
 }
 
+// TODO: ListMap is not effective but we cannot use HashMap here without
+// requiring hash functions for the grounded atoms.
 struct InterpreterCache(ListMap<Atom, InterpreterResult>);
 
 impl InterpreterCache {

--- a/lib/src/metta/interpreter.rs
+++ b/lib/src/metta/interpreter.rs
@@ -3,31 +3,16 @@ use crate::common::plan::*;
 use crate::atom::subexpr::*;
 use crate::atom::matcher::*;
 use crate::space::grounding::*;
+use crate::common::collections::ListMap;
 
+use std::ops::Deref;
 use std::rc::Rc;
-use std::cell::{RefCell, Ref};
-
-#[derive(Clone)]
-struct InterpreterContext(Rc<RefCell<InterpreterContextInternal>>);
-
-struct InterpreterContextInternal {
-    space: GroundingSpace,
-}
-
-impl InterpreterContext {
-    fn new(space: GroundingSpace) -> Self {
-        Self(Rc::new(RefCell::new(InterpreterContextInternal{ space })))
-    }
-
-    fn borrow(&self) -> Ref<'_, InterpreterContextInternal> {
-        self.0.borrow()
-    }
-}
+use std::cell::RefCell;
 
 pub type InterpreterResult = Vec<(Atom, Bindings)>;
 
 pub fn interpret_init(space: GroundingSpace, expr: &Atom) -> StepResult<InterpreterResult> {
-    let context = InterpreterContext::new(space);
+    let context = InterpreterContextRef::new(space);
     StepResult::execute(interpret_plan(context, expr.clone(), Bindings::new()))
 }
 
@@ -52,6 +37,71 @@ pub fn interpret(space: GroundingSpace, expr: &Atom) -> Result<Vec<Atom>, String
     }
 }
 
+struct InterpreterCache(ListMap<Atom, InterpreterResult>);
+
+impl InterpreterCache {
+    fn new() -> Self {
+        Self(ListMap::new())
+    }
+
+    fn get(&self, key: &Atom, current_bindings: &Bindings) -> Option<InterpreterResult> {
+        self.0.get(key).map(|res| -> Option<InterpreterResult> {
+                let mut inconsistent = Vec::new();
+                let mut result = Vec::new();
+                for (atom, bindings) in res {
+                    let merged = Bindings::merge(&bindings, &current_bindings);
+                    if let Some(merged) = merged {
+                        result.push((atom.clone(), merged));
+                    } else {
+                        inconsistent.push((atom, bindings));
+                    }
+                }
+                if inconsistent.is_empty() {
+                    Some(result)
+                } else {
+                    log::debug!("get_cached: return None as some results has inconsistent bindings");
+                    log::debug!("get_cached: current bindings: {}, inconsistent results: {:?}", current_bindings, inconsistent);
+                    None
+                }
+            }).flatten()
+    }
+
+    fn insert(&mut self, key: Atom, value: InterpreterResult) {
+        self.0.insert(key, value)
+    }
+}
+
+impl SpaceObserver for InterpreterCache {
+    fn notify(&mut self, _event: &SpaceEvent) {
+        // TODO: implement more specific cache cleanup for each event
+        self.0.clear();
+    }
+}
+
+struct InterpreterContext {
+    space: GroundingSpace,
+    cache: Rc<RefCell<InterpreterCache>>,
+}
+
+#[derive(Clone)]
+struct InterpreterContextRef(Rc<InterpreterContext>);
+
+impl InterpreterContextRef {
+    fn new(mut space: GroundingSpace) -> Self {
+        let cache = Rc::new(RefCell::new(InterpreterCache::new()));
+        space.register_observer(Rc::clone(&cache));
+        Self(Rc::new(InterpreterContext{ space, cache }))
+    }
+}
+
+impl Deref for InterpreterContextRef {
+    type Target = InterpreterContext;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 fn is_grounded(expr: &ExpressionAtom) -> bool {
     matches!(expr.children().get(0), Some(Atom::Grounded(_)))
 }
@@ -64,25 +114,46 @@ fn format_bindings(bindings: &Bindings) -> String {
     }
 }
 
-fn interpret_plan(context: InterpreterContext, atom: Atom, bindings: Bindings) -> OperatorPlan<(), InterpreterResult> {
+fn interpret_plan(context: InterpreterContextRef, atom: Atom, bindings: Bindings) -> OperatorPlan<(), InterpreterResult> {
     let descr = format!("interpret {}{}", atom, format_bindings(&bindings));
     OperatorPlan::new(|_| interpret_op(context, atom, bindings), descr)
 }
 
-fn interpret_op(context: InterpreterContext, atom: Atom, bindings: Bindings) -> StepResult<InterpreterResult> {
+fn interpret_op(context: InterpreterContextRef, atom: Atom, bindings: Bindings) -> StepResult<InterpreterResult> {
     log::debug!("interpret_op: {}, {}", atom, bindings);
     let atom = apply_bindings_to_atom(&atom, &bindings);
-    if let Atom::Expression(_) = atom {
-        StepResult::execute(OrPlan::new(
-                interpret_expression_plan(context, atom.clone(), bindings.clone()),
-                StepResult::ret(vec![(atom, bindings)]),
-        ))
+    let input = (atom, bindings);
+
+    let cached = context.cache.borrow().get(&input.0, &input.1);
+    if let Some(result) = cached {
+        return_cached_result_plan(result)
     } else {
-        StepResult::ret(vec![(atom, bindings)])
+        if let Atom::Expression(_) = input.0 {
+            StepResult::execute(SequencePlan::new(
+                OrPlan::new(interpret_expression_plan(context.clone(), input.clone()),
+                    StepResult::ret(vec![input.clone()])),
+                save_result_in_cache_plan(context, input.0)
+            ))
+        } else {
+            StepResult::ret(vec![input])
+        }
     }
 }
 
-fn interpret_expression_plan(context: InterpreterContext, atom: Atom, bindings: Bindings) -> Box<dyn Plan<(), InterpreterResult>> {
+fn return_cached_result_plan(result: InterpreterResult) -> StepResult<InterpreterResult> {
+    let descr = format!("return cached result {:?}", result);
+    StepResult::execute(OperatorPlan::new(|_| StepResult::ret(result), descr))
+}
+
+fn save_result_in_cache_plan(context: InterpreterContextRef, key: Atom) -> OperatorPlan<InterpreterResult, InterpreterResult> {
+    let descr = format!("save result in cache for key {}", key);
+    OperatorPlan::new(move |result: InterpreterResult| {
+        context.cache.borrow_mut().insert(key, result.clone());
+        StepResult::ret(result)
+    }, descr)
+}
+
+fn interpret_expression_plan(context: InterpreterContextRef, (atom, bindings): (Atom, Bindings)) -> Box<dyn Plan<(), InterpreterResult>> {
     match atom {
         Atom::Expression(ref expr) if expr.is_plain() => 
             interpret_reducted_plan(context,  atom, bindings),
@@ -98,7 +169,7 @@ fn interpret_expression_plan(context: InterpreterContext, atom: Atom, bindings: 
     }
 }
 
-fn interpret_reducted_plan(context: InterpreterContext, atom: Atom, bindings: Bindings) -> Box<dyn Plan<(), InterpreterResult>> {
+fn interpret_reducted_plan(context: InterpreterContextRef, atom: Atom, bindings: Bindings) -> Box<dyn Plan<(), InterpreterResult>> {
     let atom = apply_bindings_to_atom(&atom, &bindings);
     if let Atom::Expression(ref expr) = atom {
         if is_grounded(expr) {
@@ -111,12 +182,12 @@ fn interpret_reducted_plan(context: InterpreterContext, atom: Atom, bindings: Bi
     }
 }
 
-fn reduct_arg_by_arg_plan(context: InterpreterContext, expr: Atom, bindings: Bindings) -> OperatorPlan<(), InterpreterResult> {
+fn reduct_arg_by_arg_plan(context: InterpreterContextRef, expr: Atom, bindings: Bindings) -> OperatorPlan<(), InterpreterResult> {
     let descr = format!("reduct expression arg by arg {}", expr);
     OperatorPlan::new(|_| reduct_arg_by_arg_op(context, expr, bindings), descr)
 }
 
-fn reduct_arg_by_arg_op(context: InterpreterContext, expr: Atom, bindings: Bindings) -> StepResult<InterpreterResult> {
+fn reduct_arg_by_arg_op(context: InterpreterContextRef, expr: Atom, bindings: Bindings) -> StepResult<InterpreterResult> {
     log::debug!("reduct_arg_by_arg_op: {}", expr);
     if let Atom::Expression(_) = expr {
         let iter = SubexprStream::from_expr(expr, BOTTOM_UP_DEPTH_WALK);
@@ -126,12 +197,12 @@ fn reduct_arg_by_arg_op(context: InterpreterContext, expr: Atom, bindings: Bindi
     }
 }
 
-fn try_reduct_next_arg_plan(context: InterpreterContext, iter: SubexprStream, bindings: Bindings) -> OperatorPlan<(), InterpreterResult> {
+fn try_reduct_next_arg_plan(context: InterpreterContextRef, iter: SubexprStream, bindings: Bindings) -> OperatorPlan<(), InterpreterResult> {
     let descr = format!("try reducting next arg in {:?}", iter);
     OperatorPlan::new(|_| try_reduct_next_arg_op(context, iter, bindings), descr)
 }
 
-fn try_reduct_next_arg_op(context: InterpreterContext, mut iter: SubexprStream, bindings: Bindings) -> StepResult<InterpreterResult> {
+fn try_reduct_next_arg_op(context: InterpreterContextRef, mut iter: SubexprStream, bindings: Bindings) -> StepResult<InterpreterResult> {
     if let Some(arg) = iter.next().cloned() {
         StepResult::execute(OrPlan::new(
                 SequencePlan::new(
@@ -144,12 +215,12 @@ fn try_reduct_next_arg_op(context: InterpreterContext, mut iter: SubexprStream, 
     }
 }
 
-fn replace_arg_and_interpret_plan(context: InterpreterContext, iter: SubexprStream) -> OperatorPlan<InterpreterResult, InterpreterResult> {
+fn replace_arg_and_interpret_plan(context: InterpreterContextRef, iter: SubexprStream) -> OperatorPlan<InterpreterResult, InterpreterResult> {
     let descr = format!("interpret after reduction of {:?}", iter);
     OperatorPlan::new(|reduction_result| replace_arg_and_interpret_op(context, iter, reduction_result), descr)
 }
 
-fn replace_arg_and_interpret_op(context: InterpreterContext, iter: SubexprStream, mut reduction_result: InterpreterResult) -> StepResult<InterpreterResult> {
+fn replace_arg_and_interpret_op(context: InterpreterContextRef, iter: SubexprStream, mut reduction_result: InterpreterResult) -> StepResult<InterpreterResult> {
     log::debug!("replace_arg_and_interpret_op: reduction_result: {:?}", reduction_result);
     if reduction_result.is_empty() {
         //panic!("Unexpected empty result while reducting: {}, it should be either error or non-empty, full expression: {}", iter.get(), iter.as_atom());
@@ -185,7 +256,7 @@ fn find_next_sibling_skip_last<'a>(levels: &mut Vec<usize>, expr: &'a Expression
 }
 
 
-fn reduct_args_plan(context: InterpreterContext, expr: Atom, bindings: Bindings) -> Box<dyn Plan<(), InterpreterResult>> {
+fn reduct_args_plan(context: InterpreterContextRef, expr: Atom, bindings: Bindings) -> Box<dyn Plan<(), InterpreterResult>> {
     log::debug!("reduct_args_plan: {}", expr);
     if let Atom::Expression(ref e) = expr {
         // TODO: remove this hack when it is possible to use types in order
@@ -206,12 +277,12 @@ fn reduct_args_plan(context: InterpreterContext, expr: Atom, bindings: Bindings)
     }
 }
 
-fn reduct_next_arg_plan(context: InterpreterContext, iter: SubexprStream) -> OperatorPlan<InterpreterResult, InterpreterResult> {
+fn reduct_next_arg_plan(context: InterpreterContextRef, iter: SubexprStream) -> OperatorPlan<InterpreterResult, InterpreterResult> {
     let descr = format!("reduct next arg in {:?}", iter);
     OperatorPlan::new(|prev_result| reduct_next_arg_op(context, iter, prev_result), descr)
 }
 
-fn reduct_next_arg_op(context: InterpreterContext, iter: SubexprStream, mut prev_result: InterpreterResult) -> StepResult<InterpreterResult> {
+fn reduct_next_arg_op(context: InterpreterContextRef, iter: SubexprStream, mut prev_result: InterpreterResult) -> StepResult<InterpreterResult> {
     let plan = prev_result.drain(0..)
         .map(|(reducted, bindings)| {
             let mut iter = iter.clone();
@@ -240,12 +311,12 @@ fn reduct_next_arg_op(context: InterpreterContext, iter: SubexprStream, mut prev
     StepResult::execute(AlternativeInterpretationsPlan::new(iter.into_atom().clone(), plan))
 }
 
-fn execute_plan(context: InterpreterContext, atom: Atom, bindings: Bindings) -> OperatorPlan<(), InterpreterResult> {
+fn execute_plan(context: InterpreterContextRef, atom: Atom, bindings: Bindings) -> OperatorPlan<(), InterpreterResult> {
     let descr = format!("execute {}", atom);
     OperatorPlan::new(|_| execute_op(context, atom, bindings), descr)
 }
 
-fn execute_op(context: InterpreterContext, atom: Atom, bindings: Bindings) -> StepResult<InterpreterResult> {
+fn execute_op(context: InterpreterContextRef, atom: Atom, bindings: Bindings) -> StepResult<InterpreterResult> {
     log::debug!("execute_op: {}", atom);
     if let Atom::Expression(mut expr) = atom.clone() {
         let op = expr.children().get(0).cloned();
@@ -266,17 +337,17 @@ fn execute_op(context: InterpreterContext, atom: Atom, bindings: Bindings) -> St
     }
 }
 
-fn match_plan(context: InterpreterContext, expr: Atom, bindings: Bindings) -> OperatorPlan<(), InterpreterResult> {
+fn match_plan(context: InterpreterContextRef, expr: Atom, bindings: Bindings) -> OperatorPlan<(), InterpreterResult> {
     let descr = format!("match {}{}", expr, format_bindings(&bindings));
     OperatorPlan::new(|_| match_op(context, expr, bindings), descr)
 }
 
-fn match_op(context: InterpreterContext, expr: Atom, prev_bindings: Bindings) -> StepResult<InterpreterResult> {
+fn match_op(context: InterpreterContextRef, expr: Atom, prev_bindings: Bindings) -> StepResult<InterpreterResult> {
     log::debug!("match_op: {}", expr);
     let var_x = VariableAtom::from("X");
     // TODO: unique variable?
     let atom_x = Atom::Variable(var_x.clone());
-    let mut local_bindings = context.borrow().space.query(&Atom::expr(&[Atom::sym("="), expr.clone(), atom_x]));
+    let mut local_bindings = context.space.query(&Atom::expr(&[Atom::sym("="), expr.clone(), atom_x]));
     let results: Vec<(Atom, Bindings)> = local_bindings
         .drain(0..)
         .map(|mut binding| {
@@ -300,7 +371,7 @@ fn match_op(context: InterpreterContext, expr: Atom, prev_bindings: Bindings) ->
     }
 }
 
-fn interpret_results_plan(context: InterpreterContext, atom: Atom, mut result: InterpreterResult) -> Box<dyn Plan<(), InterpreterResult>> {
+fn interpret_results_plan(context: InterpreterContextRef, atom: Atom, mut result: InterpreterResult) -> Box<dyn Plan<(), InterpreterResult>> {
     match result.len() {
         0 => Box::new(StepResult::ret(result)),
         1 => {

--- a/lib/src/space/grounding.rs
+++ b/lib/src/space/grounding.rs
@@ -367,4 +367,18 @@ mod test {
         assert_eq!(result, vec![bind!{h: expr!("Socrates"), t: expr!("Nil")}]);
     }
 
+    #[test]
+    fn cleanup_observer() {
+        let mut space = GroundingSpace::new();
+        {
+            let observer = Rc::new(RefCell::new(SpaceEventCollector::new()));
+            space.register_observer(Rc::clone(&observer));
+            assert_eq!(space.observers.borrow().len(), 1);
+        }
+
+        space.add(expr!("a"));
+
+        assert_eq!(*space.borrow_vec(), vec![expr!("a")]);
+        assert_eq!(space.observers.borrow().len(), 0);
+    }
 }

--- a/lib/src/space/grounding.rs
+++ b/lib/src/space/grounding.rs
@@ -4,25 +4,61 @@ use crate::atom::matcher::{Bindings, Unifications, WithMatch};
 use crate::atom::subexpr::split_expr;
 
 use std::fmt::{Display, Debug};
-use std::rc::Rc;
+use std::rc::{Rc, Weak};
 use std::cell::{RefCell, Ref};
 
 // Grounding space
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum SpaceEvent {
+    Add(Atom),
+    Remove(Atom),
+    Replace(Atom, Atom),
+}
+
+pub trait SpaceObserver {
+    fn notify(&mut self, event: &SpaceEvent);
+}
 
 // TODO: Clone is required by C API
 #[derive(Clone)]
 pub struct GroundingSpace {
     content: Rc<RefCell<Vec<Atom>>>,
+    observers: Rc<RefCell<Vec<Weak<RefCell<dyn SpaceObserver>>>>>,
 }
 
 impl GroundingSpace {
 
     pub fn new() -> Self {
-        Self{ content: Rc::new(RefCell::new(Vec::new())) }
+        Self{
+            content: Rc::new(RefCell::new(Vec::new())),
+            observers: Rc::new(RefCell::new(Vec::new())),
+        }
     }
-    
+
+    pub fn register_observer<T>(&mut self, observer: Rc<RefCell<T>>)
+        where T: SpaceObserver + 'static
+    {
+        self.observers.borrow_mut().push(Rc::downgrade(&observer) as Weak<RefCell<dyn SpaceObserver>>);
+    }
+
+    fn notify(&self, event: &SpaceEvent) {
+        let mut cleanup = false;
+        for observer in self.observers.borrow_mut().iter() {
+            if let Some(observer) = observer.upgrade() {
+                observer.borrow_mut().notify(event);
+            } else {
+                cleanup = true;
+            }
+        }
+        if cleanup {
+            self.observers.borrow_mut().retain(|w| w.strong_count() > 0);
+        }
+    }
+
     pub fn add(&mut self, atom: Atom) {
-        self.content.borrow_mut().push(atom)
+        self.content.borrow_mut().push(atom.clone());
+        self.notify(&SpaceEvent::Add(atom));
     }
 
     pub fn remove(&mut self, atom: &Atom) -> bool {
@@ -30,6 +66,7 @@ impl GroundingSpace {
         match position {
             Some(position) => {
                 self.content.borrow_mut().remove(position);
+                self.notify(&SpaceEvent::Remove(atom.clone()));
                 true
             },
             None => false, 
@@ -40,7 +77,8 @@ impl GroundingSpace {
         let position = self.borrow_vec().iter().position(|other| other == from);
         match position {
             Some(position) => {
-                self.content.borrow_mut().as_mut_slice()[position] = to;
+                self.content.borrow_mut().as_mut_slice()[position] = to.clone();
+                self.notify(&SpaceEvent::Replace(from.clone(), to));
                 true
             },
             None => false, 
@@ -54,8 +92,7 @@ impl GroundingSpace {
                     |acc, pattern| {
                         if acc.is_empty() {
                             acc
-                        } else {
-                            let res = self.query(pattern);
+                        } else { let res = self.query(pattern);
                             Bindings::product(acc, res)
                         }
                     })
@@ -145,49 +182,95 @@ impl Display for GroundingSpace {
 mod test {
     use super::*;
 
+    struct SpaceEventCollector {
+        events: Vec<SpaceEvent>,
+    }
+
+    impl SpaceEventCollector {
+        fn new() -> Self {
+            Self{ events: Vec::new() }
+        }
+    }
+
+    impl SpaceObserver for SpaceEventCollector {
+        fn notify(&mut self, event: &SpaceEvent) {
+            self.events.push(event.clone());
+        }
+    }
+
     #[test]
     fn add_atom() {
         let mut space = GroundingSpace::new();
+        let observer = Rc::new(RefCell::new(SpaceEventCollector::new()));
+        space.register_observer(Rc::clone(&observer));
+
         space.add(expr!("a"));
         space.add(expr!("b"));
         space.add(expr!("c"));
+
         assert_eq!(*space.borrow_vec(), vec![expr!("a"), expr!("b"), expr!("c")]);
+        assert_eq!(observer.borrow().events, vec![SpaceEvent::Add(Atom::sym("a")),
+            SpaceEvent::Add(Atom::sym("b")), SpaceEvent::Add(Atom::sym("c"))]);
     }
 
     #[test]
     fn remove_atom() {
         let mut space = GroundingSpace::new();
+        let observer = Rc::new(RefCell::new(SpaceEventCollector::new()));
+        space.register_observer(Rc::clone(&observer));
+
         space.add(expr!("a"));
         space.add(expr!("b"));
         space.add(expr!("c"));
         assert_eq!(space.remove(&expr!("b")), true);
+
         assert_eq!(*space.borrow_vec(), vec![expr!("a"), expr!("c")]);
+        assert_eq!(observer.borrow().events, vec![SpaceEvent::Add(Atom::sym("a")),
+            SpaceEvent::Add(Atom::sym("b")), SpaceEvent::Add(Atom::sym("c")),
+            SpaceEvent::Remove(Atom::sym("b"))]);
     }
 
     #[test]
     fn remove_atom_not_found() {
         let mut space = GroundingSpace::new();
+        let observer = Rc::new(RefCell::new(SpaceEventCollector::new()));
+        space.register_observer(Rc::clone(&observer));
+
         space.add(expr!("a"));
         assert_eq!(space.remove(&expr!("b")), false);
+
         assert_eq!(*space.borrow_vec(), vec![expr!("a")]);
+        assert_eq!(observer.borrow().events, vec![SpaceEvent::Add(Atom::sym("a"))]);
     }
 
     #[test]
     fn replace_atom() {
         let mut space = GroundingSpace::new();
+        let observer = Rc::new(RefCell::new(SpaceEventCollector::new()));
+        space.register_observer(Rc::clone(&observer));
+
         space.add(expr!("a"));
         space.add(expr!("b"));
         space.add(expr!("c"));
         assert_eq!(space.replace(&expr!("b"), expr!("d")), true);
+
         assert_eq!(*space.borrow_vec(), vec![expr!("a"), expr!("d"), expr!("c")]);
+        assert_eq!(observer.borrow().events, vec![SpaceEvent::Add(Atom::sym("a")),
+            SpaceEvent::Add(Atom::sym("b")), SpaceEvent::Add(Atom::sym("c")),
+            SpaceEvent::Replace(Atom::sym("b"), Atom::sym("d"))]);
     }
 
     #[test]
     fn replace_atom_not_found() {
         let mut space = GroundingSpace::new();
+        let observer = Rc::new(RefCell::new(SpaceEventCollector::new()));
+        space.register_observer(Rc::clone(&observer));
+
         space.add(expr!("a"));
         assert_eq!(space.replace(&expr!("b"), expr!("d")), false);
+
         assert_eq!(*space.borrow_vec(), vec![expr!("a")]);
+        assert_eq!(observer.borrow().events, vec![SpaceEvent::Add(Atom::sym("a"))]);
     }
 
     #[test]

--- a/lib/src/space/grounding.rs
+++ b/lib/src/space/grounding.rs
@@ -92,7 +92,8 @@ impl GroundingSpace {
                     |acc, pattern| {
                         if acc.is_empty() {
                             acc
-                        } else { let res = self.query(pattern);
+                        } else {
+                            let res = self.query(pattern);
                             Bindings::product(acc, res)
                         }
                     })


### PR DESCRIPTION
Add API to observe `GroundingSpace` state changes. Add `InterpreterContext` to encapsulate common interpreter context like space instance. Add interpreted expression cache into `InterpreterContext`. Keep interpretation result for the non-grounded expression in cache. 