### PR TITLE
Add embedded types for GroundedAtom

### DIFF
--- a/c/src/atom.rs
+++ b/c/src/atom.rs
@@ -41,7 +41,7 @@ pub unsafe extern "C" fn atom_sym(name: *const c_char) -> *mut atom_t {
     // cstr_as_str() keeps pointer ownership, but Atom::sym() copies resulting
     // String into Atom::Symbol::symbol field. atom_to_ptr() moves value to the
     // heap and gives ownership to the caller.
-    atom_to_ptr(Atom::Symbol(cstr_as_str(name).into()))
+    atom_to_ptr(Atom::sym(cstr_as_str(name)))
 }
 
 #[no_mangle]
@@ -51,7 +51,7 @@ pub unsafe extern "C" fn atom_expr(children: *const *mut atom_t, size: usize) ->
         let c_atom = Box::from_raw(*atom);
         c_atom.atom
     }).collect();
-    atom_to_ptr(Atom::Expression(children.into()))
+    atom_to_ptr(Atom::expr(children))
 }
 
 #[no_mangle]

--- a/c/src/atom.rs
+++ b/c/src/atom.rs
@@ -56,7 +56,7 @@ pub unsafe extern "C" fn atom_expr(children: *const *mut atom_t, size: usize) ->
 
 #[no_mangle]
 pub unsafe extern "C" fn atom_var(name: *const c_char) -> *mut atom_t {
-    atom_to_ptr(Atom::Variable(cstr_as_str(name).into()))
+    atom_to_ptr(Atom::var(cstr_as_str(name)))
 }
 
 #[no_mangle]

--- a/c/src/atom.rs
+++ b/c/src/atom.rs
@@ -63,12 +63,7 @@ pub unsafe extern "C" fn atom_var(name: *const c_char) -> *mut atom_t {
 pub extern "C" fn atom_gnd(gnd: *mut gnd_t) -> *mut atom_t {
     unsafe {
         if let Some(_) = (*(*gnd).api).execute {
-            let ctx = AtomicPtr::new(gnd);
-            atom_to_ptr(Atom::Grounded(
-                    GroundedAtom::new_function(
-                        CGroundedValue(AtomicPtr::new(gnd)),
-                        CGroundedFunction(ctx))
-            ))
+            atom_to_ptr(Atom::function(CGroundedValue(AtomicPtr::new(gnd)), call_execute))
         } else {
             atom_to_ptr(Atom::value(CGroundedValue(AtomicPtr::new(gnd))))
         }
@@ -268,53 +263,18 @@ impl Drop for CGroundedValue {
     }
 }
 
-struct CGroundedFunction(AtomicPtr<gnd_t>);
-
-impl CGroundedFunction {
-    fn get_ptr(&self) -> *const gnd_t {
-        self.0.load(Ordering::Acquire)
-    }
-
-    fn api(&self) -> &gnd_api_t {
-        unsafe {
-            &*(*self.get_ptr()).api
-        }
-    }
-
-    fn clone(&self) -> Self {
-        CGroundedFunction(AtomicPtr::new((self.api().clone)(self.get_ptr())))
-    }
-}
-
-impl GroundedFunction for CGroundedFunction {
-    fn eq_trait(&self, other: &dyn GroundedFunction) -> bool {
-        match other.downcast_ref::<CGroundedFunction>() {
-            Some(other) => self.api().execute == other.api().execute,
-            _ => false,
-        }
-    }
-
-    fn clone_trait(&self) -> Box<dyn GroundedFunction> {
-        Box::new(self.clone())
-    }
-
-    fn call(&self, args: &mut Vec<Atom>) -> Result<Vec<Atom>, String> {
-        unsafe {
-            execute(&self.0, args)
-        }
-    }
-}
-
-unsafe fn execute(gnd: &AtomicPtr<gnd_t>, args: &mut Vec<Atom>) -> Result<Vec<Atom>, String> {
+fn call_execute(this: &dyn GroundedValue, args: &mut Vec<Atom>) -> Result<Vec<Atom>, String> {
+    let gnd = this.downcast_ref::<CGroundedValue>()
+        .expect("Only GroundedValue can be used as a first argument")
+        .get_ptr();
     let mut ret = Vec::new();
-    let gnd = gnd.load(Ordering::Acquire);
-    let func = (*(*gnd).api).execute.unwrap();
+    let func = unsafe{ (*(*gnd).api).execute }.unwrap();
     let res = func(gnd, (args as *mut Vec<Atom>).cast::<vec_atom_t>(),
     (&mut ret as *mut Vec<Atom>).cast::<vec_atom_t>());
     if res.is_null() {
         Ok(ret)
     } else {
-        Err(cstr_as_str(res).to_string())
+        Err(unsafe{ cstr_as_str(res) }.to_string())
     }
 }
 

--- a/c/tests/int_gnd.c
+++ b/c/tests/int_gnd.c
@@ -12,6 +12,7 @@ gnd_api_t const INT_GND_API = { 0, &int_eq, &int_clone, &int_display, &int_free 
 gnd_t* int_new(int n) {
 	int_gnd_t* self = malloc(sizeof(int_gnd_t));
 	self->api = &INT_GND_API;
+	self->typ = atom_sym("int");
 	self->n = n;
 	return (gnd_t*) self;
 }

--- a/c/tests/int_gnd.h
+++ b/c/tests/int_gnd.h
@@ -5,6 +5,7 @@
 
 typedef struct _int_gnd_t {
 	gnd_api_t const* api;
+	atom_t const* typ;
 	int n;
 } int_gnd_t;
 

--- a/lib/src/atom/matcher.rs
+++ b/lib/src/atom/matcher.rs
@@ -3,7 +3,7 @@
 #[macro_export]
 macro_rules! bind {
     ($($k:ident: $v:expr),*) => {
-        Bindings::from( vec![$( (VariableAtom::from(stringify!($k)), $v), )*])
+        Bindings::from( vec![$( (VariableAtom::new(stringify!($k)), $v), )*])
     };
 }
 

--- a/lib/src/atom/matcher.rs
+++ b/lib/src/atom/matcher.rs
@@ -306,8 +306,10 @@ pub fn apply_bindings_to_atom(atom: &Atom, bindings: &Bindings) -> Atom {
             }
         },
         Atom::Expression(ExpressionAtom{ children }) => {
-            let children = children.iter().map(|a| apply_bindings_to_atom(a, bindings)).collect::<Vec<Atom>>();
-            Atom::expr(&children[..])
+            let children = children.iter()
+                .map(|a| apply_bindings_to_atom(a, bindings))
+                .collect::<Vec<Atom>>();
+            Atom::expr(children)
         },
     }
 }

--- a/lib/src/atom/mod.rs
+++ b/lib/src/atom/mod.rs
@@ -88,8 +88,8 @@ pub struct VariableAtom {
 }
 
 impl VariableAtom {
-    fn new(name: String) -> Self {
-        Self{ name }
+    pub fn new<T: Into<String>>(name: T) -> Self {
+        Self{ name: name.into() }
     }
 
     pub fn name(&self) -> &str {
@@ -100,12 +100,6 @@ impl VariableAtom {
 impl Display for VariableAtom {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "${}", self.name)
-    }
-}
-
-impl From<&str> for VariableAtom {
-    fn from(name: &str) -> Self {
-        VariableAtom::new(name.to_string())
     }
 }
 
@@ -297,7 +291,7 @@ impl Atom {
     }
 
     pub fn var<T: Into<String>>(name: T) -> Self {
-        Self::Variable(VariableAtom::new(name.into()))
+        Self::Variable(VariableAtom::new(name))
     }
 
     pub fn value<T: GroundedValue>(value: T) -> Atom {

--- a/lib/src/common/arithmetics.rs
+++ b/lib/src/common/arithmetics.rs
@@ -2,12 +2,17 @@ use crate::*;
 use super::*;
 
 macro_rules! def_op {
-    ($x:ident, $o:tt, $e:expr) => { pub static $x: &Operation =
-            &Operation{ name: stringify!($o), execute: $e }; };
+    ($x:ident, $o:tt, $e:expr, $t: expr) => {
+        pub static $x: &Operation =
+            &Operation{ name: stringify!($o), execute: $e, typ: $t };
+    };
 }
 
 macro_rules! def_bin_op {
-    ($x:ident, $o:tt, $t1:ty, $r:ty) => { def_op!($x, $o, |_, args| bin_op::<$t1,$t1,$r>(args, |a, b| a $o b)); };
+    ($x:ident, $o:tt, $t:ty, $r:ty) => {
+        def_op!($x, $o, |_, args| bin_op::<$t,$t,$r>(args, |a, b| a $o b),
+            concat!("(-> ", stringify!($t), " ", stringify!($t), " ", stringify!($r), ")"));
+    };
 }
 
 def_bin_op!(SUM, +, i32, i32);
@@ -20,21 +25,26 @@ def_bin_op!(EQ, ==, i32, bool);
 
 def_bin_op!(AND, &&, bool, bool);
 def_bin_op!(OR, ||, bool, bool);
-def_op!(NOT, !, |_, args| unary_op(args, |a: bool| !a));
+def_op!(NOT, !, |_, args| unary_op(args, |a: bool| !a), "(-> bool bool)");
 
-def_op!(NOP, nop, |_, _| Ok(vec![]));
-def_op!(ERR, err, |_, _| Err("Error".into()));
+// FIXME: find out correct types for nop and err
+def_op!(NOP, nop, |_, _| Ok(vec![]), "(-> ())");
+def_op!(ERR, err, |_, _| Err("Error".into()), "(-> !)");
 
-pub static IS_INT: &Operation = &Operation{ name: "is_int", execute: |_, args| check_type(args,
-    // TODO: it is ugly, but I cannot do something more clear without downcasting
-    |a| is_instance::<i32>(a) || is_instance::<u32>(a)
-    || is_instance::<i64>(a) || is_instance::<u64>(a)
-    || is_instance::<i128>(a) || is_instance::<u128>(a)
-)};
+pub static IS_INT: &Operation = &Operation{
+    name: "is_int",
+    execute: |_, args| check_type(args,
+        // TODO: it is ugly, but I cannot do something more clear without downcasting
+        |a| is_instance::<i32>(a) || is_instance::<u32>(a)
+        || is_instance::<i64>(a) || is_instance::<u64>(a)
+        || is_instance::<i128>(a) || is_instance::<u128>(a)
+    ),
+    typ: "(-> Grounded bool)",
+};
 
 fn check_type(args: &mut Vec<Atom>, op: fn(&Atom) -> bool) -> Result<Vec<Atom>, String> {
     let arg = args.get(0).ok_or_else(|| format!("Unary operation called without arguments"))?; 
-    Ok(vec![Atom::value(op(arg))])
+    Ok(vec![Atom::rust_value(op(arg))])
 }
 
 fn is_instance<T>(arg: &Atom) -> bool
@@ -51,7 +61,7 @@ where
 {
     let arg = args.get(0).ok_or_else(|| format!("Unary operation called without arguments"))?; 
     if let Some(arg) = arg.as_gnd::<T>() {
-        Ok(vec![Atom::value(op(*arg))])
+        Ok(vec![Atom::rust_value(op(*arg))])
     } else {
         Err(format!("Incorrect type of the unary operation argument: ({})", arg))
     }
@@ -66,7 +76,7 @@ where
     let arg1 = args.get(0).ok_or_else(|| format!("Binary operation called without arguments"))?; 
     let arg2 = args.get(1).ok_or_else(|| format!("Binary operation called with only argument"))?;
     if let (Some(arg1), Some(arg2)) = (arg1.as_gnd::<T1>(), arg2.as_gnd::<T2>()) {
-        Ok(vec![Atom::value(op(*arg1, *arg2))])
+        Ok(vec![Atom::rust_value(op(*arg1, *arg2))])
     } else {
         Err(format!("Incorrect type of the binary operation argument: ({}, {})", arg1, arg2))
     }
@@ -82,7 +92,7 @@ mod tests {
     use crate::space::grounding::GroundingSpace;
 
     // Aliases to have a shorter notation
-    fn G<T: GroundedValue>(value: T) -> Atom { Atom::value(value) }
+    fn G<T: GroundedValue>(value: T) -> Atom { Atom::rust_value(value) }
 
     #[test]
     fn test_sum_ints() {

--- a/lib/src/common/arithmetics.rs
+++ b/lib/src/common/arithmetics.rs
@@ -7,7 +7,7 @@ macro_rules! def_op {
 }
 
 macro_rules! def_bin_op {
-    ($x:ident, $o:tt, $t1:ty, $r:ty) => { def_op!($x, $o, |args| bin_op::<$t1,$t1,$r>(args, |a, b| a $o b)); };
+    ($x:ident, $o:tt, $t1:ty, $r:ty) => { def_op!($x, $o, |_, args| bin_op::<$t1,$t1,$r>(args, |a, b| a $o b)); };
 }
 
 def_bin_op!(SUM, +, i32, i32);
@@ -20,12 +20,12 @@ def_bin_op!(EQ, ==, i32, bool);
 
 def_bin_op!(AND, &&, bool, bool);
 def_bin_op!(OR, ||, bool, bool);
-def_op!(NOT, !, |args| unary_op(args, |a: bool| !a));
+def_op!(NOT, !, |_, args| unary_op(args, |a: bool| !a));
 
-def_op!(NOP, nop, |_| Ok(vec![]));
-def_op!(ERR, err, |_| Err("Error".into()));
+def_op!(NOP, nop, |_, _| Ok(vec![]));
+def_op!(ERR, err, |_, _| Err("Error".into()));
 
-pub static IS_INT: &Operation = &Operation{ name: "is_int", execute: |args| check_type(args,
+pub static IS_INT: &Operation = &Operation{ name: "is_int", execute: |_, args| check_type(args,
     // TODO: it is ugly, but I cannot do something more clear without downcasting
     |a| is_instance::<i32>(a) || is_instance::<u32>(a)
     || is_instance::<i64>(a) || is_instance::<u64>(a)

--- a/lib/src/common/collections.rs
+++ b/lib/src/common/collections.rs
@@ -25,4 +25,3 @@ impl<K: PartialEq, V> ListMap<K, V> {
         self.list.clear()
     }
 }
-

--- a/lib/src/common/mod.rs
+++ b/lib/src/common/mod.rs
@@ -17,7 +17,7 @@ pub fn init_logger(is_test: bool) {
 // The instance has 'static lifetime and not copied when cloned.
 pub struct Operation {
     pub name: &'static str,
-    pub execute: fn(&mut Vec<Atom>) -> Result<Vec<Atom>, String>,
+    pub execute: fn(&dyn GroundedValue, &mut Vec<Atom>) -> Result<Vec<Atom>, String>,
 }
 
 impl GroundedValue for &'static Operation {
@@ -77,7 +77,7 @@ impl<T> Debug for GndRefCell<T> {
 mod tests {
     use super::*;
 
-    fn test(_args: &mut Vec<Atom>) -> Result<Vec<Atom>, String> {
+    fn test(_this: &dyn GroundedValue, _args: &mut Vec<Atom>) -> Result<Vec<Atom>, String> {
         Ok(vec![])
     }
 

--- a/lib/src/metta/interpreter.rs
+++ b/lib/src/metta/interpreter.rs
@@ -371,7 +371,8 @@ fn match_op(context: InterpreterContextRef, expr: Atom, prev_bindings: Bindings)
     let var_x = VariableAtom::from("%X%");
     // TODO: unique variable?
     let atom_x = Atom::Variable(var_x.clone());
-    let mut local_bindings = context.space.query(&Atom::expr(&[equal_symbol(), expr.clone(), atom_x]));
+    let query = Atom::expr(vec![equal_symbol(), expr.clone(), atom_x]);
+    let mut local_bindings = context.space.query(&query);
     let results: Vec<(Atom, Bindings)> = local_bindings
         .drain(0..)
         .map(|mut binding| {

--- a/lib/src/metta/interpreter.rs
+++ b/lib/src/metta/interpreter.rs
@@ -368,7 +368,7 @@ fn match_plan(context: InterpreterContextRef, expr: Atom, bindings: Bindings) ->
 
 fn match_op(context: InterpreterContextRef, expr: Atom, prev_bindings: Bindings) -> StepResult<InterpreterResult> {
     log::debug!("match_op: {}", expr);
-    let var_x = VariableAtom::from("%X%");
+    let var_x = VariableAtom::new("%X%");
     // TODO: unique variable?
     let atom_x = Atom::Variable(var_x.clone());
     let query = Atom::expr(vec![equal_symbol(), expr.clone(), atom_x]);

--- a/lib/src/metta/interpreter.rs
+++ b/lib/src/metta/interpreter.rs
@@ -9,6 +9,9 @@ use std::ops::Deref;
 use std::rc::Rc;
 use std::cell::RefCell;
 
+#[inline]
+fn equal_symbol() -> Atom { sym!("=") }
+
 pub type InterpreterResult = Vec<(Atom, Bindings)>;
 
 pub fn interpret_init(space: GroundingSpace, expr: &Atom) -> StepResult<InterpreterResult> {
@@ -368,7 +371,7 @@ fn match_op(context: InterpreterContextRef, expr: Atom, prev_bindings: Bindings)
     let var_x = VariableAtom::from("%X%");
     // TODO: unique variable?
     let atom_x = Atom::Variable(var_x.clone());
-    let mut local_bindings = context.space.query(&Atom::expr(&[Atom::sym("="), expr.clone(), atom_x]));
+    let mut local_bindings = context.space.query(&Atom::expr(&[equal_symbol(), expr.clone(), atom_x]));
     let results: Vec<(Atom, Bindings)> = local_bindings
         .drain(0..)
         .map(|mut binding| {

--- a/lib/src/metta/mod.rs
+++ b/lib/src/metta/mod.rs
@@ -6,7 +6,7 @@ mod examples;
 
 use crate::Atom;
 use crate::space::grounding::GroundingSpace;
-use text::SExprSpace;
+use text::{SExprParser, Tokenizer, SExprSpace};
 
 pub fn metta_space(text: &str) -> GroundingSpace {
     let mut parser = SExprSpace::new();
@@ -15,11 +15,13 @@ pub fn metta_space(text: &str) -> GroundingSpace {
 }
 
 pub fn metta_atom(atom: &str) -> Atom {
-    let space = metta_space(atom);
-    if space.borrow_vec().len() != 1 {
-        panic!("Single atom is expected");
+    let tokenizer = Tokenizer::new();
+    let mut parser = SExprParser::new(atom);
+    let atom = parser.parse(&tokenizer);
+    if let Some(atom) = atom {
+        atom
     } else {
-        space.leak().pop().unwrap()
+        panic!("Single atom is expected");
     }
 }
 

--- a/lib/src/metta/text.rs
+++ b/lib/src/metta/text.rs
@@ -54,7 +54,7 @@ impl<'a> SExprParser<'a> {
                 '$' => {
                     self.it.next();
                     let token = next_token(&mut self.it);
-                    return Some(Atom::Variable(token.into()));
+                    return Some(Atom::var(token));
                 },
                 '(' => {
                     self.it.next();

--- a/lib/src/metta/text.rs
+++ b/lib/src/metta/text.rs
@@ -187,7 +187,7 @@ mod tests {
     fn test_text_recognize_full_token() {
         let mut text = SExprSpace::new();
         text.register_token(Regex::new(r"b").unwrap(),
-            |_| Atom::value("b"));
+            |_| Atom::rust_value("b"));
 
         text.add_str("ab").unwrap();
         let space = GroundingSpace::from(&text);
@@ -199,7 +199,7 @@ mod tests {
     fn test_text_gnd() {
         let mut text = SExprSpace::new();
         text.register_token(Regex::new(r"\d+").unwrap(),
-            |token| Atom::value(token.parse::<i32>().unwrap()));
+            |token| Atom::rust_value(token.parse::<i32>().unwrap()));
 
         text.add_str("(3d 42)").unwrap();
         let space = GroundingSpace::from(&text);

--- a/lib/src/metta/text.rs
+++ b/lib/src/metta/text.rs
@@ -204,7 +204,7 @@ mod tests {
         text.add_str("(3d 42)").unwrap();
         let space = GroundingSpace::from(&text);
 
-        assert_eq!(vec![Atom::expr(&[Atom::sym("3d"), Atom::value(42)])],
+        assert_eq!(vec![Atom::expr(&[sym!("3d"), Atom::value(42)])],
             *space.borrow_vec());
     }
 

--- a/lib/src/metta/text.rs
+++ b/lib/src/metta/text.rs
@@ -67,7 +67,7 @@ impl<'a> SExprParser<'a> {
                     if let Some(constr) = constr {
                         return Some(constr(token.as_str()));
                     } else {
-                        return Some(Atom::Symbol(token.into()));
+                        return Some(Atom::sym(token));
                     }
                 },
             }
@@ -82,7 +82,7 @@ impl<'a> SExprParser<'a> {
                 _ if c.is_whitespace() => { self.it.next(); },
                 ')' => {
                     self.it.next();
-                    let expr = Atom::Expression(children.into());
+                    let expr = Atom::expr(children);
                     return expr;
                 },
                 _ => {
@@ -204,8 +204,7 @@ mod tests {
         text.add_str("(3d 42)").unwrap();
         let space = GroundingSpace::from(&text);
 
-        assert_eq!(vec![Atom::expr(&[sym!("3d"), Atom::value(42)])],
-            *space.borrow_vec());
+        assert_eq!(vec![expr!("3d", {42})], *space.borrow_vec());
     }
 
     #[test]

--- a/lib/src/metta/types.rs
+++ b/lib/src/metta/types.rs
@@ -18,11 +18,11 @@ pub enum AtomType {
 }
 
 fn typeof_query(atom: &Atom, typ: &Atom) -> Atom {
-    Atom::expr(&[has_type_symbol(), atom.clone(), typ.clone()])
+    Atom::expr(vec![has_type_symbol(), atom.clone(), typ.clone()])
 }
 
 fn isa_query(sub_type: &Atom, super_type: &Atom) -> Atom {
-    Atom::expr(&[sub_type_symbol(), sub_type.clone(), super_type.clone()])
+    Atom::expr(vec![sub_type_symbol(), sub_type.clone(), super_type.clone()])
 }
 
 fn query_has_type(space: &GroundingSpace, sub_type: &Atom, super_type: &Atom) -> Vec<Bindings> {
@@ -118,7 +118,7 @@ fn get_reducted_types(space: &GroundingSpace, atom: &Atom) -> Vec<Atom> {
         },
         Atom::Expression(expr) => {
             // tuple type
-            let mut types = vec![Atom::expr(&[])];
+            let mut types = vec![Atom::expr([])];
             for (i, child) in expr.children().iter().enumerate() {
                 let child_types = get_reducted_types(space, child);
                 let child_types = child_types.iter()
@@ -129,7 +129,7 @@ fn get_reducted_types(space: &GroundingSpace, atom: &Atom) -> Vec<Atom> {
                             child_types.clone().map(|typ| {
                                 let mut children = expr.children().clone();
                                 children.push(typ.clone());
-                                Atom::expr(children.as_slice())
+                                Atom::expr(children)
                             }).collect()
                         },
                         _ => vec![prev],

--- a/lib/src/metta/types.rs
+++ b/lib/src/metta/types.rs
@@ -31,7 +31,7 @@ fn query_has_type(space: &GroundingSpace, sub_type: &Atom, super_type: &Atom) ->
 
 fn query_super_types(space: &GroundingSpace, sub_type: &Atom) -> Vec<Atom> {
     // TODO: query should check that sub type is a type and not another typed symbol
-    let var_x = VariableAtom::from("%X%");
+    let var_x = VariableAtom::new("%X%");
     let mut super_types = space.query(&isa_query(&sub_type, &Atom::Variable(var_x.clone())));
     super_types.drain(0..).map(|mut bindings| bindings.remove(&var_x).unwrap()).collect()
 }
@@ -76,7 +76,7 @@ fn is_func(typ: &&Atom) -> bool {
 }
 
 fn query_types(space: &GroundingSpace, atom: &Atom) -> Vec<Atom> {
-    let var_x = VariableAtom::from("%X%");
+    let var_x = VariableAtom::new("%X%");
     let mut types = query_has_type(space, atom, &Atom::Variable(var_x.clone()));
     let mut types = types.drain(0..).map(|mut bindings| bindings.remove(&var_x).unwrap()).collect();
     add_super_types(space, &mut types, 0);

--- a/lib/src/space/grounding.rs
+++ b/lib/src/space/grounding.rs
@@ -9,6 +9,9 @@ use std::cell::{RefCell, Ref};
 
 // Grounding space
 
+#[inline]
+fn comma_symbol() -> Atom { sym!(",") }
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum SpaceEvent {
     Add(Atom),
@@ -87,7 +90,7 @@ impl GroundingSpace {
 
     pub fn query(&self, pattern: &Atom) -> Vec<Bindings> {
         match split_expr(pattern) {
-            Some((Atom::Symbol(sym), args)) if *sym == SymbolAtom::from(",") => {
+            Some((sym @ Atom::Symbol(_), args)) if *sym == comma_symbol() => {
                 args.fold(vec![bind!{}],
                     |acc, pattern| {
                         if acc.is_empty() {
@@ -210,8 +213,8 @@ mod test {
         space.add(expr!("c"));
 
         assert_eq!(*space.borrow_vec(), vec![expr!("a"), expr!("b"), expr!("c")]);
-        assert_eq!(observer.borrow().events, vec![SpaceEvent::Add(Atom::sym("a")),
-            SpaceEvent::Add(Atom::sym("b")), SpaceEvent::Add(Atom::sym("c"))]);
+        assert_eq!(observer.borrow().events, vec![SpaceEvent::Add(sym!("a")),
+            SpaceEvent::Add(sym!("b")), SpaceEvent::Add(sym!("c"))]);
     }
 
     #[test]
@@ -226,9 +229,9 @@ mod test {
         assert_eq!(space.remove(&expr!("b")), true);
 
         assert_eq!(*space.borrow_vec(), vec![expr!("a"), expr!("c")]);
-        assert_eq!(observer.borrow().events, vec![SpaceEvent::Add(Atom::sym("a")),
-            SpaceEvent::Add(Atom::sym("b")), SpaceEvent::Add(Atom::sym("c")),
-            SpaceEvent::Remove(Atom::sym("b"))]);
+        assert_eq!(observer.borrow().events, vec![SpaceEvent::Add(sym!("a")),
+            SpaceEvent::Add(sym!("b")), SpaceEvent::Add(sym!("c")),
+            SpaceEvent::Remove(sym!("b"))]);
     }
 
     #[test]
@@ -241,7 +244,7 @@ mod test {
         assert_eq!(space.remove(&expr!("b")), false);
 
         assert_eq!(*space.borrow_vec(), vec![expr!("a")]);
-        assert_eq!(observer.borrow().events, vec![SpaceEvent::Add(Atom::sym("a"))]);
+        assert_eq!(observer.borrow().events, vec![SpaceEvent::Add(sym!("a"))]);
     }
 
     #[test]
@@ -256,9 +259,9 @@ mod test {
         assert_eq!(space.replace(&expr!("b"), expr!("d")), true);
 
         assert_eq!(*space.borrow_vec(), vec![expr!("a"), expr!("d"), expr!("c")]);
-        assert_eq!(observer.borrow().events, vec![SpaceEvent::Add(Atom::sym("a")),
-            SpaceEvent::Add(Atom::sym("b")), SpaceEvent::Add(Atom::sym("c")),
-            SpaceEvent::Replace(Atom::sym("b"), Atom::sym("d"))]);
+        assert_eq!(observer.borrow().events, vec![SpaceEvent::Add(sym!("a")),
+            SpaceEvent::Add(sym!("b")), SpaceEvent::Add(sym!("c")),
+            SpaceEvent::Replace(sym!("b"), sym!("d"))]);
     }
 
     #[test]
@@ -271,7 +274,7 @@ mod test {
         assert_eq!(space.replace(&expr!("b"), expr!("d")), false);
 
         assert_eq!(*space.borrow_vec(), vec![expr!("a")]);
-        assert_eq!(observer.borrow().events, vec![SpaceEvent::Add(Atom::sym("a"))]);
+        assert_eq!(observer.borrow().events, vec![SpaceEvent::Add(sym!("a"))]);
     }
 
     #[test]

--- a/python/hyperon/__init__.py
+++ b/python/hyperon/__init__.py
@@ -85,22 +85,19 @@ def call_execute_on_grounded_atom(gnd, args):
     return gnd.execute(*args)
 
 
-class ConstGroundedObject:
-
-    def copy(self):
-        return self
-
-class TypedObject(ConstGroundedObject):
+class TypedObject:
 
     def __init__(self, atype):
         super().__init__()
         self.atype = atype
 
+    def copy(self):
+        return self
+
 class TypedValue(TypedObject):
 
     def __init__(self, value, type_name):
-        #super().__init__(S(type_name))
-        super().__init__(type_name)
+        super().__init__(S(type_name))
         self.value = value
 
     def __eq__(self, other):
@@ -116,7 +113,8 @@ class TypedOperation(TypedObject):
 
     def __init__(self, name, op, type_names, unwrap=True):
         # TODO: if we want to have arbitrary expressions as types
-        super().__init__(type_names)
+        super().__init__(E(S("->"), *[S(n) for n in type_names]))
+        self.res_type_name = type_names[-1]
         self.name = name
         self.op = op
         self.unwrap = unwrap
@@ -125,7 +123,7 @@ class TypedOperation(TypedObject):
         # type-check?
         if self.unwrap:
             args = [arg.get_object().value for arg in args]
-            return [G(TypedValue(self.op(*args), self.atype[-1]))]
+            return [G(TypedValue(self.op(*args), self.res_type_name))]
         else:
             return self.op(*args)
 

--- a/python/hyperonpy.cpp
+++ b/python/hyperonpy.cpp
@@ -61,6 +61,7 @@ struct GroundedObject : gnd_t {
 		} else {
 			this->api = &PY_VALUE_API;
 		}
+		this->typ = pyobj.attr("atype").attr("catom").cast<CAtom>().ptr;
 	}
 	virtual ~GroundedObject() { }
 	py::object pyobj;
@@ -102,7 +103,8 @@ bool py_eq(const struct gnd_t* _a, const struct gnd_t* _b) {
 }
 
 struct gnd_t *py_clone(const struct gnd_t* _cgnd) {
-	py::object pyobj = static_cast<GroundedObject const*>(_cgnd)->pyobj;
+	GroundedObject const* cgnd = static_cast<GroundedObject const*>(_cgnd);
+	py::object pyobj = cgnd->pyobj;
 	py::object copy = pyobj.attr("copy")();
 	return new GroundedObject(copy);
 }


### PR DESCRIPTION
Main change: add a field to keep type of the grounded atom inside `GroundedAtom` struct. Pass value to this field either automatically (using compile time Rust type knowledge) or manually. Use manual typing API to pass types for GroundedAtoms from Python library.

Minor changes: simplify Atom and GroundedAtom API.