### PR TITLE
Init logger on library load

### DIFF
--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -7,6 +7,6 @@ pub mod metta;
 
 #[no_mangle]
 pub extern "C" fn init_logger() {
-   let _ = env_logger::builder().is_test(true).try_init();
+   hyperon::common::init_logger(false);
 }
 

--- a/c/tests/test.c
+++ b/c/tests/test.c
@@ -18,8 +18,6 @@ static Suite * capi_suite(void (*init_test)(TCase* test_case)) {
 }
 
 int test_main(void (*init_test)(TCase* test_case)) {
-	init_logger();
-
 	int number_failed;
     Suite *s;
     SRunner *sr;

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -10,6 +10,7 @@ regex = "1.5.4"
 log = "0.4.0"
 env_logger = "0.8.4"
 delegate = "0.6.1"
+ctor = "0.1.22"
 
 [lib]
 name = "hyperon"

--- a/lib/src/atom/mod.rs
+++ b/lib/src/atom/mod.rs
@@ -362,10 +362,6 @@ mod test {
     fn V(name: &str) -> Atom { Atom::var(name) }
     fn G<T: GroundedValue>(gnd: T) -> Atom { Atom::value(gnd) }
 
-    fn init_logger() {
-        let _ = env_logger::builder().is_test(true).try_init();
-    }
-
     #[test]
     fn test_expr_symbol() {
         assert_eq!(expr!("="), S("="));
@@ -487,7 +483,6 @@ mod test {
 
     #[test]
     fn test_custom_matching() {
-        init_logger();
         let mut dict = TestDict::new();
         dict.put(expr!("x"), expr!({2}, {5}));
         dict.put(expr!("y"), expr!({5}));

--- a/lib/src/atom/subexpr.rs
+++ b/lib/src/atom/subexpr.rs
@@ -203,10 +203,6 @@ pub fn split_expr(expr: &Atom) -> Option<(&Atom, std::slice::Iter<Atom>)> {
 mod tests {
     use super::*;
 
-    fn init_logger() {
-        let _ = env_logger::builder().is_test(true).try_init();
-    }
-
     #[test]
     fn bottom_up_depth_walk() {
         let expr = expr!("+", ("*", "3", ("+", "1", n)), ("-", "4", "3"));
@@ -263,7 +259,6 @@ mod tests {
 
     #[test]
     fn string_formatting() {
-        init_logger();
         let expr = expr!("+", ("*", "3", ("+", "1", n)), ("-", "4", "3"));
         let mut iter = SubexprStream::from_expr(expr, TOP_DOWN_DEPTH_WALK);
 

--- a/lib/src/common/arithmetics.rs
+++ b/lib/src/common/arithmetics.rs
@@ -84,13 +84,8 @@ mod tests {
     // Aliases to have a shorter notation
     fn G<T: GroundedValue>(value: T) -> Atom { Atom::value(value) }
 
-    fn init_logger() {
-        let _ = env_logger::builder().is_test(true).try_init();
-    }
-
     #[test]
     fn test_sum_ints() {
-        init_logger();
         let space = GroundingSpace::new();
         // (+ 3 5)
         let expr = expr!({SUM}, {3}, {5});
@@ -100,7 +95,6 @@ mod tests {
 
     #[test]
     fn test_sum_ints_recursively() {
-        init_logger();
         let space = GroundingSpace::new();
         // (+ 4 (+ 3 5))
         let expr = expr!({SUM}, {4}, ({SUM}, {3}, {5}));
@@ -110,7 +104,6 @@ mod tests {
 
     #[test]
     fn test_match_factorial() {
-        init_logger();
         let mut space = GroundingSpace::new();
         // (= (fac 0) 1)
         space.add(expr!("=", ("fac", {0}), {1}));
@@ -123,7 +116,6 @@ mod tests {
 
     #[test]
     fn test_factorial() {
-        init_logger();
         let mut space = GroundingSpace::new();
         // NOTE: multiple matches are treated non-deterministically.
         // ATM, we don't have means to describe mutually exclusive ordered lists

--- a/lib/src/common/mod.rs
+++ b/lib/src/common/mod.rs
@@ -7,6 +7,10 @@ use crate::*;
 use std::cell::RefCell;
 use std::fmt::Debug;
 
+pub fn init_logger(is_test: bool) {
+   let _ = env_logger::builder().is_test(is_test).try_init();
+}
+
 // Operation implements stateless operations as GroundedAtom.
 // Each operation has the only instance which is identified by unique name.
 // The instance has 'static lifetime and not copied when cloned.

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -7,3 +7,10 @@ pub mod space;
 pub mod metta;
 
 pub use atom::*;
+
+use ctor::ctor;
+
+#[ctor]
+fn on_load() {
+    common::init_logger(false);
+}

--- a/lib/src/metta/examples/types.rs
+++ b/lib/src/metta/examples/types.rs
@@ -3,14 +3,8 @@ use crate::common::*;
 use crate::metta::interpreter::*;
 use crate::space::grounding::GroundingSpace;
 
-fn init_logger() {
-    let _ = env_logger::builder().is_test(true).try_init();
-}
-
 #[test]
 fn test_types_in_metta() {
-    init_logger();
-
     let mut space = GroundingSpace::new();
     space.add(expr!("=", ("check", (":", n, "Int")), ({IS_INT}, n)));
     space.add(expr!("=", ("check", (":", n, "Nat")), ({AND}, ("check", (":", n, "Int")), ({GT}, n, {0}))));

--- a/lib/src/metta/interpreter.rs
+++ b/lib/src/metta/interpreter.rs
@@ -352,13 +352,8 @@ impl<T> Debug for AlternativeInterpretationsPlan<T> {
 mod tests {
     use super::*;
     
-    fn init_logger() {
-        let _ = env_logger::builder().is_test(true).try_init();
-    }
-
     #[test]
     fn test_match_all() {
-        init_logger();
         let mut space = GroundingSpace::new();
         space.add(expr!("=", ("color"), "blue"));
         space.add(expr!("=", ("color"), "red"));
@@ -371,7 +366,6 @@ mod tests {
 
     #[test]
     fn test_frog_reasoning() {
-        init_logger();
         let mut space = GroundingSpace::new();
         space.add(expr!("=", ("and", "True", "True"), "True"));
         space.add(expr!("=", ("if", "True", then, else), then));
@@ -390,7 +384,6 @@ mod tests {
 
     #[test]
     fn test_variable_keeps_value_in_different_sub_expressions() {
-        init_logger();
         let mut space = GroundingSpace::new();
         space.add(expr!("=", ("eq", x, x), "True"));
         space.add(expr!("=", ("plus", "Z", y), y));

--- a/lib/src/metta/types.rs
+++ b/lib/src/metta/types.rs
@@ -208,10 +208,6 @@ mod tests {
     use crate::metta::metta_space;
     use crate::metta::metta_atom as atom;
     
-    fn init_logger() {
-        let _ = env_logger::builder().is_test(true).try_init();
-    }
-
     fn grammar_space() -> GroundingSpace {
         let mut space = GroundingSpace::new();
         space.add(expr!(":", "answer", ("->", "Sent", "Sent")));
@@ -233,7 +229,6 @@ mod tests {
 
     #[test]
     fn test_check_type() {
-        init_logger();
         let mut space = GroundingSpace::new();
         space.add(expr!(":", "do", "Verb"));
         space.add(expr!(":", "do", "Aux"));
@@ -272,7 +267,6 @@ mod tests {
 
     #[test]
     fn nested_type() {
-        init_logger();
         let space = metta_space("
             (: a A)
             (< A B)
@@ -285,7 +279,6 @@ mod tests {
 
     #[test]
     fn nested_loop_type() {
-        init_logger();
         let space = metta_space("
             (< B A)
             (: a A)
@@ -298,7 +291,6 @@ mod tests {
 
     #[test]
     fn test_validate_atom() {
-        init_logger();
         let space = grammar_space();
         let expr = expr!("answer", ("do", "you", "like", ("a", "pizza")));
 
@@ -313,7 +305,6 @@ mod tests {
 
     #[test]
     fn simple_types() {
-        init_logger();
         let space = metta_space("
             (: blue Color)
             (: balloon Object)
@@ -325,7 +316,6 @@ mod tests {
 
     #[test]
     fn arrow_type() {
-        init_logger();
         let space = metta_space("
             (: a (-> B A))
         ");
@@ -335,7 +325,6 @@ mod tests {
 
     #[test]
     fn arrow_allows_specific_type() {
-        init_logger();
         let space = metta_space("
             (: a (-> B A))
             (: b B)
@@ -348,7 +337,6 @@ mod tests {
 
     #[test]
     fn validate_basic_expr() {
-        init_logger();
         let space = GroundingSpace::new();
         assert!(validate_atom(&space, &expr!({5})));
         assert!(validate_atom(&space, &expr!("+", {3}, {5})));
@@ -357,7 +345,6 @@ mod tests {
 
     #[test]
     fn simple_dep_types() {
-        init_logger();
         let space = metta_space("
             (: = (-> $t $t Prop))
             (: Entity Prop)
@@ -403,7 +390,6 @@ mod tests {
 
     #[test]
     fn dep_types_prop() {
-        init_logger();
         let space = metta_space("
             (: Sam Entity)
             (: Frog (-> Entity Prop))
@@ -420,7 +406,6 @@ mod tests {
 
     #[test]
     fn arrow_allows_undefined_type() {
-        init_logger();
         let space = metta_space("
             (: a (-> B A))
         ");
@@ -430,7 +415,6 @@ mod tests {
 
     #[test]
     fn arrow_has_type_of_returned_value() {
-        init_logger();
         let space = metta_space("
             (: a (-> B A))
             (: b B)
@@ -441,7 +425,6 @@ mod tests {
 
     #[test]
     fn nested_arrow_type() {
-        init_logger();
         let space = metta_space("
             (: a (-> B A))
             (: h (-> (-> B A) C))
@@ -452,7 +435,6 @@ mod tests {
 
     #[test]
     fn nested_return_type() {
-        init_logger();
         let space = metta_space("
             (: a (-> B A))
             (: b B)
@@ -464,7 +446,6 @@ mod tests {
 
     #[test]
     fn validate_non_functional_expression() {
-        init_logger();
         let space = metta_space("
             (: a A)
             (: b B)
@@ -475,7 +456,6 @@ mod tests {
 
     #[test]
     fn check_type_non_functional_expression() {
-        init_logger();
         let space = metta_space("
             (: a (-> C D))
             (: a A)

--- a/python/tests/test_examples.py
+++ b/python/tests/test_examples.py
@@ -500,6 +500,5 @@ class Setter:
         self.var.get_object().value = self.val.get_object().value
 
 
-init_logger()
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/test_minecraft.py
+++ b/python/tests/test_minecraft.py
@@ -116,6 +116,5 @@ class MinecraftTest(unittest.TestCase):
         # (, (get iron-pickaxe) (find diamond-ore)
         #    (do-mine diamond diamond-ore iron-pickaxe))
 
-init_logger()
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/test_minelogy.py
+++ b/python/tests/test_minelogy.py
@@ -209,6 +209,5 @@ class MinelogyTest(unittest.TestCase):
         self.assertEqual(repr(output[0]), '(list ((CEntityT stick) 2) ((CEntityV planks $_) 3))')
 
 
-init_logger()
 if __name__ == "__main__":
     unittest.main()

--- a/python/tests/test_pln_tv.py
+++ b/python/tests/test_pln_tv.py
@@ -85,6 +85,5 @@ class PLNTVTest(unittest.TestCase):
             '''))
 
 
-init_logger()
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
FYI, code does not require manual calling of `init_logger()` anymore. Removed this to make behavior more obvious. `RUST_LOG` environment variable should be used to configure logger behavior.