### PR TITLE
Return Undefined type when no type was found for operator atom

### DIFF
--- a/lib/src/metta/interpreter.rs
+++ b/lib/src/metta/interpreter.rs
@@ -70,7 +70,7 @@ use crate::space::grounding::*;
 use crate::common::collections::ListMap;
 use crate::metta::*;
 use crate::metta::types::{is_func, get_arg_types, check_type_bindings,
-    get_reducted_types, match_reducted_types};
+    get_atom_types, match_reducted_types};
 
 use std::ops::Deref;
 use std::rc::Rc;
@@ -310,7 +310,7 @@ fn cast_atom_to_type_plan(context: InterpreterContextRef,
 
 fn get_type_of_atom_plan(context: InterpreterContextRef, atom: Atom) -> StepResult<Vec<Atom>> {
     // TODO: implement this via interpreting of the (:? atom)
-    StepResult::ret(get_reducted_types(&context.space, &atom))
+    StepResult::ret(get_atom_types(&context.space, &atom))
 }
 
 fn interpret_expression_as_type_plan(context: InterpreterContextRef,

--- a/lib/src/metta/types.rs
+++ b/lib/src/metta/types.rs
@@ -89,7 +89,16 @@ fn get_args(expr: &ExpressionAtom) -> &[Atom] {
     &expr.children().as_slice()[1..]
 }
 
-pub fn get_reducted_types(space: &GroundingSpace, atom: &Atom) -> Vec<Atom> {
+pub fn get_atom_types(space: &GroundingSpace, atom: &Atom) -> Vec<Atom> {
+    let mut types = get_reducted_types(space, atom);
+    if types.is_empty() {
+        types.push(ATOM_TYPE_UNDEFINED);
+    }
+    log::debug!("get_atom_types: atom: {}, types: {:?}", atom, types);
+    types
+}
+
+fn get_reducted_types(space: &GroundingSpace, atom: &Atom) -> Vec<Atom> {
     log::trace!("get_reducted_types: atom: {}", atom);
     let types = match atom {
         Atom::Variable(_) => vec![ATOM_TYPE_UNDEFINED],
@@ -558,5 +567,14 @@ mod tests {
     fn get_reducted_types_empty_expression() {
         let space = GroundingSpace::new();
         assert_eq!(get_reducted_types(&space, &Atom::expr([])), vec![ATOM_TYPE_UNDEFINED]);
+    }
+
+    #[test]
+    fn get_atom_types_undefined_expression_type() {
+        let space = metta_space("
+            (: a (-> C D))
+            (: b B)
+        ");
+        assert_eq!(get_atom_types(&space, &atom("(a b)")), vec![ATOM_TYPE_UNDEFINED]);
     }
 }


### PR DESCRIPTION
Fixes #138 
Root cause of the issue is that when first atom inside expression doesn't have correct type (for instance `(S S`) in `((S S))` is incorrect constructor application to constructor) then `get_reducted_type()` returned empty list of types. So expressions with badly typed operator was not interpreted further.
This PR fixes this behavior returning `Undefined` type in such case. 