### PR TITLE
Fix expressions matching

### DIFF
--- a/lib/src/atom/matcher.rs
+++ b/lib/src/atom/matcher.rs
@@ -9,7 +9,7 @@ macro_rules! bind {
 
 use super::*;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, BTreeMap};
 use delegate::delegate;
 
 #[derive(Clone, PartialEq, Eq)]
@@ -46,15 +46,15 @@ impl Bindings {
         if !prev.iter().all(|(k, v)| !next.0.contains_key(k)
                 || next.0[k] == *v
                 || matches!(next.0[k], Atom::Variable(_))) {
-            log::trace!("Bindings::merge: {} ^ {} = None", prev, next);
+            log::trace!("Bindings::merge: {} ^ {} -> None", prev, next);
             None
         } else {
             let mut res = Bindings::new();
             prev.iter().for_each(|(k, v)| { res.insert(k.clone(), v.clone()); });
             next.iter().filter(|(k, _)| !prev.0.contains_key(k))
                 .for_each(|(k, v)| { res.insert(k.clone(), v.clone()); });
-            log::trace!("Bindings::merge: {} ^ {} = {}", prev, next, res);
-            Some(res) 
+            log::trace!("Bindings::merge: {} ^ {} -> {}", prev, next, res);
+            Some(res)
         }
     }
 
@@ -67,6 +67,14 @@ impl Bindings {
     pub fn filter<F>(&mut self, mut pred: F)
         where F: FnMut(&VariableAtom, &Atom) -> bool {
         self.0 = self.0.drain().filter(|(k, v)| pred(k, v)).collect();
+    }
+
+    fn into_variable_matcher(self) -> VariableMatcher {
+        let mut var_matcher = VariableMatcher::new();
+        for (k, v) in self.0 {
+            var_matcher.add_var_binding(Var::Pattern(k), &v);
+        }
+        var_matcher
     }
 }
 
@@ -103,38 +111,277 @@ impl Debug for Bindings {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
-pub struct MatchResult {
-    pub candidate_bindings: Bindings,
-    pub pattern_bindings: Bindings,
+#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+enum Var {
+    Data(VariableAtom),
+    Pattern(VariableAtom),
 }
 
-impl MatchResult {
-    pub fn new() -> Self {
-        MatchResult {
-            candidate_bindings: Bindings::new(),
-            pattern_bindings: Bindings::new()
-        }
-    }
-
-    pub fn merge(prev: &MatchResult, next: &MatchResult) -> Option<MatchResult> {
-        let candidate_bindings = Bindings::merge(&prev.candidate_bindings, &next.candidate_bindings);
-        let pattern_bindings = Bindings::merge(&prev.pattern_bindings, &next.pattern_bindings);
-        if let (Some(candidate_bindings), Some(pattern_bindings)) = (candidate_bindings, pattern_bindings) {
-            Some(MatchResult::from((candidate_bindings, pattern_bindings)))
-        } else {
-            None
+impl Display for Var {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Data(var) => write!(f, "_{}", var),
+            Self::Pattern(var) => write!(f, "{}", var),
         }
     }
 }
 
-impl From<(Bindings, Bindings)> for MatchResult {
-    fn from((candidate_bindings, pattern_bindings): (Bindings, Bindings)) -> Self {
-        Self { candidate_bindings, pattern_bindings }
+// FIXME: rename to AtomMatcher?
+#[derive(Clone)]
+struct VariableMatcher {
+    next_var_set: u32,
+    vars: BTreeMap<Var, u32>,
+    values: HashMap<u32, Atom>,
+}
+
+impl VariableMatcher {
+    fn new() -> Self {
+        Self{ next_var_set: 0, vars: BTreeMap::new(), values: HashMap::new() }
+    }
+
+    fn get(&self, var: &Var) -> Option<Atom> {
+        self.vars.get(var).and_then(|set|
+            match self.values.get(set) {
+                Some(value) => self.resolve_atom_vars(value, var),
+                None => panic!("get() should be called after assigning value or unique variable to each variable set"),
+            })
+    }
+
+    fn resolve_atom_vars(&self, atom: &Atom, root: &Var) -> Option<Atom> {
+        match atom {
+            // FIXME: excessive cloning here
+            Atom::Variable(var) if Var::Pattern(var.clone()) == *root => None,
+            Atom::Variable(var) => {
+                match self.get(&Var::Pattern(var.clone())) {
+                    Some(atom) => Some(atom.clone()),
+                    None => match self.get(&Var::Data(var.clone())) {
+                        Some(atom) => Some(atom.clone()),
+                        None => Some(atom.clone()),
+                    },
+                }
+            }
+            Atom::Expression(expr) => {
+                let children = expr.children().iter()
+                    .fold(Some(Vec::new()), |vec, child| {
+                        match (vec, self.resolve_atom_vars(child, root)) {
+                            (Some(mut vec), Some(child)) => {
+                                vec.push(child);
+                                Some(vec)
+                            },
+                            _ => None,
+                        }
+                    });
+                if children.is_some() {
+                    Some(Atom::Expression(ExpressionAtom::new(children.unwrap())))
+                } else {
+                    None
+                }
+            }
+            _ => Some(atom.clone()),
+        }
+    }
+
+    fn add_vars_equality(self, data_var: &VariableAtom,
+            pattern_var: &VariableAtom) -> Option<Self> {
+        self.add_any_vars_equality(Var::Data(data_var.clone()),
+            Var::Pattern(pattern_var.clone()))
+    }
+
+    fn add_any_vars_equality(mut self, a: Var, b: Var) -> Option<Self> {
+        match (self.vars.get(&a).copied(), self.vars.get(&b).copied()) {
+            (Some(a_var_set), Some(b_var_set))  =>
+                if a_var_set != b_var_set {
+                    self.merge_var_sets(a_var_set, b_var_set)
+                } else {
+                    true
+                }
+            (Some(var_set), None) => {
+                self.vars.insert(b, var_set);
+                true
+            },
+            (None, Some(var_set)) => {
+                self.vars.insert(a, var_set);
+                true
+            },
+            (None, None) => {
+                let var_set = self.get_next_var_set();
+                self.vars.insert(a, var_set);
+                self.vars.insert(b, var_set);
+                true
+            },
+        }.then(|| self)
+    }
+
+    fn merge_var_sets(&mut self, a_var_set: u32, b_var_set: u32) -> bool {
+        fn move_set(vars: &mut BTreeMap<Var, u32>, from: u32, to: u32) {
+            vars.iter_mut().for_each(|(_var, set)| {
+                if *set == from {
+                    *set = to;
+                }
+            });
+        }
+        match (self.values.get(&a_var_set), self.values.get(&b_var_set)) {
+            (Some(a_val), Some(b_val)) if a_val != b_val => false,
+            (Some(_), None) => {
+                move_set(&mut self.vars, b_var_set, a_var_set);
+                true
+            }
+            _ => {
+                move_set(&mut self.vars, a_var_set, b_var_set);
+                true
+            },
+        }
+    }
+
+    fn get_next_var_set(&mut self) -> u32 {
+        let next_var_set = self.next_var_set;
+        self.next_var_set = self.next_var_set + 1;
+        next_var_set
+    }
+
+    fn with_data_binding(mut self, data_var: &VariableAtom, value: &Atom) -> Option<Self> {
+        self.add_var_binding(Var::Data(data_var.clone()), value).then(|| self)
+    }
+
+    fn with_pattern_binding(mut self, pattern_var: &VariableAtom, value: &Atom) -> Option<Self> {
+        self.add_var_binding(Var::Pattern(pattern_var.clone()), value).then(|| self)
+    }
+
+    fn add_var_binding(&mut self, var: Var, value: &Atom) -> bool {
+        let value_is_from_pattern = matches!(var, Var::Data(_));
+        match self.vars.get(&var) {
+            Some(var_set) =>
+                match self.values.get(var_set) {
+                    Some(current) => {
+                        if current == value {
+                            true
+                        } else {
+                            let sub_match = if value_is_from_pattern {
+                                match_atoms_recursively(current, value)
+                            } else {
+                                match_atoms_recursively(value, current)
+                            };
+                            let sub_match: Vec<VariableMatcher> = sub_match.collect();
+                            assert!(sub_match.len() <= 1, concat!(
+                                    "Case when sub_match returns more than ",
+                                    "one matcher because match_() is overloaded ",
+                                    "inside grounded atom is not implemented yet"));
+                            if sub_match.len() == 1 {
+                                match VariableMatcher::merge(self, &sub_match[0]) {
+                                    Some(sub_match) => { *self = sub_match; true },
+                                    None => false,
+                                }
+                            } else {
+                                false
+                            }
+                        }
+                    },
+                    None => {
+                        self.values.insert(*var_set, value.clone());
+                        true
+                    },
+                },
+            None => {
+                let var_set = self.get_next_var_set();
+                self.vars.insert(var, var_set);
+                self.values.insert(var_set, value.clone());
+                true
+            },
+        }
+    }
+
+    fn add_var_no_value(mut self, var: Var) -> Self {
+        if !self.vars.contains_key(&var) {
+            let var_set = self.get_next_var_set();
+            self.vars.insert(var, var_set);
+        }
+        self
+    }
+
+    fn merge(a: &VariableMatcher, b: &VariableMatcher) -> Option<VariableMatcher> {
+        let mut var_sets: HashMap<u32, Var> = HashMap::new();
+        let result = b.vars.iter().fold(Some(a.clone()),
+            |result, (var, set)| match result {
+                Some(mut result) => {
+                    if let Some(first_var) = var_sets.get(&set) {
+                        result.add_any_vars_equality(first_var.clone(), var.clone())
+                    } else {
+                        var_sets.insert(*set, var.clone());
+                        if let Some(value) = b.values.get(set) {
+                            result.add_var_binding(var.clone(), value).then(|| result)
+                        } else {
+                            Some(result.add_var_no_value(var.clone()))
+                        }
+                    }
+                },
+                None => None,
+            });
+        log::trace!("VariableMatcher::merge: {} ^ {} -> {:?}", a, b, result);
+        result
+    }
+
+    fn vars_by_set(&self) -> HashMap<&u32, Vec<&Var>> {
+        let mut var_sets: HashMap<&u32, Vec<&Var>> = HashMap::new();
+        self.vars.iter().for_each(|(var, set)| {
+            match var_sets.get_mut(set) {
+                Some(vec) => vec.push(var),
+                None => { var_sets.insert(set, vec![var]); },
+            };
+        });
+        var_sets
+    }
+
+    fn into_bindings(mut self) -> Option<Bindings> {
+        let mut bindings = Bindings::new();
+        for (_var, set) in &self.vars {
+            match self.values.get(set) {
+                Some(_value) => {},
+                None => {
+                    let var = VariableAtom::new(format!("u{}", set)).make_unique();
+                    self.values.insert(*set, Atom::Variable(var));
+                },
+            }
+        }
+        for var in self.vars.keys().filter(|var| matches!(var, Var::Pattern(_))) {
+            match (var, self.get(var)) {
+                (Var::Pattern(var), Some(value)) => {
+                    bindings.insert(var.clone(), value.clone());
+                },
+                (Var::Pattern(_var), None) => return None,
+                _ => {},
+            }
+        }
+        Some(bindings)
     }
 }
 
-pub type MatchResultIter = Box<dyn Iterator<Item=matcher::MatchResult>>;
+impl Display for VariableMatcher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let vars_by_set = self.vars_by_set();
+        // FIXME: rewrite in procedural style
+        write!(f, "{{")
+            .and_then(|_| vars_by_set.iter().take(1).fold(Ok(()),
+                |res, (set, vars)| vars.iter().fold(res,
+                    |res, var| res.and_then(|_| write!(f, "{} = ", var)))
+                .and_then(|_| write!(f, "{}", self.values.get(set)
+                        .map_or(&sym!("?"), std::convert::identity)))))
+            .and_then(|_| vars_by_set.iter().skip(1).fold(Ok(()),
+                |res, (set, vars)| write!(f, ", ")
+                .and_then(|_| vars.iter().fold(res,
+                        |res, var| res.and_then(|_| write!(f, "{} = ", var)))
+                    .and_then(|_| write!(f, "{}", self.values.get(set)
+                            .map_or(&sym!("?"), std::convert::identity))))))
+            .and_then(|_| write!(f, "}}"))
+    }
+}
+
+impl Debug for VariableMatcher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+pub type MatchResultIter = Box<dyn Iterator<Item=matcher::Bindings>>;
 
 pub trait WithMatch {
     fn match_(&self, pattern: &Atom) -> MatchResultIter;
@@ -142,55 +389,67 @@ pub trait WithMatch {
 
 impl WithMatch for Atom {
     fn match_(&self, pattern: &Atom) -> MatchResultIter {
-        match (self, pattern) {
-            (Atom::Symbol(a), Atom::Symbol(b)) if a == b => Box::new(std::iter::once(MatchResult::new())),
-            (Atom::Grounded(a), Atom::Grounded(_)) => a.match_(pattern),
-            (Atom::Variable(_), Atom::Variable(v)) => {
-                // We stick to prioritize pattern bindings in this case.
-                // This logic allows us propagate value of `$then` in `(= (if T $then) $then)` when
-                // it is matched with `(= (if T (do-something)) $X)` during interpretation. Finally
-                // `$X` bound to `(do-something)`  because `$X` is bound to `$then` and `$then` is
-                // bound to `(do-something)`.
-                log::trace!("match_(): bind a pattern's variable: {} = {}", v, self);
-                Box::new(std::iter::once(MatchResult::from((Bindings::new(), Bindings::from(vec![(v.clone(), self.clone())])))))
-            }
-            (Atom::Variable(v), b) => {
-                log::trace!("match_(): bind a candidate's variable: {} = {}", v, b);
-                Box::new(std::iter::once(MatchResult::from((Bindings::from(vec![(v.clone(), b.clone())]), Bindings::new()))))
-            }
-            (a, Atom::Variable(v)) => {
-                log::trace!("match_(): bind a pattern's variable: {} = {}", v, a);
-                Box::new(std::iter::once(MatchResult::from((Bindings::new(), Bindings::from(vec![(v.clone(), a.clone())])))))
-            },
-            (Atom::Expression(ExpressionAtom{ children: a }), Atom::Expression(ExpressionAtom{ children: b }))
-                if a.len() == b.len() => {
-                a.iter().zip(b.iter()).fold(Box::new(std::iter::once(MatchResult::new())),
-                    |acc, (a, b)| {
-                        match_result_product_iter(acc, a.match_(b))
-                    })
-            },
-            _ => Box::new(std::iter::empty()),
-        }
+        Box::new(match_atoms_recursively(self, pattern)
+            .map(VariableMatcher::into_bindings)
+            .filter(Option::is_some).map(Option::unwrap))
     }
 }
 
-pub fn match_result_product_iter(prev: MatchResultIter, next: MatchResultIter) -> MatchResultIter {
-    let next : Vec<MatchResult> = next.collect();
-    log::trace!("match_result_product_iter, next: {:?}", next);
-    Box::new(prev.flat_map(move |p| -> Vec<Option<MatchResult>> {
-        next.iter().map(|n| MatchResult::merge(&p, n)).collect()
+type VarMatchIter = Box<dyn Iterator<Item=VariableMatcher>>;
+
+fn match_atoms_recursively(data: &Atom, pattern: &Atom) -> VarMatchIter {
+    log::trace!("match_atoms_recursively: {} ~ {}", data, pattern);
+    fn empty() -> VarMatchIter { Box::new(std::iter::empty()) }
+    fn once(b: VariableMatcher) -> VarMatchIter { Box::new(std::iter::once(b)) }
+
+    match (data, pattern) {
+        (Atom::Symbol(a), Atom::Symbol(b)) if a == b => once(VariableMatcher::new()),
+        (Atom::Grounded(a), Atom::Grounded(_)) => Box::new(a.match_(pattern).map(Bindings::into_variable_matcher)),
+        (Atom::Variable(dv), Atom::Variable(pv)) => {
+            VariableMatcher::new().add_vars_equality(dv, pv).map_or(empty(), once)
+        }
+        (Atom::Variable(v), b) => {
+            VariableMatcher::new().with_data_binding(v, b).map_or(empty(), once)
+        }
+        (a, Atom::Variable(v)) => {
+            VariableMatcher::new().with_pattern_binding(v, a).map_or(empty(), once)
+        },
+        (Atom::Expression(ExpressionAtom{ children: a }), Atom::Expression(ExpressionAtom{ children: b }))
+                if a.len() == b.len() => {
+            // FIXME: how to log it properly?
+            a.iter().zip(b.iter()).fold(once(VariableMatcher::new()),
+                |acc, (a, b)| {
+                    variable_matcher_product(acc, match_atoms_recursively(a, b))
+                })
+        },
+        _ => empty(),
+    }
+}
+
+fn variable_matcher_product(prev: VarMatchIter, next: VarMatchIter) -> VarMatchIter {
+    let next : Vec<VariableMatcher> = next.collect();
+    Box::new(prev.flat_map(move |p| -> Vec<Option<VariableMatcher>> {
+        next.iter().map(|n| VariableMatcher::merge(&p, n)).collect()
     }).filter(Option::is_some).map(Option::unwrap))
 }
-    
+
+pub fn match_result_product(prev: MatchResultIter, next: MatchResultIter) -> MatchResultIter {
+    let next : Vec<Bindings> = next.collect();
+    log::trace!("match_result_product_iter, next: {:?}", next);
+    Box::new(prev.flat_map(move |p| -> Vec<Option<Bindings>> {
+        next.iter().map(|n| Bindings::merge(&p, n)).collect()
+    }).filter(Option::is_some).map(Option::unwrap))
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub struct UnificationPair {
-    pub candidate: Atom,
+    pub data: Atom,
     pub pattern: Atom,
 }
 
 impl From<(Atom, Atom)> for UnificationPair {
-    fn from((candidate, pattern): (Atom, Atom)) -> Self {
-        Self { candidate, pattern }
+    fn from((data, pattern): (Atom, Atom)) -> Self {
+        Self { data, pattern }
     }
 }
 
@@ -198,7 +457,7 @@ pub type Unifications = Vec<matcher::UnificationPair>;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct UnifyResult {
-    pub candidate_bindings: Bindings,
+    pub data_bindings: Bindings,
     pub pattern_bindings: Bindings,
     pub unifications: Unifications,
 }
@@ -206,27 +465,27 @@ pub struct UnifyResult {
 impl UnifyResult {
     fn new() -> Self {
         UnifyResult {
-            candidate_bindings: Bindings::new(),
+            data_bindings: Bindings::new(),
             pattern_bindings: Bindings::new(),
             unifications: Vec::new(),
         }
     }
 }
 
-fn unify_atoms_recursively(candidate: &Atom, pattern: &Atom, res: &mut UnifyResult, depth: u32) -> bool {
-    match (candidate, pattern) {
+fn unify_atoms_recursively(data: &Atom, pattern: &Atom, res: &mut UnifyResult, depth: u32) -> bool {
+    match (data, pattern) {
         (Atom::Symbol(a), Atom::Symbol(b)) => a == b,
         (Atom::Grounded(a), Atom::Grounded(b)) => a == b,
         (Atom::Variable(_), Atom::Variable(v)) => {
             // We stick to prioritize pattern bindings in this case
             // because otherwise the $X in (= (...) $X) will not be matched with
             // (= (if True $then) $then)
-            log::trace!("check_and_insert_binding for pattern({:?}, {}, {})", res.pattern_bindings, v, candidate);
-            res.pattern_bindings.check_and_insert_binding(v, candidate)
+            log::trace!("check_and_insert_binding for pattern({:?}, {}, {})", res.pattern_bindings, v, data);
+            res.pattern_bindings.check_and_insert_binding(v, data)
         }
         (Atom::Variable(v), b) => {
-            log::trace!("check_and_insert_binding for candidate({:?}, {}, {})", res.candidate_bindings, v, b);
-            res.candidate_bindings.check_and_insert_binding(v, b)
+            log::trace!("check_and_insert_binding for data({:?}, {}, {})", res.data_bindings, v, b);
+            res.data_bindings.check_and_insert_binding(v, b)
         }
         (a, Atom::Variable(v)) => {
             log::trace!("check_and_insert_binding for pattern({:?}, {}, {})", res.pattern_bindings, v, a);
@@ -237,7 +496,7 @@ fn unify_atoms_recursively(candidate: &Atom, pattern: &Atom, res: &mut UnifyResu
                 if depth == 1 {
                     false
                 } else {
-                    res.unifications.push((candidate.clone(), pattern.clone()).into());
+                    res.unifications.push((data.clone(), pattern.clone()).into());
                     true
                 }
             } else {
@@ -246,17 +505,17 @@ fn unify_atoms_recursively(candidate: &Atom, pattern: &Atom, res: &mut UnifyResu
             }
         },
         (Atom::Expression(_), _) | (_, Atom::Expression(_)) => {
-            res.unifications.push((candidate.clone(), pattern.clone()).into());
+            res.unifications.push((data.clone(), pattern.clone()).into());
             true
         }
         _ => false,
     }
 }
 
-pub fn unify_atoms(candidate: &Atom, pattern: &Atom) -> Option<UnifyResult> {
-    log::trace!("unify_atoms: candidate: {}, pattern: {}", candidate, pattern);
+pub fn unify_atoms(data: &Atom, pattern: &Atom) -> Option<UnifyResult> {
+    log::trace!("unify_atoms: data: {}, pattern: {}", data, pattern);
     let mut res = UnifyResult::new();
-    if unify_atoms_recursively(candidate, pattern, &mut res, 0) {
+    if unify_atoms_recursively(data, pattern, &mut res, 0) {
         Some(res)
     } else {
         None
@@ -268,7 +527,7 @@ pub fn apply_bindings_to_atom(atom: &Atom, bindings: &Bindings) -> Atom {
         atom.clone()
     } else {
         let result = apply_bindings_to_atom_recurse(atom, bindings);
-        log::trace!("applied bindings to {} result: {}", atom, result);
+        log::trace!("apply_bindings_to_atom: {} | {} -> {}", atom, bindings, result);
         return result;
     }
 }
@@ -302,7 +561,7 @@ fn atom_contains_variable(atom: &Atom, var: &VariableAtom) -> bool {
 }
 
 pub fn apply_bindings_to_bindings(from: &Bindings, to: &Bindings) -> Result<Bindings, ()> {
-    log::trace!("apply_bindings_to_bindings: from: {}, to: {}", from, to);
+    // FIXME: try removing this method
     let mut res = Bindings::new();
     for (key, value) in to {
         let applied = apply_bindings_to_atom(value, from);
@@ -317,7 +576,7 @@ pub fn apply_bindings_to_bindings(from: &Bindings, to: &Bindings) -> Result<Bind
             return Err(())
         }
     }
-    log::trace!("apply_bindings_to_bindings: result: {}", res);
+    log::trace!("apply_bindings_to_bindings: {} | {} -> {}", to, from, res);
     return Ok(res);
 }
 
@@ -346,22 +605,29 @@ fn atoms_are_equivalent_with_bindings(first: &Atom, second: &Atom,
 mod test {
     use super::*;
 
-    #[test]
-    fn test_match_variables_in_data() {
-        assert_eq!(
-            expr!("+" a ("*" b c)).match_(&expr!("+" "A" ("*" "B" "C"))).collect::<Vec<MatchResult>>(),
-            vec![MatchResult::from((bind!{a: expr!("A"), b: expr!("B"), c: expr!("C") }, bind!{}))]);
+    fn assert_match(data: Atom, pattern: Atom, expected: Vec<Bindings>) {
+        let actual: Vec<Bindings> = data.match_(&pattern).collect();
+        assert_eq!(actual, expected);
     }
 
     #[test]
-    fn test_match_different_value_for_variable_in_data() {
-        assert_eq!(
-            expr!("+" a ("*" a c)).match_(&expr!("+" "A" ("*" "B" "C"))).collect::<Vec<MatchResult>>(),
+    fn match_variables_in_data() {
+        assert_match(
+            expr!("+"  a  ("*"  b   c )),
+            expr!("+" "A" ("*" "B" "C")),
+            vec![bind!{}]);
+    }
+
+    #[test]
+    fn match_value_conflict_for_variable_in_data() {
+        assert_match(
+            expr!("+"  a  ("*"  a   c )),
+            expr!("+" "A" ("*" "B" "C")),
             vec![]);
     }
 
     #[test]
-    fn test_bindings_merge_different_values() {
+    fn bindings_merge_value_conflict() {
         assert_eq!(Bindings::merge(&bind!{ a: expr!("A") },
             &bind!{ a: expr!("C"), b: expr!("B") }), None);
         assert_eq!(Bindings::merge(&bind!{ a: expr!("C"), b: expr!("B") },
@@ -379,18 +645,105 @@ mod test {
     }
 
     #[test]
-    fn test_variable_name_conflict() {
-        assert_eq!(expr!("a" (W)).match_(&expr!("a" W)).collect::<Vec<MatchResult>>(),
-            vec![MatchResult::from((bind!{}, bind!{ W: expr!((W)) }))]);
+    fn match_variable_name_conflict() {
+        assert_match(expr!("a" (W)), expr!("a" W), vec![]);
     }
 
     #[test]
-    fn test_are_equivalent() {
+    fn test_atoms_are_equivalent() {
         assert!(atoms_are_equivalent(&expr!(a "b" {"c"}), &expr!(x "b" {"c"})));
         assert!(atoms_are_equivalent(&expr!(a b), &expr!(c d)));
         assert!(!atoms_are_equivalent(&expr!(a "b" {"c"}), &expr!(a "x" {"c"})));
         assert!(!atoms_are_equivalent(&expr!(a "b" {"c"}), &expr!(a "b" {"x"})));
         assert!(!atoms_are_equivalent(&expr!(a a), &expr!(c d)));
         assert!(!atoms_are_equivalent(&expr!(a b), &expr!(b b)));
+    }
+
+    #[test]
+    fn match_spread_value_via_data_variable() {
+        assert_match(
+            expr!( a  a a),
+            expr!("v" x y),
+            vec![bind!{x: sym!("v"), y: sym!("v")}]);
+    }
+
+    #[test]
+    fn match_spread_value_via_data_variable_reverse_order() {
+        assert_match(
+            expr!(a a  a  a),
+            expr!(x x "v" y),
+            vec![bind!{x: sym!("v"), y: sym!("v")}]);
+    }
+
+    #[test]
+    fn match_spread_value_via_pattern_variable() {
+        assert_match(
+            expr!("v" a a),
+            expr!( x  x y),
+            vec![bind!{x: sym!("v"), y: sym!("v")}]);
+    }
+
+    #[test]
+    fn match_spread_value_via_pattern_variable_reverse_order() {
+        assert_match(
+            expr!(a "v" a),
+            expr!(x  x  y),
+            vec![bind!{x: sym!("v"), y: sym!("v")}]);
+    }
+
+    #[ignore]
+    #[test]
+    fn match_replace_variable_via_data_variable() {
+        assert_match(
+            expr!(a a),
+            expr!(x y),
+            vec![bind!{x: expr!(u0), y: expr!(u0)}]);
+    }
+
+    #[test]
+    fn match_variable_via_itself() {
+        assert_match(
+            expr!(a  a ),
+            expr!(x (x)),
+            vec![]);
+    }
+
+    #[ignore]
+    #[test]
+    fn match_variable_with_unique_itself() {
+        assert_match(
+            replace_variables(&expr!(("A" x) ("B" x))),
+                               expr!(("A" x)    z   ),
+            vec![bind!{x: expr!(u0), z: expr!("B" u0)}]);
+    }
+
+    #[test]
+    fn match_stub_variable_is_unique() {
+        let data =    expr!(a a);
+        let pattern = expr!(x y);
+        let x = VariableAtom::new("x");
+
+        let bindings_a = data.match_(&pattern).next().unwrap();
+        let bindings_b = data.match_(&pattern).next().unwrap();
+
+        assert_ne!(bindings_a.get(&x), bindings_b.get(&x));
+    }
+
+    #[ignore]
+    #[test]
+    fn match_equality_of_pattern_variables_inside_expression() {
+        assert_match(
+            expr!( a    a   a),
+            expr!((x) ("v") y),
+            vec![bind!{x: expr!("v"), y: expr!(("v"))}]);
+    }
+
+    #[ignore]
+    #[test]
+    fn match_equality_of_data_variables_inside_expression() {
+        assert_match(
+            expr!((a) ("v") a),
+            expr!( x    x   y),
+            vec![bind!{x: expr!(("v")), y: expr!("v")}]);
     }
 }

--- a/lib/src/atom/mod.rs
+++ b/lib/src/atom/mod.rs
@@ -93,7 +93,7 @@ fn next_variable_id() -> usize {
     NEXT_VARIABLE_ID.fetch_add(1, Ordering::Relaxed)
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct VariableAtom {
     name: String,
     id: usize,
@@ -497,63 +497,6 @@ mod test {
     }
 
     #[derive(PartialEq, Clone, Debug)]
-    struct TestDict(Vec<(Atom, Atom)>);
-
-    impl TestDict {
-        fn new() -> Self {
-            TestDict(Vec::new())
-        }
-        fn get(&self, key: &Atom) -> Option<&Atom> {
-            self.0.iter().filter(|(k, _)| { k == key }).nth(0).map(|(_, v)| { v })
-        }
-        fn remove(&mut self, key: &Atom) -> Option<Atom> {
-            let v = self.get(key).map(Atom::clone);
-            self.0 = self.0.drain(..).filter(|(k, _)| { k != key }).collect();
-            v
-        }
-        fn put(&mut self, key: Atom, value: Atom) -> Option<Atom> {
-            let v = self.remove(&key);
-            self.0.push((key, value));
-            v
-        }
-    }
-
-    use crate::*;
-    use crate::atom::matcher::*;
-
-    impl Grounded for TestDict {
-        fn type_(&self) -> Atom {
-            Atom::sym("Dict")
-        }
-        fn execute(&self, _args: &mut Vec<Atom>) -> Result<Vec<Atom>, ExecError> {
-            execute_not_executable(self)
-        }
-        fn match_(&self, other: &Atom) -> matcher::MatchResultIter {
-            if let Some(other) = other.as_gnd::<TestDict>() {
-                other.0.iter().map(|(ko, vo)| {
-                    self.0.iter().map(|(k, v)| {
-                        Atom::expr(vec![k.clone(), v.clone()]).match_(&Atom::expr(vec![ko.clone(), vo.clone()]))
-                    }).fold(Box::new(std::iter::empty()) as MatchResultIter, |acc, i| {
-                        Box::new(acc.chain(i))
-                    })
-                }).fold(Box::new(std::iter::once(Bindings::new())),
-                    |acc, i| { matcher::match_result_product(acc, i) })
-            } else {
-                Box::new(std::iter::empty())
-            }
-        }
-    }
-    
-    impl Display for TestDict {
-        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-            write!(f, "{{ ").and_then(|_| self.0.iter().fold(Ok(()),
-                |ret, (key, val)| ret.and_then(
-                    |_| write!(f, "{}: {}, ", key, val))))
-                .and_then(|_| write!(f, "}}"))
-        }
-    }
-
-    #[derive(PartialEq, Clone, Debug)]
     struct TestMulX(i32);
 
     impl Grounded for TestMulX {
@@ -592,7 +535,6 @@ mod test {
     fn test_expr_grounded() {
         assert_eq!(expr!({42}), value(42));
         assert_eq!(expr!({TestInteger(42)}), grounded(TestInteger(42)));
-        assert_eq!(expr!({TestDict::new()}), grounded(TestDict::new()));
         assert_eq!(expr!({TestMulX(3)}), grounded(TestMulX(3)));
     }
 
@@ -637,8 +579,6 @@ mod test {
             "{\"hello\": \"world\"}");
         assert_eq!(format!("{}", Atom::gnd(TestInteger(42))), "42");
         assert_eq!(format!("{}", Atom::gnd(TestMulX(3))), "x3");
-        assert_eq!(format!("{}", Atom::gnd(TestDict(vec![(Atom::sym("A"), Atom::sym("b"))]))),
-            "{ A: b, }");
         assert_eq!(format!("{}", expr!("=" ("fact" n) ("*" n ("-" n "1")))),
             "(= (fact $n) (* $n (- $n 1)))");
         assert_eq!(format!("{}", expr!()), "()");
@@ -655,8 +595,6 @@ mod test {
             "Grounded(AutoGroundedAtom({\"hello\": \"world\"}))");
         assert_eq!(format!("{:?}", Atom::gnd(TestInteger(42))), "Grounded(CustomGroundedAtom(TestInteger(42)))");
         assert_eq!(format!("{:?}", Atom::gnd(TestMulX(3))), "Grounded(CustomGroundedAtom(TestMulX(3)))");
-        assert_eq!(format!("{:?}", Atom::gnd(TestDict(vec![(Atom::sym("A"), Atom::sym("b"))]))),
-            "Grounded(CustomGroundedAtom(TestDict([(Symbol(SymbolAtom { name: \"A\" }), Symbol(SymbolAtom { name: \"b\" }))])))");
     }
 
     #[test]
@@ -687,22 +625,6 @@ mod test {
         } else {
             assert!(false, "GroundedAtom is expected");
         }
-    }
-
-    #[test]
-    fn test_custom_matching() {
-        let mut dict = TestDict::new();
-        dict.put(expr!("x"), expr!({2} {5}));
-        dict.put(expr!("y"), expr!({5}));
-        let dict = expr!({dict}); 
-
-        let mut query = TestDict::new();
-        query.put(expr!(b), expr!(y));
-        query.put(expr!(a), expr!({2} y));
-        let query = expr!({query});
-
-        let result: Vec<Bindings> = dict.match_(&query).collect();
-        assert_eq!(result, vec![bind!{y: expr!({5}), b: expr!("y"), a: expr!("x")}]);
     }
 
     #[test]

--- a/lib/src/metta/interpreter.rs
+++ b/lib/src/metta/interpreter.rs
@@ -704,9 +704,10 @@ mod tests {
 
         assert_eq!(interpret(space.clone(), &expr!("eq" ("plus" "Z" n) n)),
             Ok(vec![expr!("True")]));
-        assert!(results_are_equivalent(
-            &interpret(space.clone(), &expr!("eq" ("plus" ("S" "Z") n) n)),
-            &Ok(vec![expr!("eq" ("S" y) y)])));
+        let actual = interpret(space.clone(), &expr!("eq" ("plus" ("S" "Z") n) n));
+        let expected = Ok(vec![expr!("eq" ("S" y) y)]);
+        assert!(results_are_equivalent(&actual, &expected),
+            "actual: {:?} and expected: {:?} are not equivalent", actual, expected);
     }
 
     fn test_interpret<T, R, P: Plan<T, R>>(plan: P, arg: T) -> Result<R, String> {

--- a/lib/src/space/grounding.rs
+++ b/lib/src/space/grounding.rs
@@ -122,16 +122,14 @@ impl GroundingSpace {
         log::debug!("single_query: pattern: {}", pattern);
         let mut result = Vec::new();
         for next in &(*self.borrow_vec()) {
-            log::trace!("single_query: match next: {}", next);
             let next = replace_variables(next);
-            for res in next.match_(pattern) {
-                let bindings = matcher::apply_bindings_to_bindings(&res.candidate_bindings, &res.pattern_bindings);
-                if let Ok(bindings) = bindings {
-                    log::debug!("single_query: push result: {}, bindings: {}", next, bindings);
-                    result.push(bindings);
-                }
+            log::trace!("single_query: match next: {}", next);
+            for bindings in next.match_(pattern) {
+                log::trace!("single_query: push result: {}", bindings);
+                result.push(bindings);
             }
         }
+        log::debug!("single_query: result: {:?}", result);
         result
     }
 
@@ -156,7 +154,7 @@ impl GroundingSpace {
         for next in &(*self.borrow_vec()) {
             match matcher::unify_atoms(next, pattern) {
                 Some(res) => {
-                    let bindings = matcher::apply_bindings_to_bindings(&res.candidate_bindings, &res.pattern_bindings);
+                    let bindings = matcher::apply_bindings_to_bindings(&res.data_bindings, &res.pattern_bindings);
                     if let Ok(bindings) = bindings {
                         // TODO: implement Display for bindings
                         log::debug!("unify: push result: {}, bindings: {:?}", next, bindings);

--- a/lib/src/space/grounding.rs
+++ b/lib/src/space/grounding.rs
@@ -96,7 +96,7 @@ impl GroundingSpace {
                 let vars = collect_variables(&pattern);
                 let mut result = args.fold(vec![bind!{}],
                     |mut acc, pattern| {
-                        if acc.is_empty() {
+                        let result = if acc.is_empty() {
                             acc
                         } else {
                             acc.drain(0..).flat_map(|prev| -> Vec<Bindings> {
@@ -109,7 +109,9 @@ impl GroundingSpace {
                                         .expect("Self consistent bindings are expected"))
                                     .collect()
                             }).collect()
-                        }
+                        };
+                        log::debug!("query: current result: {:?}", result);
+                        result
                     });
                 result.iter_mut().for_each(|bindings| bindings.filter(|k, _v| vars.contains(k)));
                 result


### PR DESCRIPTION
Fixes #127
This PR reworks pattern matcher to handle different tricky matches which were not processed before. I didn't implemented logic to substitute variables by their previous names because of reasons explained here: https://github.com/trueagi-io/hyperon-experimental/issues/127#issuecomment-1181645146
Particular cases which are handled now can be seen at the tests section of the `matcher.rs`.