### PR TITLE
Use Atom instead of AtomType in type related API

### DIFF
--- a/c/src/atom.rs
+++ b/c/src/atom.rs
@@ -78,7 +78,7 @@ pub unsafe extern "C" fn atom_get_type(atom: *const atom_t) -> atom_type_t {
 #[no_mangle]
 pub extern "C" fn atom_to_str(atom: *const atom_t, callback: c_str_callback_t, context: *mut c_void) {
     let atom = unsafe{ &(*atom).atom };
-    callback(str_as_cstr(format!("{}", atom).as_str()).as_ptr(), context);
+    callback(str_as_cstr(atom.to_string().as_str()).as_ptr(), context);
 }
 
 #[no_mangle]

--- a/c/src/metta.rs
+++ b/c/src/metta.rs
@@ -1,4 +1,3 @@
-use hyperon::metta::*;
 use hyperon::metta::text::*;
 use hyperon::metta::interpreter;
 use hyperon::metta::interpreter::InterpretedAtom;
@@ -113,7 +112,7 @@ pub unsafe extern "C" fn sexpr_space_into_grounding_space(sexpr: *const sexpr_sp
 }
 
 #[no_mangle]
-pub static ATOM_TYPE_UNDEFINED: &atom_t = &atom_t{ atom: UNDEFINED_TYPE };
+pub static ATOM_TYPE_UNDEFINED: &atom_t = &atom_t{ atom: hyperon::metta::ATOM_TYPE_UNDEFINED };
 
 #[no_mangle]
 pub unsafe extern "C" fn check_type(space: *const grounding_space_t, atom: *const atom_t, typ: *const atom_t) -> bool {

--- a/c/src/metta.rs
+++ b/c/src/metta.rs
@@ -1,5 +1,5 @@
+use hyperon::metta::*;
 use hyperon::metta::text::*;
-use hyperon::metta::types::AtomType;
 use hyperon::metta::interpreter;
 use hyperon::metta::interpreter::InterpretedAtom;
 use hyperon::common::plan::StepResult;
@@ -112,29 +112,12 @@ pub unsafe extern "C" fn sexpr_space_into_grounding_space(sexpr: *const sexpr_sp
     (*sexpr).space.into_grounding_space(&mut (*gnd).space);
 }
 
-pub struct atom_type_t {
-    pub typ: AtomType,
-}
+#[no_mangle]
+pub static ATOM_TYPE_UNDEFINED: &atom_t = &atom_t{ atom: UNDEFINED_TYPE };
 
 #[no_mangle]
-pub static ATOM_TYPE_UNDEFINED: &atom_type_t = &atom_type_t{ typ: AtomType::Undefined };
-
-#[no_mangle]
-pub unsafe extern "C" fn atom_type_specific(atom: *mut atom_t) -> *mut atom_type_t {
-    let c_atom = Box::from_raw(atom);
-    Box::into_raw(Box::new(atom_type_t{ typ: AtomType::Specific(c_atom.atom) })) 
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn atom_type_free(typ: *const atom_type_t) {
-    if typ != ATOM_TYPE_UNDEFINED {
-        drop(Box::from_raw(typ as *mut atom_type_t)) 
-    }
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn check_type(space: *const grounding_space_t, atom: *const atom_t, typ: *const atom_type_t) -> bool {
-    hyperon::metta::types::check_type(&(*space).space, &(*atom).atom, &(*typ).typ)
+pub unsafe extern "C" fn check_type(space: *const grounding_space_t, atom: *const atom_t, typ: *const atom_t) -> bool {
+    hyperon::metta::types::check_type(&(*space).space, &(*atom).atom, &(*typ).atom)
 }
 
 #[no_mangle]

--- a/c/src/util.rs
+++ b/c/src/util.rs
@@ -27,6 +27,6 @@ pub fn cstr_into_string(s: *const c_char) -> String {
     String::from(cstr_as_str(s))
 }
 
-pub fn str_as_cstr<'a>(s: &str) -> CString {
+pub fn str_as_cstr(s: &str) -> CString {
     CString::new(s).expect("CString::new failed")
 }

--- a/c/tests/check_types.c
+++ b/c/tests/check_types.c
@@ -14,14 +14,14 @@ START_TEST (test_check_type)
 {
 	grounding_space_t* space = grounding_space_new();
 	grounding_space_add(space, expr(atom_sym(":"), atom_sym("do"), atom_sym("Verb"), 0));
-    atom_type_t* verb = atom_type_specific(atom_sym("Verb"));
+    atom_t* verb = atom_sym("Verb");
 
     atom_t* nonsense = atom_sym("nonsense");
     ck_assert(check_type(space, nonsense, ATOM_TYPE_UNDEFINED));
     ck_assert(check_type(space, nonsense, verb));
     atom_free(nonsense);
 
-    atom_type_free(verb);
+    atom_free(verb);
 }
 END_TEST
 

--- a/lib/src/common/collections.rs
+++ b/lib/src/common/collections.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 #[derive(Clone)]
 pub struct ListMap<K, V> {
     list: Vec<(K, V)>,
@@ -23,5 +25,40 @@ impl<K: PartialEq, V> ListMap<K, V> {
 
     pub fn clear(&mut self) {
         self.list.clear()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum ImmutableString {
+    Allocated(String),
+    Literal(&'static str),
+}
+
+impl ImmutableString {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Allocated(name) => name.as_str(),
+            Self::Literal(name) => name,
+        }
+    }
+}
+
+impl PartialEq for ImmutableString {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl Eq for ImmutableString {}
+
+impl std::hash::Hash for ImmutableString {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.as_str().hash(state)
+    }
+}
+
+impl Display for ImmutableString {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
     }
 }

--- a/lib/src/metta/interpreter.rs
+++ b/lib/src/metta/interpreter.rs
@@ -133,7 +133,7 @@ pub fn interpret_init(space: GroundingSpace, expr: &Atom) -> StepResult<Vec<Inte
     let context = InterpreterContextRef::new(space);
     interpret_as_type_plan(context,
         InterpretedAtom(expr.clone(), Bindings::new()),
-        UNDEFINED_TYPE)
+        ATOM_TYPE_UNDEFINED)
 }
 
 /// Perform next step of the interpretation plan and return the result. Panics
@@ -337,7 +337,7 @@ fn get_expr_mut(atom: &mut Atom) -> &mut ExpressionAtom {
 fn interpret_expression_as_type_op(context: InterpreterContextRef,
         input: InterpretedAtom, op_typ: Atom, ret_typ: Atom) -> NoInputPlan {
     log::debug!("interpret_expression_as_type_op: input: {}, operation type: {}, expected return type: {}", input, op_typ, ret_typ);
-    if ret_typ == ATOM_TYPE || ret_typ == EXPRESSION_TYPE {
+    if ret_typ == ATOM_TYPE_ATOM || ret_typ == ATOM_TYPE_EXPRESSION {
         Box::new(StepResult::ret(vec![input]))
     } else if is_func(&op_typ) {
         let InterpretedAtom(input_atom, mut input_bindings) = input;
@@ -387,7 +387,7 @@ fn interpret_expression_as_type_op(context: InterpreterContextRef,
                         Box::new(SequencePlan::new(
                             interpret_as_type_plan(context.clone(),
                                 InterpretedAtom(arg.clone(), result.bindings().clone()),
-                                UNDEFINED_TYPE),
+                                ATOM_TYPE_UNDEFINED),
                             insert_reducted_arg_plan(result, expr_idx)))
                     }).collect();
                     StepResult::execute(AlternativeInterpretationsPlan::new(arg, alternatives))
@@ -508,7 +508,7 @@ fn execute_op(context: InterpreterContextRef, input: InterpretedAtom) -> StepRes
                         } else {
                             make_alternives_plan(input, results, move |result| {
                                 interpret_as_type_plan(context.clone(),
-                                    result, UNDEFINED_TYPE)
+                                    result, ATOM_TYPE_UNDEFINED)
                             })
                         }
                     },
@@ -554,7 +554,7 @@ fn match_op(context: InterpreterContextRef, input: InterpretedAtom) -> StepResul
         .map(|(result, bindings)| InterpretedAtom(result, bindings.unwrap()))
         .collect();
     make_alternives_plan(input, results, move |result| {
-        interpret_as_type_plan(context.clone(), result, UNDEFINED_TYPE)
+        interpret_as_type_plan(context.clone(), result, ATOM_TYPE_UNDEFINED)
     })
 }
 

--- a/lib/src/metta/interpreter.rs
+++ b/lib/src/metta/interpreter.rs
@@ -68,6 +68,7 @@ use crate::atom::subexpr::*;
 use crate::atom::matcher::*;
 use crate::space::grounding::*;
 use crate::common::collections::ListMap;
+use crate::metta::*;
 use crate::metta::types::{AtomType, is_func, get_arg_types, check_type_bindings,
     get_reducted_types, match_reducted_types};
 
@@ -75,9 +76,6 @@ use std::ops::Deref;
 use std::rc::Rc;
 use std::cell::RefCell;
 use std::fmt::{Debug, Display, Formatter};
-
-#[inline]
-fn equal_symbol() -> Atom { sym!("=") }
 
 /// Result of atom interpretation plus variable bindings found
 #[derive(Clone, PartialEq)]
@@ -343,8 +341,8 @@ fn get_expr_mut(atom: &mut Atom) -> &mut ExpressionAtom {
 fn interpret_expression_as_type_op(context: InterpreterContextRef,
         input: InterpretedAtom, op_typ: Atom, ret_typ: AtomType) -> NoInputPlan {
     log::debug!("interpret_expression_as_type_op: input: {}, operation type: {}, expected return type: {}", input, op_typ, ret_typ);
-    if ret_typ == AtomType::Specific(Atom::sym("Atom")) ||
-            ret_typ == AtomType::Specific(Atom::sym("Expression")) {
+    if ret_typ == AtomType::Specific(ATOM_TYPE) ||
+            ret_typ == AtomType::Specific(EXPRESSION_TYPE) {
         Box::new(StepResult::ret(vec![input]))
     } else if is_func(&op_typ) {
         let InterpretedAtom(input_atom, mut input_bindings) = input;
@@ -539,7 +537,7 @@ fn match_op(context: InterpreterContextRef, input: InterpretedAtom) -> StepResul
     let var_x = VariableAtom::new("%X%");
     // TODO: unique variable?
     let atom_x = Atom::Variable(var_x.clone());
-    let query = Atom::expr(vec![equal_symbol(), input.atom().clone(), atom_x]);
+    let query = Atom::expr(vec![EQUAL_SYMBOL, input.atom().clone(), atom_x]);
     let mut local_bindings = context.space.query(&query);
     let results: Vec<InterpretedAtom> = local_bindings
         .drain(0..)
@@ -656,7 +654,6 @@ impl<T: Debug> Debug for AlternativeInterpretationsPlan<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::metta::*;
     
     #[test]
     fn test_match_all() {

--- a/lib/src/metta/interpreter.rs
+++ b/lib/src/metta/interpreter.rs
@@ -69,7 +69,7 @@ use crate::atom::matcher::*;
 use crate::space::grounding::*;
 use crate::common::collections::ListMap;
 use crate::metta::*;
-use crate::metta::types::{AtomType, is_func, get_arg_types, check_type_bindings,
+use crate::metta::types::{is_func, get_arg_types, check_type_bindings,
     get_reducted_types, match_reducted_types};
 
 use std::ops::Deref;
@@ -133,7 +133,7 @@ pub fn interpret_init(space: GroundingSpace, expr: &Atom) -> StepResult<Vec<Inte
     let context = InterpreterContextRef::new(space);
     interpret_as_type_plan(context,
         InterpretedAtom(expr.clone(), Bindings::new()),
-        AtomType::Undefined)
+        UNDEFINED_TYPE)
 }
 
 /// Perform next step of the interpretation plan and return the result. Panics
@@ -255,7 +255,7 @@ fn has_grounded_sub_expr(expr: &Atom) -> bool {
 }
 
 fn interpret_as_type_plan(context: InterpreterContextRef,
-        input: InterpretedAtom, typ: AtomType) -> StepResult<Results> {
+        input: InterpretedAtom, typ: Atom) -> StepResult<Results> {
     log::debug!("interpret_as_type_plan: input: {}, type: {}", input, typ);
     match input.atom() {
         Atom::Symbol(_) | Atom::Grounded(_) =>
@@ -279,13 +279,9 @@ fn interpret_as_type_plan(context: InterpreterContextRef,
 }
 
 fn cast_atom_to_type_plan(context: InterpreterContextRef,
-        input: InterpretedAtom, typ: AtomType) -> StepResult<Results> {
+        input: InterpretedAtom, typ: Atom) -> StepResult<Results> {
     // TODO: implement this via interpreting of the (:cast atom typ) expression
-    let typ = if let AtomType::Specific(typ) = typ {
-            AtomType::Specific(apply_bindings_to_atom(&typ, input.bindings()))
-        } else {
-            typ
-        };
+    let typ = apply_bindings_to_atom(&typ, input.bindings());
     let mut results = check_type_bindings(&context.space, input.atom(), &typ);
     log::debug!("cast_atom_to_type_plan: type check results: {:?}", results);
     if !results.is_empty() {
@@ -314,7 +310,7 @@ fn get_type_of_atom_plan(context: InterpreterContextRef, atom: Atom) -> StepResu
 }
 
 fn interpret_expression_as_type_plan(context: InterpreterContextRef,
-        input: InterpretedAtom, typ: AtomType) -> OperatorPlan<Vec<Atom>, Results> {
+        input: InterpretedAtom, typ: Atom) -> OperatorPlan<Vec<Atom>, Results> {
     let descr = format!("form alternative plans for expression {} using types", input);
     OperatorPlan::new(move |op_types: Vec<Atom>| {
         make_alternives_plan(input.clone(), op_types, move |op_typ| {
@@ -339,17 +335,16 @@ fn get_expr_mut(atom: &mut Atom) -> &mut ExpressionAtom {
 }
 
 fn interpret_expression_as_type_op(context: InterpreterContextRef,
-        input: InterpretedAtom, op_typ: Atom, ret_typ: AtomType) -> NoInputPlan {
+        input: InterpretedAtom, op_typ: Atom, ret_typ: Atom) -> NoInputPlan {
     log::debug!("interpret_expression_as_type_op: input: {}, operation type: {}, expected return type: {}", input, op_typ, ret_typ);
-    if ret_typ == AtomType::Specific(ATOM_TYPE) ||
-            ret_typ == AtomType::Specific(EXPRESSION_TYPE) {
+    if ret_typ == ATOM_TYPE || ret_typ == EXPRESSION_TYPE {
         Box::new(StepResult::ret(vec![input]))
     } else if is_func(&op_typ) {
         let InterpretedAtom(input_atom, mut input_bindings) = input;
         let expr = get_expr(&input_atom);
         let (op_arg_types, op_ret_typ) = get_arg_types(&op_typ);
         // TODO: supertypes should be checked as well
-        if !ret_typ.map_or(|typ| match_reducted_types(op_ret_typ, typ, &mut input_bindings), true) {
+        if !match_reducted_types(op_ret_typ, &ret_typ, &mut input_bindings) {
             Box::new(StepResult::err(format!("Operation returns wrong type: {}, expected: {}", op_ret_typ, ret_typ)))
         } else if op_arg_types.len() != (expr.children().len() - 1) {
             Box::new(StepResult::err(format!("Operation arity is not equal to call arity: operation type, {}, call: {}", op_typ, expr)))
@@ -370,7 +365,7 @@ fn interpret_expression_as_type_op(context: InterpreterContextRef,
                             Box::new(SequencePlan::new(
                                 interpret_as_type_plan(context.clone(),
                                     InterpretedAtom(arg.clone(), result.bindings().clone()),
-                                    AtomType::Specific(arg_typ)),
+                                    arg_typ),
                                 insert_reducted_arg_plan(result, expr_idx)))
                         }).collect();
                         StepResult::execute(AlternativeInterpretationsPlan::new(arg, alternatives))
@@ -392,7 +387,7 @@ fn interpret_expression_as_type_op(context: InterpreterContextRef,
                         Box::new(SequencePlan::new(
                             interpret_as_type_plan(context.clone(),
                                 InterpretedAtom(arg.clone(), result.bindings().clone()),
-                                AtomType::Undefined),
+                                UNDEFINED_TYPE),
                             insert_reducted_arg_plan(result, expr_idx)))
                     }).collect();
                     StepResult::execute(AlternativeInterpretationsPlan::new(arg, alternatives))
@@ -513,7 +508,7 @@ fn execute_op(context: InterpreterContextRef, input: InterpretedAtom) -> StepRes
                         } else {
                             make_alternives_plan(input, results, move |result| {
                                 interpret_as_type_plan(context.clone(),
-                                    result, AtomType::Undefined)
+                                    result, UNDEFINED_TYPE)
                             })
                         }
                     },
@@ -559,7 +554,7 @@ fn match_op(context: InterpreterContextRef, input: InterpretedAtom) -> StepResul
         .map(|(result, bindings)| InterpretedAtom(result, bindings.unwrap()))
         .collect();
     make_alternives_plan(input, results, move |result| {
-        interpret_as_type_plan(context.clone(), result, AtomType::Undefined)
+        interpret_as_type_plan(context.clone(), result, UNDEFINED_TYPE)
     })
 }
 

--- a/lib/src/metta/mod.rs
+++ b/lib/src/metta/mod.rs
@@ -4,11 +4,25 @@ pub mod types;
 
 mod examples;
 
-use crate::Atom;
-use crate::space::grounding::GroundingSpace;
 use text::{SExprParser, Tokenizer, SExprSpace};
-use crate::common::*;
 use regex::Regex;
+
+use crate::*;
+use crate::common::*;
+use crate::space::grounding::GroundingSpace;
+
+pub const UNDEFINED_TYPE : Atom = sym!("%Undefined%");
+pub const FUNCTION_TYPE : Atom = sym!("->");
+pub const TYPE_TYPE : Atom = sym!("Type");
+pub const ATOM_TYPE : Atom = sym!("Atom");
+pub const SYMBOL_TYPE : Atom = sym!("Symbol");
+pub const VARIABLE_TYPE : Atom = sym!("Variable");
+pub const EXPRESSION_TYPE : Atom = sym!("Expression");
+pub const GROUNDED_TYPE : Atom = sym!("Grounded");
+
+pub const HAS_TYPE_SYMBOL : Atom = sym!(":");
+pub const SUB_TYPE_SYMBOL : Atom = sym!(":<");
+pub const EQUAL_SYMBOL : Atom = sym!("=");
 
 pub fn metta_space(text: &str) -> GroundingSpace {
     let mut parser = SExprSpace::new(common_tokenizer());

--- a/lib/src/metta/mod.rs
+++ b/lib/src/metta/mod.rs
@@ -11,14 +11,14 @@ use crate::*;
 use crate::common::*;
 use crate::space::grounding::GroundingSpace;
 
-pub const UNDEFINED_TYPE : Atom = sym!("%Undefined%");
-pub const FUNCTION_TYPE : Atom = sym!("->");
-pub const TYPE_TYPE : Atom = sym!("Type");
-pub const ATOM_TYPE : Atom = sym!("Atom");
-pub const SYMBOL_TYPE : Atom = sym!("Symbol");
-pub const VARIABLE_TYPE : Atom = sym!("Variable");
-pub const EXPRESSION_TYPE : Atom = sym!("Expression");
-pub const GROUNDED_TYPE : Atom = sym!("Grounded");
+pub const ATOM_TYPE_UNDEFINED : Atom = sym!("%Undefined%");
+pub const ATOM_TYPE_FUNCTION : Atom = sym!("->");
+pub const ATOM_TYPE_TYPE : Atom = sym!("Type");
+pub const ATOM_TYPE_ATOM : Atom = sym!("Atom");
+pub const ATOM_TYPE_SYMBOL : Atom = sym!("Symbol");
+pub const ATOM_TYPE_VARIABLE : Atom = sym!("Variable");
+pub const ATOM_TYPE_EXPRESSION : Atom = sym!("Expression");
+pub const ATOM_TYPE_GROUNDED : Atom = sym!("Grounded");
 
 pub const HAS_TYPE_SYMBOL : Atom = sym!(":");
 pub const SUB_TYPE_SYMBOL : Atom = sym!(":<");

--- a/lib/src/metta/types.rs
+++ b/lib/src/metta/types.rs
@@ -1,14 +1,8 @@
-use crate::*;
+use super::*;
 use crate::atom::matcher::{Bindings, apply_bindings_to_atom};
 use crate::space::grounding::GroundingSpace;
 
 use std::fmt::{Debug, Display};
-
-pub const UNDEFINED_TYPE : Atom = sym!("%Undefined%");
-pub const FUNCTION_TYPE : Atom = sym!("->");
-
-pub const HAS_TYPE_SYMBOL : Atom = sym!(":");
-pub const SUB_TYPE_SYMBOL : Atom = sym!(":<");
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum AtomType {

--- a/python/hyperon/__init__.py
+++ b/python/hyperon/__init__.py
@@ -69,7 +69,7 @@ class ExpressionAtom(Atom):
 def E(*args):
     return ExpressionAtom(hp.atom_expr([atom.catom for atom in args]))
 
-UNDEFINED_TYPE = S("%Undefined%")
+ATOM_TYPE_UNDEFINED = S("%Undefined%")
 
 class GroundedAtom(Atom):
 
@@ -82,12 +82,12 @@ class GroundedAtom(Atom):
     def get_grounded_type(self):
         return Atom._from_catom(hp.atom_get_grounded_type(self.catom))
 
-def G(object, type=UNDEFINED_TYPE):
+def G(object, type=ATOM_TYPE_UNDEFINED):
     return GroundedAtom(hp.atom_gnd(object, type.catom))
 
 def call_execute_on_grounded_atom(gnd, typ, args):
-    # ... if hp.atom_to_str(typ) == UNDEFINED_TYPE
-    res_typ = UNDEFINED_TYPE if hp.atom_get_type(typ) != AtomKind.EXPR \
+    # ... if hp.atom_to_str(typ) == ATOM_TYPE_UNDEFINED
+    res_typ = ATOM_TYPE_UNDEFINED if hp.atom_get_type(typ) != AtomKind.EXPR \
         else Atom._from_catom(hp.atom_get_children(typ)[-1])
     args = [Atom._from_catom(catom) for catom in args]
     return gnd.execute(*args, res_typ=res_typ)
@@ -121,7 +121,7 @@ class OperationObject(ConstGroundedObject):
         self.op = op
         self.unwrap = unwrap
 
-    def execute(self, *args, res_typ=UNDEFINED_TYPE):
+    def execute(self, *args, res_typ=ATOM_TYPE_UNDEFINED):
         # type-check?
         if self.unwrap:
             args = [arg.get_object().value for arg in args]
@@ -138,7 +138,7 @@ class OperationObject(ConstGroundedObject):
 
 def type_sugar(type_names):
     if type_names is None:
-        return UNDEFINED_TYPE
+        return ATOM_TYPE_UNDEFINED
     if isinstance(type_names, list):
         return E(S("->"), *[type_sugar(n) for n in type_names])
     if isinstance(type_names, str):

--- a/python/hyperonpy.cpp
+++ b/python/hyperonpy.cpp
@@ -17,7 +17,6 @@ using CVecAtom = CPtr<vec_atom_t>;
 using CGroundingSpace = CPtr<grounding_space_t>;
 using CTokenizer = CPtr<tokenizer_t>;
 using CSExprSpace = CPtr<sexpr_space_t>;
-using CAtomType = CPtr<const atom_type_t>;
 using CStepResult = CPtr<step_result_t>;
 
 static void copy_to_string(char const* cstr, void* context) {
@@ -301,13 +300,7 @@ PYBIND11_MODULE(hyperonpy, m) {
 			return atoms;
 		}, "Return result of the interpretation");
 
-	py::class_<CAtomType>(m, "CAtomType")
-		.def_property_readonly_static("UNDEFINED", [](py::object) { return CAtomType(ATOM_TYPE_UNDEFINED); }, "Undefined type instance");
-	m.def("atom_type_specific", [](CAtom atom) { return CAtomType(atom_type_specific(atom_clone(atom.ptr))); },
-			"Return specific type instance");
-	m.def("atom_type_free", [](CAtomType type) { atom_type_free(type.ptr); },
-			"Deallocate type instance");
-	m.def("check_type", [](CGroundingSpace space, CAtom atom, CAtomType type) { 
+	m.def("check_type", [](CGroundingSpace space, CAtom atom, CAtom type) { 
 			return check_type(space.ptr, atom.ptr, type.ptr);
 		}, "Check if atom is an instance of the passed type");
 	m.def("validate_atom", [](CGroundingSpace space, CAtom expr) { 

--- a/python/tests/test_atom.py
+++ b/python/tests/test_atom.py
@@ -116,7 +116,7 @@ class AtomTest(unittest.TestCase):
         space = GroundingSpace()
         interpreter = Interpreter(space, E(x2Atom, ValueAtom(1)))
         self.assertEqual(str(interpreter.get_step_result()),
-                "return [" + UNDEFINED_TYPE.get_name() + "] then form alternative plans for expression (*2 1) using types")
+                "return [" + ATOM_TYPE_UNDEFINED.get_name() + "] then form alternative plans for expression (*2 1) using types")
 
 # No unwrap
 def x2_op(atom):

--- a/python/tests/test_atom.py
+++ b/python/tests/test_atom.py
@@ -116,7 +116,7 @@ class AtomTest(unittest.TestCase):
         space = GroundingSpace()
         interpreter = Interpreter(space, E(x2Atom, ValueAtom(1)))
         self.assertEqual(str(interpreter.get_step_result()),
-                "return [" + GroundedAtom.UNDEFINED_TYPE.get_name() + "] then form alternative plans for expression (*2 1) using types")
+                "return [" + UNDEFINED_TYPE.get_name() + "] then form alternative plans for expression (*2 1) using types")
 
 # No unwrap
 def x2_op(atom):

--- a/python/tests/test_atom_type.py
+++ b/python/tests/test_atom_type.py
@@ -8,7 +8,7 @@ class AtomTest(unittest.TestCase):
         space = GroundingSpace()
         space.add_atom(E(S(":"), S("a"), S("A")))
 
-        self.assertTrue(check_type(space, S("a"), UNDEFINED_TYPE))
+        self.assertTrue(check_type(space, S("a"), ATOM_TYPE_UNDEFINED))
         self.assertTrue(check_type(space, S("a"), S("A")))
         self.assertFalse(check_type(space, S("a"), S("B")))
 

--- a/python/tests/test_atom_type.py
+++ b/python/tests/test_atom_type.py
@@ -7,10 +7,10 @@ class AtomTest(unittest.TestCase):
     def test_check_type(self):
         space = GroundingSpace()
         space.add_atom(E(S(":"), S("a"), S("A")))
-        
-        self.assertTrue(check_type(space, S("a"), AtomType.undefined()))
-        self.assertTrue(check_type(space, S("a"), AtomType.specific(S("A"))))
-        self.assertFalse(check_type(space, S("a"), AtomType.specific(S("B"))))
+
+        self.assertTrue(check_type(space, S("a"), UNDEFINED_TYPE))
+        self.assertTrue(check_type(space, S("a"), S("A")))
+        self.assertFalse(check_type(space, S("a"), S("B")))
 
     def test_validate_atom(self):
         space = GroundingSpace()


### PR DESCRIPTION
`AtomType` type is removed and replaced by `Atom`. Reserved atoms are exported as constants from `hyperon::metta` crate.
`ImmutableString` is introduced to represent either static or dynamically allocated strings. It is used to keep name inside `SymbolAtom` in order to allow creating `const` and `static` instances of `Atom::Symbol`.