### PR TITLE
Python grounded types

### DIFF
--- a/c/src/atom.rs
+++ b/c/src/atom.rs
@@ -34,7 +34,7 @@ pub struct gnd_api_t {
 #[repr(C)]
 pub struct gnd_t {
     api: *const gnd_api_t,
-    typ: *const atom_t,
+    typ: *mut atom_t,
 }
 
 #[no_mangle]

--- a/c/src/atom.rs
+++ b/c/src/atom.rs
@@ -111,6 +111,15 @@ pub unsafe extern "C" fn atom_get_object(atom: *const atom_t) -> *mut gnd_t {
 }
 
 #[no_mangle]
+pub extern "C" fn atom_get_grounded_type(atom: *const atom_t) -> *const atom_t {
+    if let Atom::Grounded(ref g) = unsafe{ &(*atom) }.atom {
+        (g.get_type() as *const Atom).cast::<atom_t>()
+    } else {
+        panic!("Only Grounded atoms has grounded type attribute!");
+    }
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn atom_get_children(atom: *const atom_t,
         callback: c_atoms_callback_t, context: *mut c_void) {
     if let Atom::Expression(ref e) = (*atom).atom {

--- a/lib/src/atom/mod.rs
+++ b/lib/src/atom/mod.rs
@@ -212,6 +212,10 @@ impl GroundedAtom {
     pub fn downcast_mut<T: GroundedValue>(&mut self) -> Option<&mut T> {
         self.value.downcast_mut::<T>()
     }
+
+    pub fn get_type(&self) -> &Atom {
+        &*self.typ
+    }
 }
 
 impl PartialEq for GroundedAtom {
@@ -389,6 +393,23 @@ mod test {
         assert_eq!(Atom::rust_value(HashMap::from([("q", 0), ("a", 42),])),
             value(HashMap::from([("q", 0), ("a", 42),]), "HashMap<&str, i32>"));
         assert_eq!(Atom::value(3, Atom::sym("Integer")), value(3, "Integer"));
+    }
+
+    #[test]
+    fn test_grounded_type() {
+        let atom = Atom::rust_value(42);
+        if let Atom::Grounded(gnd) = atom {
+            assert_eq!(*gnd.get_type(), Atom::sym("i32"));
+        } else {
+            assert!(false, "GroundedAtom is expected");
+        }
+
+        let atom = Atom::value(3, Atom::sym("Integer"));
+        if let Atom::Grounded(gnd) = atom {
+            assert_eq!(*gnd.get_type(), Atom::sym("Integer"));
+        } else {
+            assert!(false, "GroundedAtom is expected");
+        }
     }
 
     #[test]

--- a/python/hyperon/__init__.py
+++ b/python/hyperon/__init__.py
@@ -79,15 +79,22 @@ class GroundedAtom(Atom):
     def get_object(self):
         return hp.atom_get_object(self.catom)
 
-def G(object):
-    return GroundedAtom(hp.atom_gnd(object, GroundedAtom.UNDEFINED_TYPE.catom))
+    def get_grounded_type(self):
+        return Atom._from_catom(hp.atom_get_grounded_type(self.catom))
+
+def G(object, type=GroundedAtom.UNDEFINED_TYPE):
+    return GroundedAtom(hp.atom_gnd(object, type.catom))
 
 def call_execute_on_grounded_atom(gnd, args):
     args = [Atom._from_catom(catom) for catom in args]
     return gnd.execute(*args)
 
+class ConstGroundedObject:
 
-class TypedObject:
+    def copy(self):
+        return self
+
+class TypedObject(ConstGroundedObject):
 
     def __init__(self, atype):
         super().__init__()

--- a/python/hyperon/__init__.py
+++ b/python/hyperon/__init__.py
@@ -71,6 +71,8 @@ def E(*args):
 
 class GroundedAtom(Atom):
 
+    UNDEFINED_TYPE = S("Undefined")
+
     def __init__(self, catom):
         super().__init__(catom)
 
@@ -78,7 +80,7 @@ class GroundedAtom(Atom):
         return hp.atom_get_object(self.catom)
 
 def G(object):
-    return GroundedAtom(hp.atom_gnd(object))
+    return GroundedAtom(hp.atom_gnd(object, GroundedAtom.UNDEFINED_TYPE.catom))
 
 def call_execute_on_grounded_atom(gnd, args):
     args = [Atom._from_catom(catom) for catom in args]

--- a/python/hyperonpy.cpp
+++ b/python/hyperonpy.cpp
@@ -55,15 +55,17 @@ const gnd_api_t PY_EXECUTABLE_API = { &py_execute, &py_eq, &py_clone, &py_displa
 const gnd_api_t PY_VALUE_API = { nullptr, &py_eq, &py_clone, &py_display, &py_free };
 
 struct GroundedObject : gnd_t {
-	GroundedObject(py::object pyobj) : pyobj(pyobj) {
+	GroundedObject(py::object pyobj, atom_t* typ) : pyobj(pyobj) {
 		if (py::hasattr(pyobj, "execute")) {
 			this->api = &PY_EXECUTABLE_API;
 		} else {
 			this->api = &PY_VALUE_API;
 		}
-		this->typ = pyobj.attr("atype").attr("catom").cast<CAtom>().ptr;
+		this->typ = typ;
 	}
-	virtual ~GroundedObject() { }
+	virtual ~GroundedObject() {
+		atom_free(this->typ);
+	}
 	py::object pyobj;
 };
 
@@ -106,7 +108,8 @@ struct gnd_t *py_clone(const struct gnd_t* _cgnd) {
 	GroundedObject const* cgnd = static_cast<GroundedObject const*>(_cgnd);
 	py::object pyobj = cgnd->pyobj;
 	py::object copy = pyobj.attr("copy")();
-	return new GroundedObject(copy);
+	atom_t* typ = atom_copy(cgnd->typ);
+	return new GroundedObject(copy, typ);
 }
 
 size_t py_display(const struct gnd_t* _cgnd, char* buffer, size_t size) {
@@ -186,7 +189,10 @@ PYBIND11_MODULE(hyperonpy, m) {
     		}
     		return CAtom(atom_expr(children, size));
     	}, "Create expression atom");
-    m.def("atom_gnd", [](py::object object) { return CAtom(atom_gnd(new GroundedObject(object))); }, "Create grounded atom");
+    m.def("atom_gnd", [](py::object object, CAtom ctyp) {
+    		atom_t* typ = atom_copy(ctyp.ptr);
+    		return CAtom(atom_gnd(new GroundedObject(object, typ)));
+    		}, "Create grounded atom");
     m.def("atom_free", [](CAtom atom) { atom_free(atom.ptr); }, "Free C atom");
 
     m.def("atom_eq", [](CAtom a, CAtom b) -> bool { return atom_eq(a.ptr, b.ptr); }, "Test if two atoms are equal");

--- a/python/hyperonpy.cpp
+++ b/python/hyperonpy.cpp
@@ -210,6 +210,9 @@ PYBIND11_MODULE(hyperonpy, m) {
 	m.def("atom_get_object", [](CAtom atom) {
 			return static_cast<GroundedObject const*>(atom_get_object(atom.ptr))->pyobj;
 		}, "Get object of the grounded atom");
+	m.def("atom_get_grounded_type", [](CAtom atom) {
+			return CAtom(atom_copy(atom_get_grounded_type(atom.ptr)));
+		}, "Get object of the grounded atom");
 	m.def("atom_get_children", [](CAtom atom) {
 			py::list atoms;
 			atom_get_children(atom.ptr, copy_atoms, &atoms);

--- a/python/tests/test_atom.py
+++ b/python/tests/test_atom.py
@@ -43,6 +43,10 @@ class AtomTest(unittest.TestCase):
     def test_grounded_type(self):
         self.assertEqual(ValueAtom(1.0).get_type(), AtomKind.GROUNDED)
 
+    def test_grounded_grounded_type(self):
+        atom = G(ConstGroundedObject(), S("Float"))
+        self.assertEqual(atom.get_grounded_type(), S("Float"))
+
     # def test_grounded_execute_default(self):
         # self.assertEqual(ValueAtom(1.0).get_object().execute(VecAtom(),
             # VecAtom()), "1.0 is not executable")


### PR DESCRIPTION
Add API to pass grounded atom type into grounded atom constructor and to get atom type back from grounded atom.
Add an unit test to demonstrate approach.