### PR TITLE
Grounded atom refactoring

### DIFF
--- a/c/src/atom.rs
+++ b/c/src/atom.rs
@@ -247,7 +247,7 @@ impl Grounded for CGrounded {
     }
 
     fn match_(&self, other: &Atom) -> matcher::MatchResultIter {
-        default_match(self, other)
+        match_by_equality(self, other)
     }
 }
 

--- a/c/src/atom.rs
+++ b/c/src/atom.rs
@@ -3,7 +3,7 @@ use hyperon::*;
 use crate::util::*;
 
 use std::os::raw::*;
-use std::fmt::Debug;
+use std::fmt::Display;
 use std::sync::atomic::{AtomicPtr, Ordering};
 
 // Atom
@@ -62,14 +62,7 @@ pub unsafe extern "C" fn atom_var(name: *const c_char) -> *mut atom_t {
 
 #[no_mangle]
 pub extern "C" fn atom_gnd(gnd: *mut gnd_t) -> *mut atom_t {
-    unsafe {
-        let typ = (*(*gnd).typ).atom.clone();
-        if let Some(_) = (*(*gnd).api).execute {
-            atom_to_ptr(Atom::function(CGroundedValue(AtomicPtr::new(gnd)), call_execute, typ))
-        } else {
-            atom_to_ptr(Atom::value(CGroundedValue(AtomicPtr::new(gnd)), typ))
-        }
-    }
+    atom_to_ptr(Atom::gnd(CGrounded(AtomicPtr::new(gnd))))
 }
 
 #[no_mangle]
@@ -101,7 +94,7 @@ pub extern "C" fn atom_get_name(atom: *const atom_t, callback: c_str_callback_t,
 #[no_mangle]
 pub unsafe extern "C" fn atom_get_object(atom: *const atom_t) -> *mut gnd_t {
     if let Atom::Grounded(ref g) = (*atom).atom {
-        match (*g).downcast_ref::<CGroundedValue>() {
+        match (*g).as_any_ref().downcast_ref::<CGrounded>() {
             Some(g) => g.get_mut_ptr(),
             None => panic!("Returning non C grounded objects is not implemented yet!"),
         }
@@ -111,9 +104,9 @@ pub unsafe extern "C" fn atom_get_object(atom: *const atom_t) -> *mut gnd_t {
 }
 
 #[no_mangle]
-pub extern "C" fn atom_get_grounded_type(atom: *const atom_t) -> *const atom_t {
+pub extern "C" fn atom_get_grounded_type(atom: *const atom_t) -> *mut atom_t {
     if let Atom::Grounded(ref g) = unsafe{ &(*atom) }.atom {
-        (g.get_type() as *const Atom).cast::<atom_t>()
+        atom_to_ptr(g.type_())
     } else {
         panic!("Only Grounded atoms has grounded type attribute!");
     }
@@ -207,10 +200,10 @@ pub fn return_atoms(atoms: &Vec<Atom>, callback: c_atoms_callback_t, context: *m
 
 // C grounded atom wrapper
 
-struct CGroundedValue(AtomicPtr<gnd_t>);
+#[derive(Debug)]
+struct CGrounded(AtomicPtr<gnd_t>);
 
-impl CGroundedValue {
-
+impl CGrounded {
     fn get_mut_ptr(&self) -> *mut gnd_t {
         self.0.load(Ordering::Acquire)
     }
@@ -225,69 +218,63 @@ impl CGroundedValue {
         }
     }
 
-    fn eq(&self, other: &Self) -> bool {
-        (self.api().eq)(self.get_ptr(), other.get_ptr())
-    }
-
-    fn clone(&self) -> Self {
-        CGroundedValue(AtomicPtr::new((self.api().clone)(self.get_ptr())))
-    }
-
-    unsafe fn display(&self) -> String {
-        let mut buffer = [0u8; 4096];
-        (self.api().display)(self.get_ptr(), buffer.as_mut_ptr().cast::<c_char>(), 4096);
-        cstr_into_string(buffer.as_ptr().cast::<c_char>())
-    }
-
     fn free(&mut self) {
         (self.api().free)(self.get_mut_ptr());
     }
-
 }
 
-impl GroundedValue for CGroundedValue {
+impl Grounded for CGrounded {
+    fn type_(&self) -> Atom {
+        unsafe{ &*(*self.get_ptr()).typ }.atom.clone()
+    }
 
-    fn eq_gnd(&self, other: &dyn GroundedValue) -> bool {
-        match other.downcast_ref::<CGroundedValue>() {
-            Some(o) => self.eq(o),
-            None => false,
+    fn execute(&self, args: &mut Vec<Atom>) -> Result<Vec<Atom>, String> {
+        let mut ret = Vec::new();
+        match self.api().execute {
+            Some(func) => {
+                let res = func(self.get_ptr(), (args as *mut Vec<Atom>).cast::<vec_atom_t>(),
+                (&mut ret as *mut Vec<Atom>).cast::<vec_atom_t>());
+                let ret = if res.is_null() {
+                    Ok(ret)
+                } else {
+                    Err(cstr_as_str(res).into())
+                };
+                log::trace!("CGrounded::execute: atom: {:?}, args: {:?}, ret: {:?}", self, args, ret);
+                ret
+            },
+            None => Err("Trying to execute non executable atom".into()),
         }
     }
 
-    fn clone_gnd(&self) -> Box<dyn GroundedValue> {
-        Box::new(self.clone())
+    fn match_(&self, other: &Atom) -> matcher::MatchResultIter {
+        default_match(self, other)
     }
-
 }
 
-impl Debug for CGroundedValue {
+impl PartialEq for CGrounded {
+    fn eq(&self, other: &CGrounded) -> bool {
+        (self.api().eq)(self.get_ptr(), other.get_ptr())
+    }
+}
+
+impl Clone for CGrounded {
+    fn clone(&self) -> Self {
+        CGrounded(AtomicPtr::new((self.api().clone)(self.get_ptr())))
+    }
+}
+
+impl Display for CGrounded {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        unsafe {
-            write!(f, "{}", self.display())
-        }
+        let mut buffer = [0u8; 4096];
+        (self.api().display)(self.get_ptr(), buffer.as_mut_ptr().cast::<c_char>(), 4096);
+        let text = cstr_into_string(buffer.as_ptr().cast::<c_char>());
+        write!(f, "{}", text)
     }
 }
 
-impl Drop for CGroundedValue {
+impl Drop for CGrounded {
     fn drop(&mut self) {
         self.free();
     }
-}
-
-fn call_execute(this: &dyn GroundedValue, args: &mut Vec<Atom>) -> Result<Vec<Atom>, String> {
-    let gnd = this.downcast_ref::<CGroundedValue>()
-        .expect("Only GroundedValue can be used as a first argument")
-        .get_ptr();
-    let mut ret = Vec::new();
-    let func = unsafe{ (*(*gnd).api).execute }.unwrap();
-    let res = func(gnd, (args as *mut Vec<Atom>).cast::<vec_atom_t>(),
-    (&mut ret as *mut Vec<Atom>).cast::<vec_atom_t>());
-    let ret = if res.is_null() {
-        Ok(ret)
-    } else {
-        Err(unsafe{ cstr_as_str(res) }.to_string())
-    };
-    log::trace!("call_execute: atom: {:?}, args: {:?}, ret: {:?}", this, args, ret);
-    ret
 }
 

--- a/c/src/util.rs
+++ b/c/src/util.rs
@@ -17,11 +17,11 @@ pub type lambda_t<T> = extern "C" fn(data: T, context: *mut c_void);
 
 pub type c_str_callback_t = lambda_t<*const c_char>;
 
-pub unsafe fn cstr_as_str<'a>(s: *const c_char) -> &'a str {
-    CStr::from_ptr(s).to_str().expect("Incorrect UTF-8 sequence")
+pub fn cstr_as_str<'a>(s: *const c_char) -> &'a str {
+    unsafe{ CStr::from_ptr(s) }.to_str().expect("Incorrect UTF-8 sequence")
 }
 
-pub unsafe fn cstr_into_string(s: *const c_char) -> String {
+pub fn cstr_into_string(s: *const c_char) -> String {
     String::from(cstr_as_str(s))
 }
 

--- a/lib/src/atom/matcher.rs
+++ b/lib/src/atom/matcher.rs
@@ -130,6 +130,7 @@ impl From<(Bindings, Bindings)> for MatchResult {
 pub type MatchResultIter = Box<dyn Iterator<Item=matcher::MatchResult>>;
 
 pub trait WithMatch {
+    // FIXME: rename to match_()
     fn do_match(&self, other: &Atom) -> MatchResultIter;
 }
 

--- a/lib/src/atom/matcher.rs
+++ b/lib/src/atom/matcher.rs
@@ -137,7 +137,7 @@ impl WithMatch for Atom {
     fn do_match(&self, other: &Atom) -> MatchResultIter {
         match (self, other) {
             (Atom::Symbol(a), Atom::Symbol(b)) if a == b => Box::new(std::iter::once(MatchResult::new())),
-            (Atom::Grounded(a), Atom::Grounded(_)) => a.do_match(other),
+            (Atom::Grounded(a), Atom::Grounded(_)) => a.match_(other),
             (Atom::Variable(_), Atom::Variable(v)) => {
                 // We stick to prioritize pattern bindings in this case
                 // because otherwise the $X in (= (...) $X) will not be matched with

--- a/lib/src/atom/matcher.rs
+++ b/lib/src/atom/matcher.rs
@@ -130,12 +130,11 @@ impl From<(Bindings, Bindings)> for MatchResult {
 pub type MatchResultIter = Box<dyn Iterator<Item=matcher::MatchResult>>;
 
 pub trait WithMatch {
-    // FIXME: rename to match_()
-    fn do_match(&self, other: &Atom) -> MatchResultIter;
+    fn match_(&self, other: &Atom) -> MatchResultIter;
 }
 
 impl WithMatch for Atom {
-    fn do_match(&self, other: &Atom) -> MatchResultIter {
+    fn match_(&self, other: &Atom) -> MatchResultIter {
         match (self, other) {
             (Atom::Symbol(a), Atom::Symbol(b)) if a == b => Box::new(std::iter::once(MatchResult::new())),
             (Atom::Grounded(a), Atom::Grounded(_)) => a.match_(other),
@@ -143,22 +142,22 @@ impl WithMatch for Atom {
                 // We stick to prioritize pattern bindings in this case
                 // because otherwise the $X in (= (...) $X) will not be matched with
                 // (= (if True $then) $then)
-                log::trace!("do_match bind a pattern's variable: {} = {}", v, self);
+                log::trace!("match_(): bind a pattern's variable: {} = {}", v, self);
                 Box::new(std::iter::once(MatchResult::from((Bindings::new(), Bindings::from(vec![(v.clone(), self.clone())])))))
             }
             (Atom::Variable(v), b) => {
-                log::trace!("do_match bind a candidate's variable: {} = {}", v, b);
+                log::trace!("match_(): bind a candidate's variable: {} = {}", v, b);
                 Box::new(std::iter::once(MatchResult::from((Bindings::from(vec![(v.clone(), b.clone())]), Bindings::new()))))
             }
             (a, Atom::Variable(v)) => {
-                log::trace!("do_match bind a pattern's variable: {} = {}", v, a);
+                log::trace!("match_(): bind a pattern's variable: {} = {}", v, a);
                 Box::new(std::iter::once(MatchResult::from((Bindings::new(), Bindings::from(vec![(v.clone(), a.clone())])))))
             },
             (Atom::Expression(ExpressionAtom{ children: a }), Atom::Expression(ExpressionAtom{ children: b }))
                 if a.len() == b.len() => {
                 a.iter().zip(b.iter()).fold(Box::new(std::iter::once(MatchResult::new())),
                     |acc, (a, b)| {
-                        product_iter(acc, a.do_match(b))
+                        product_iter(acc, a.match_(b))
                     })
             },
             _ => Box::new(std::iter::empty()),

--- a/lib/src/atom/mod.rs
+++ b/lib/src/atom/mod.rs
@@ -136,7 +136,6 @@ impl Display for VariableAtom {
 // match_by_equality() method allows reusing default match_() implementation in
 // 3rd party code when it is not needed to be customized. 
 
-// FIXME: try implementing eq_gnd/clone_gnd and as_any_ref on the trait level
 pub trait GroundedAtom : mopa::Any + Debug + Display + Sync {
     fn eq_gnd(&self, other: &dyn GroundedAtom) -> bool;
     fn clone_gnd(&self) -> Box<dyn GroundedAtom>;
@@ -157,18 +156,9 @@ pub trait Grounded : Display {
 }
 
 pub fn match_by_equality<T: 'static + PartialEq>(this: &T, other: &Atom) -> matcher::MatchResultIter {
-    match other {
-        Atom::Grounded(other) => {
-            if let Some(other) = other.as_any_ref().downcast_ref::<T>() {
-                if *this == *other {
-                    Box::new(std::iter::once(matcher::MatchResult::new()))
-                } else {
-                    Box::new(std::iter::empty())
-                }
-            } else {
-                Box::new(std::iter::empty())
-            }
-        },
+    match other.as_gnd::<T>() {
+        Some(other) if *this == *other => 
+            Box::new(std::iter::once(matcher::MatchResult::new())),
         _ => Box::new(std::iter::empty()),
     }
 }

--- a/lib/src/atom/mod.rs
+++ b/lib/src/atom/mod.rs
@@ -463,7 +463,7 @@ mod test {
             if let Some(other) = other.as_gnd::<TestDict>() {
                 other.0.iter().map(|(ko, vo)| {
                     self.0.iter().map(|(k, v)| {
-                        Atom::expr(vec![k.clone(), v.clone()]).do_match(&Atom::expr(vec![ko.clone(), vo.clone()]))
+                        Atom::expr(vec![k.clone(), v.clone()]).match_(&Atom::expr(vec![ko.clone(), vo.clone()]))
                     }).fold(Box::new(std::iter::empty()) as MatchResultIter, |acc, i| {
                         Box::new(acc.chain(i))
                     })
@@ -629,7 +629,7 @@ mod test {
         query.put(expr!(a), expr!({2}, y));
         let query = expr!({query});
 
-        let result: Vec<MatchResult> = dict.do_match(&query).collect();
+        let result: Vec<MatchResult> = dict.match_(&query).collect();
         assert_eq!(result, vec![MatchResult::from((bind!{},
                     bind!{y: expr!({5}), b: expr!("y"), a: expr!("x")}))]);
     }

--- a/lib/src/atom/mod.rs
+++ b/lib/src/atom/mod.rs
@@ -325,8 +325,7 @@ impl Atom {
         Self::Grounded(Box::new(CustomGrounded(gnd)))
     }
 
-    // FIXME: rename into value()
-    pub fn rust_value<T: 'static + PartialEq + Clone + Debug + Sync>(value: T) -> Atom {
+    pub fn value<T: 'static + PartialEq + Clone + Debug + Sync>(value: T) -> Atom {
         Self::Grounded(Box::new(DefaultGrounded(value)))
     }
 
@@ -456,20 +455,20 @@ mod test {
 
     #[test]
     fn test_grounded() {
-        assert_eq!(Atom::rust_value(3), value(3));
-        assert_eq!(Atom::rust_value(42).as_gnd::<i32>().unwrap(), &42);
-        assert_eq!(Atom::rust_value("Data string"), value("Data string"));
-        assert_eq!(Atom::rust_value(vec![1, 2, 3]), value(vec![1, 2, 3]));
-        assert_eq!(Atom::rust_value([42, -42]).as_gnd::<[i32; 2]>().unwrap(), &[42, -42]);
-        assert_eq!(Atom::rust_value((-42, "42")).as_gnd::<(i32, &str)>().unwrap(), &(-42, "42"));
-        assert_eq!(Atom::rust_value(HashMap::from([("q", 0), ("a", 42),])),
+        assert_eq!(Atom::value(3), value(3));
+        assert_eq!(Atom::value(42).as_gnd::<i32>().unwrap(), &42);
+        assert_eq!(Atom::value("Data string"), value("Data string"));
+        assert_eq!(Atom::value(vec![1, 2, 3]), value(vec![1, 2, 3]));
+        assert_eq!(Atom::value([42, -42]).as_gnd::<[i32; 2]>().unwrap(), &[42, -42]);
+        assert_eq!(Atom::value((-42, "42")).as_gnd::<(i32, &str)>().unwrap(), &(-42, "42"));
+        assert_eq!(Atom::value(HashMap::from([("q", 0), ("a", 42),])),
             value(HashMap::from([("q", 0), ("a", 42),])));
         assert_eq!(Atom::gnd(TestGrounded(42)), gnd(TestGrounded(42)));
     }
 
     #[test]
     fn test_grounded_type() {
-        let atom = Atom::rust_value(42);
+        let atom = Atom::value(42);
         if let Atom::Grounded(gnd) = atom {
             assert_eq!(gnd.type_(), Atom::sym("i32"));
         } else {
@@ -503,17 +502,17 @@ mod test {
 
     #[test]
     fn test_display_grounded() {
-        assert_eq!(format!("{}", Atom::rust_value(42)), "42");
-        assert_eq!(format!("{}", Atom::rust_value([1, 2, 3])), "[1, 2, 3]");
-        assert_eq!(format!("{}", Atom::rust_value(HashMap::from([("hello", "world")]))),
+        assert_eq!(format!("{}", Atom::value(42)), "42");
+        assert_eq!(format!("{}", Atom::value([1, 2, 3])), "[1, 2, 3]");
+        assert_eq!(format!("{}", Atom::value(HashMap::from([("hello", "world")]))),
             "{\"hello\": \"world\"}");
     }
 
     #[test]
     fn test_debug_grounded() {
-        assert_eq!(format!("{:?}", Atom::rust_value(42)), "Grounded(DefaultGrounded(42))");
-        assert_eq!(format!("{:?}", Atom::rust_value([1, 2, 3])), "Grounded(DefaultGrounded([1, 2, 3]))");
-        assert_eq!(format!("{:?}", Atom::rust_value(HashMap::from([("hello", "world")]))),
+        assert_eq!(format!("{:?}", Atom::value(42)), "Grounded(DefaultGrounded(42))");
+        assert_eq!(format!("{:?}", Atom::value([1, 2, 3])), "Grounded(DefaultGrounded([1, 2, 3]))");
+        assert_eq!(format!("{:?}", Atom::value(HashMap::from([("hello", "world")]))),
             "Grounded(DefaultGrounded({\"hello\": \"world\"}))");
     }
 

--- a/lib/src/common/arithmetics.rs
+++ b/lib/src/common/arithmetics.rs
@@ -44,7 +44,7 @@ pub static IS_INT: &Operation = &Operation{
 
 fn check_type(args: &mut Vec<Atom>, op: fn(&Atom) -> bool) -> Result<Vec<Atom>, String> {
     let arg = args.get(0).ok_or_else(|| format!("Unary operation called without arguments"))?; 
-    Ok(vec![Atom::rust_value(op(arg))])
+    Ok(vec![Atom::value(op(arg))])
 }
 
 fn is_instance<T: 'static>(arg: &Atom) -> bool
@@ -59,7 +59,7 @@ where
 {
     let arg = args.get(0).ok_or_else(|| format!("Unary operation called without arguments"))?; 
     if let Some(arg) = arg.as_gnd::<T>() {
-        Ok(vec![Atom::rust_value(op(*arg))])
+        Ok(vec![Atom::value(op(*arg))])
     } else {
         Err(format!("Incorrect type of the unary operation argument: ({})", arg))
     }
@@ -74,7 +74,7 @@ where
     let arg1 = args.get(0).ok_or_else(|| format!("Binary operation called without arguments"))?; 
     let arg2 = args.get(1).ok_or_else(|| format!("Binary operation called with only argument"))?;
     if let (Some(arg1), Some(arg2)) = (arg1.as_gnd::<T1>(), arg2.as_gnd::<T2>()) {
-        Ok(vec![Atom::rust_value(op(*arg1, *arg2))])
+        Ok(vec![Atom::value(op(*arg1, *arg2))])
     } else {
         Err(format!("Incorrect type of the binary operation argument: ({}, {})", arg1, arg2))
     }
@@ -95,7 +95,7 @@ mod tests {
         // (+ 3 5)
         let expr = expr!({SUM}, {3}, {5});
 
-        assert_eq!(interpret(space, &expr), Ok(vec![Atom::rust_value(8)]));
+        assert_eq!(interpret(space, &expr), Ok(vec![Atom::value(8)]));
     }
 
     #[test]
@@ -104,7 +104,7 @@ mod tests {
         // (+ 4 (+ 3 5))
         let expr = expr!({SUM}, {4}, ({SUM}, {3}, {5}));
 
-        assert_eq!(interpret(space, &expr), Ok(vec![Atom::rust_value(12)]));
+        assert_eq!(interpret(space, &expr), Ok(vec![Atom::value(12)]));
     }
 
     #[test]
@@ -137,6 +137,6 @@ mod tests {
                    {1})));
 
         let expr = expr!("fac", {3});
-        assert_eq!(interpret(space, &expr), Ok(vec![Atom::rust_value(6)]));
+        assert_eq!(interpret(space, &expr), Ok(vec![Atom::value(6)]));
     }
 }

--- a/lib/src/common/arithmetics.rs
+++ b/lib/src/common/arithmetics.rs
@@ -55,7 +55,7 @@ fn is_instance<T: 'static>(arg: &Atom) -> bool
 fn unary_op<T, R>(args: &mut Vec<Atom>, op: fn(T) -> R) -> Result<Vec<Atom>, String>
 where
     T: 'static + Copy,
-    R: 'static + PartialEq + Clone + Debug + Sync,
+    R: AutoGroundedType,
 {
     let arg = args.get(0).ok_or_else(|| format!("Unary operation called without arguments"))?; 
     if let Some(arg) = arg.as_gnd::<T>() {
@@ -69,7 +69,7 @@ fn bin_op<T1, T2, R>(args: &mut Vec<Atom>, op: fn(T1, T2) -> R) -> Result<Vec<At
 where
     T1: 'static + Copy,
     T2: 'static + Copy,
-    R: 'static + PartialEq + Clone + Debug + Sync,
+    R: AutoGroundedType,
 {
     let arg1 = args.get(0).ok_or_else(|| format!("Binary operation called without arguments"))?; 
     let arg2 = args.get(1).ok_or_else(|| format!("Binary operation called with only argument"))?;

--- a/lib/src/common/arithmetics.rs
+++ b/lib/src/common/arithmetics.rs
@@ -27,7 +27,7 @@ def_bin_op!(AND, &&, bool, bool);
 def_bin_op!(OR, ||, bool, bool);
 def_op!(NOT, !, |_, args| unary_op(args, |a: bool| !a), "(-> bool bool)");
 
-// FIXME: find out correct types for nop and err
+// TODO: find out correct types for nop and err
 def_op!(NOP, nop, |_, _| Ok(vec![]), "(-> ())");
 def_op!(ERR, err, |_, _| Err("Error".into()), "(-> !)");
 

--- a/lib/src/common/mod.rs
+++ b/lib/src/common/mod.rs
@@ -34,7 +34,7 @@ impl Grounded for &'static Operation {
     }
 
     fn match_(&self, other: &Atom) -> matcher::MatchResultIter {
-        default_match(self, other)
+        match_by_equality(self, other)
     }
 }
 

--- a/lib/src/common/mod.rs
+++ b/lib/src/common/mod.rs
@@ -6,7 +6,7 @@ pub use arithmetics::*;
 
 use crate::*;
 use std::cell::RefCell;
-use std::fmt::Debug;
+use std::fmt::{Debug, Display};
 
 use crate::metta::metta_atom;
 
@@ -14,40 +14,48 @@ pub fn init_logger(is_test: bool) {
    let _ = env_logger::builder().is_test(is_test).try_init();
 }
 
-type OperationFn = fn(&dyn GroundedValue, &mut Vec<Atom>) -> Result<Vec<Atom>, String>;
-
 // TODO: move Operation and arithmetics under metta package as it uses metta_atom
 // Operation implements stateless operations as GroundedAtom.
 // Each operation has the only instance which is identified by unique name.
 // The instance has 'static lifetime and not copied when cloned.
 pub struct Operation {
     pub name: &'static str,
-    pub execute: OperationFn,
+    pub execute: fn(&Operation, &mut Vec<Atom>) -> Result<Vec<Atom>, String>,
     pub typ: &'static str,
 }
 
-impl GroundedValue for &'static Operation {
-    fn eq_gnd(&self, other: &dyn GroundedValue) -> bool {
-        match other.downcast_ref::<&Operation>() {
-            Some(o) => self.name.eq(o.name),
-            None => false,
-        }
+impl Grounded for &'static Operation {
+    fn type_(&self) -> Atom {
+        metta_atom(self.typ)
     }
 
-    fn clone_gnd(&self) -> Box<dyn GroundedValue> {
-        Box::new(*self)
+    fn execute(&self, args: &mut Vec<Atom>) -> Result<Vec<Atom>, String> {
+        (self.execute)(self, args)
+    }
+
+    fn match_(&self, other: &Atom) -> matcher::MatchResultIter {
+        default_match(self, other)
     }
 }
 
-impl Debug for &'static Operation {
+impl PartialEq for Operation {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+    }
+}
+
+impl Debug for Operation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Operation")
+            .field("name", &self.name)
+            .field("typ", &self.typ)
+            .finish()
+    }
+}
+
+impl Display for Operation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.name)
-    }
-}
-
-impl From<&'static Operation> for Atom {
-    fn from(op: &'static Operation) -> Self {
-        Atom::Grounded(GroundedAtom::new_function(op, op.execute, metta_atom(op.typ)))
     }
 }
 
@@ -56,6 +64,7 @@ impl From<&'static Operation> for Atom {
 // data even when kept type doesn't implement PartialEq. GndRefCell fixes this
 // by implementing dummy Display and implementing PartialEq via comparing
 // pointers to the data.
+#[derive(Clone, Debug)]
 pub struct GndRefCell<T>(RefCell<T>);
 
 impl<T> GndRefCell<T> {
@@ -73,7 +82,7 @@ impl<T> PartialEq for GndRefCell<T> {
     }
 }
 
-impl<T> Debug for GndRefCell<T> {
+impl<T> Display for GndRefCell<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "GndRefCell")
     }
@@ -83,40 +92,38 @@ impl<T> Debug for GndRefCell<T> {
 mod tests {
     use super::*;
 
-    fn test(_this: &dyn GroundedValue, _args: &mut Vec<Atom>) -> Result<Vec<Atom>, String> {
+    fn test_op(_this: &Operation, _args: &mut Vec<Atom>) -> Result<Vec<Atom>, String> {
         Ok(vec![])
     }
 
     #[test]
     fn test_operation_display() {
-        let op = &Operation{ name: "test", execute: test, typ: "(-> ())" };
-        assert_eq!(format!("{}", Atom::from(op)), "test");
+        let op = &Operation{ name: "test_op", execute: test_op, typ: "(-> ())" };
+        assert_eq!(format!("{}", Atom::gnd(op)), "test_op");
     }
 
-    // FIXME: have both Display and Debug for grounded atoms
-    #[ignore]
     #[test]
     fn test_operation_debug() {
-        let op = &Operation{ name: "test", execute: test, typ: "(-> ())" };
-        assert_eq!(format!("{:?}", Atom::from(op)), "test((-> ()))");
+        let op = &Operation{ name: "test_op", execute: test_op, typ: "(-> ())" };
+        assert_eq!(format!("{:?}", Atom::gnd(op)), "Grounded(CustomGrounded(Operation { name: \"test_op\", typ: \"(-> ())\" }))");
     }
 
     #[test]
     fn test_operation_eq() {
-        let a = Atom::from(&Operation{ name: "a", execute: test, typ: "(-> ())" });
-        let aa = Atom::from(&Operation{ name: "a", execute: test, typ: "(-> ())" });
-        let b = Atom::from(&Operation{ name: "b", execute: test, typ: "(-> ())" });
+        let a = Atom::gnd(&Operation{ name: "a", execute: test_op, typ: "(-> ())" });
+        let aa = Atom::gnd(&Operation{ name: "a", execute: test_op, typ: "(-> ())" });
+        let b = Atom::gnd(&Operation{ name: "b", execute: test_op, typ: "(-> ())" });
         assert!(a == aa);
         assert!(a != b);
     }
 
     #[test]
     fn test_operation_clone() {
-        let opa = Atom::from(&Operation{ name: "a", execute: test, typ: "(-> ())" });
+        let opa = Atom::gnd(&Operation{ name: "a", execute: test_op, typ: "(-> ())" });
         let opc = opa.clone();
-        if let (Atom::Grounded(boxa), Atom::Grounded(boxc)) = (opa, opc) {
-            let ptra: *const Operation = *(boxa.downcast_ref::<&Operation>().unwrap());
-            let ptrc: *const Operation = *(boxc.downcast_ref::<&Operation>().unwrap());
+        if let (Some(refa), Some(refc)) = (opa.as_gnd::<&Operation>(), opc.as_gnd::<&Operation>()) {
+            let ptra: *const Operation = *refa; 
+            let ptrc: *const Operation = *refc;
             assert_eq!(ptra, ptrc);
         } else {
             assert!(false);

--- a/lib/src/common/mod.rs
+++ b/lib/src/common/mod.rs
@@ -105,7 +105,7 @@ mod tests {
     #[test]
     fn test_operation_debug() {
         let op = &Operation{ name: "test_op", execute: test_op, typ: "(-> ())" };
-        assert_eq!(format!("{:?}", Atom::gnd(op)), "Grounded(CustomGrounded(Operation { name: \"test_op\", typ: \"(-> ())\" }))");
+        assert_eq!(format!("{:?}", Atom::gnd(op)), "Grounded(CustomGroundedAtom(Operation { name: \"test_op\", typ: \"(-> ())\" }))");
     }
 
     #[test]

--- a/lib/src/metta/text.rs
+++ b/lib/src/metta/text.rs
@@ -187,7 +187,7 @@ mod tests {
     fn test_text_recognize_full_token() {
         let mut text = SExprSpace::new();
         text.register_token(Regex::new(r"b").unwrap(),
-            |_| Atom::rust_value("b"));
+            |_| Atom::value("b"));
 
         text.add_str("ab").unwrap();
         let space = GroundingSpace::from(&text);
@@ -199,7 +199,7 @@ mod tests {
     fn test_text_gnd() {
         let mut text = SExprSpace::new();
         text.register_token(Regex::new(r"\d+").unwrap(),
-            |token| Atom::rust_value(token.parse::<i32>().unwrap()));
+            |token| Atom::value(token.parse::<i32>().unwrap()));
 
         text.add_str("(3d 42)").unwrap();
         let space = GroundingSpace::from(&text);

--- a/lib/src/space/grounding.rs
+++ b/lib/src/space/grounding.rs
@@ -112,7 +112,7 @@ impl GroundingSpace {
             for res in next.do_match(pattern) {
                 let bindings = matcher::apply_bindings_to_bindings(&res.candidate_bindings, &res.pattern_bindings);
                 if let Ok(bindings) = bindings {
-                    // FIXME: why compiler cannot see Display is implemented for Bindings
+                    // TODO: why compiler cannot see Display is implemented for Bindings
                     log::debug!("single_query: push result: {}, bindings: {:?}", next, bindings);
                     result.push(bindings);
                 }

--- a/lib/src/space/grounding.rs
+++ b/lib/src/space/grounding.rs
@@ -109,7 +109,7 @@ impl GroundingSpace {
         log::debug!("single_query: pattern: {}", pattern);
         let mut result = Vec::new();
         for next in &(*self.borrow_vec()) {
-            for res in next.do_match(pattern) {
+            for res in next.match_(pattern) {
                 let bindings = matcher::apply_bindings_to_bindings(&res.candidate_bindings, &res.pattern_bindings);
                 if let Ok(bindings) = bindings {
                     // TODO: why compiler cannot see Display is implemented for Bindings

--- a/python/hyperonpy.cpp
+++ b/python/hyperonpy.cpp
@@ -211,7 +211,7 @@ PYBIND11_MODULE(hyperonpy, m) {
 			return static_cast<GroundedObject const*>(atom_get_object(atom.ptr))->pyobj;
 		}, "Get object of the grounded atom");
 	m.def("atom_get_grounded_type", [](CAtom atom) {
-			return CAtom(atom_copy(atom_get_grounded_type(atom.ptr)));
+			return CAtom(atom_get_grounded_type(atom.ptr));
 		}, "Get object of the grounded atom");
 	m.def("atom_get_children", [](CAtom atom) {
 			py::list atoms;


### PR DESCRIPTION
The main idea is to keep an implementation of the grounded atom behaviour inside type rather than a type instance. To allow default behaviour overriding two wrappers for grounded values are introduced:
- `AutoGroundedAtom<T>` for intrinsic Rust types;
- `CustomGroundedAtom<T>` for customized grounded types.

Both of them implement `GroundedAtom` trait which implements type erasure and has all necessary methods to implement traits required by Atom: `PartialEq`, `Clone`, `Debug`, `Display`. `AutoGroundedAtom<T>` implements default behaviour (match via equality, no execution) and doesn't expect any specific traits implemented. `CustomGroundedAtom<T>` expects `Grounded` trait to be implemented and delegates calls to it.

Both grounded atom wrappers expect grounded type implements `PartialEq`, `Clone`, `Debug`, `Sync` and `Any` traits and use them to implement `eq_gnd()`, `clone_gnd()` and `as_any_...()` methods. This allows reusing standard behaviour as much as possible. `CustomGroundedAtom<T>` also expects `Display` is implemented. `AutoGroundedAtom<T>` implements `Display` via `Debug` because not all standard Rust types implement `Display` (see `HashMap` for example). `as_any_...()` method are used to transparently convert grounded atom to original Rust type.

`Grounded` trait contains three methods to implement customized behaviour for grounded values:
- `type_()` to return MeTTa type of the atom;
- `execute()` to represent functions as atoms;
- `match_()` to implement custom matching behaviour.

`match_by_equality()` method allows reusing default `match_()` implementation in 3rd party code when it is not needed to be customized. `execute_not_executable()` similar implementation for the `execute()` method.
