### PR TITLE
Support quoted strings in MeTTa expressions

### DIFF
--- a/python/tests/common.py
+++ b/python/tests/common.py
@@ -208,8 +208,6 @@ class MeTTa:
                        lambda token: ValueAtom(float(token), 'Number'))
         self.add_token(r"\d+",
                        lambda token: ValueAtom(int(token), 'Number'))
-        #self.add_token(r"'[^']*'",
-        #               lambda token: ValueAtom(str(token[1:-1]), 'String'))
         self.add_token("\"[^\"]*\"",
                        lambda token: ValueAtom(str(token[1:-1]), 'String'))
         self.add_token(r"True|False",


### PR DESCRIPTION
Fixes #112. Parse string in double quotes as a single token.