### PR TITLE
Type based interpreter PR follow up

### DIFF
--- a/python/tests/test_grounded_type.py
+++ b/python/tests/test_grounded_type.py
@@ -31,3 +31,16 @@ class GroundedTypeTest(unittest.TestCase):
             metta.interpret("(> 1 1)")[0].get_grounded_type(),
             metta.interpret("(+ 1 1)")[0].get_grounded_type())
 
+    # TODO: For now OperationAtom without type has Undefined type. We discussed
+    # that it would be nice to have something like *args in the future. The
+    # type of untyped operations is yet another example showing this can be
+    # useful. So, the type of untyped operations might become something like
+    # (-> *Undefined Undefined) in the future.
+    @unittest.skip("Behavior to be defined")
+    def test_undefined_operation_type(self):
+        metta = MeTTa()
+        metta.add_atom("untyped", ValueAtom(None))
+        metta.add_atom("untop", OperationAtom("untop", lambda: None))
+        self.assertNotEqual(metta.parse_single("untop").get_grounded_type(),
+                metta.parse_single("untyped").get_grounded_type())
+

--- a/python/tests/test_minelogy.py
+++ b/python/tests/test_minelogy.py
@@ -112,10 +112,10 @@ class MinelogyTest(unittest.TestCase):
             ''')
         output = utils.interpret('(how-get cobblestone)')
         self.assertEqual(repr(output),
-            '[(let $t (get-ingredients cobblestone) (do-craft $t)), (do-mine ((: stone type) (: stone variant)))]')
+            '[(do-mine ((: stone type) (: stone variant)))]')
         output = utils.interpret('(how-get stick)')
         self.assertEqual(repr(output),
-            '[(do-craft ((: planks type) (: $x variant) (: 2 quantity))), (let $t (get-mine-block stick) (do-mine $t))]')
+            '[(do-craft ((: planks type) (: $x variant) (: 2 quantity)))]')
 
     def test_minelogy_wtypes(self):
         # TODO: revisit this example, when types are automatically checked


### PR DESCRIPTION
Fixes comments for #95.
Added TODO and unit test for the undefined `OperationAtom` type.
Fixed behavior for the case where the interpreter returned empty result for an argument of the expression.