### PR TITLE
Fix VariableAtom.name() function

### DIFF
--- a/c/src/atom.rs
+++ b/c/src/atom.rs
@@ -105,7 +105,7 @@ pub extern "C" fn atom_get_name(atom: *const atom_t, callback: c_str_callback_t,
     let atom = unsafe{ &(*atom).atom };
     match atom {
         Atom::Symbol(s) => callback(str_as_cstr(s.name()).as_ptr(), context),
-        Atom::Variable(v) => callback(str_as_cstr(v.name()).as_ptr(), context),
+        Atom::Variable(v) => callback(string_as_cstr(v.name()).as_ptr(), context),
         _ => panic!("Only Symbol and Variable has name attribute!"),
     }
 }

--- a/c/src/space.rs
+++ b/c/src/space.rs
@@ -70,8 +70,9 @@ pub extern "C" fn grounding_space_query(space: *const grounding_space_t,
     for result in results {
         let mut vars : Vec<CString> = Vec::new();
         let vec = result.iter().map(|(k, v)| {
-                // prevent C string from deallocation before callback is called
-                vars.push(str_as_cstr(k.name()));
+                // put C string into collection which is external to closure
+                // to prevent its deallocation before callback is called
+                vars.push(string_as_cstr(k.name()));
                 binding_t{
                     var: vars.last().unwrap().as_ptr(),
                     atom: (v as *const Atom).cast::<atom_t>()

--- a/c/src/util.rs
+++ b/c/src/util.rs
@@ -30,3 +30,7 @@ pub fn cstr_into_string(s: *const c_char) -> String {
 pub fn str_as_cstr(s: &str) -> CString {
     CString::new(s).expect("CString::new failed")
 }
+
+pub fn string_as_cstr(s: String) -> CString {
+    CString::new(s).expect("CString::new failed")
+}

--- a/lib/src/atom/mod.rs
+++ b/lib/src/atom/mod.rs
@@ -214,12 +214,16 @@ impl VariableAtom {
         Self{ name: name.into(), id: 0 }
     }
 
-    // TODO: this method is likely to be removed as name is not
-    // unique and it may confuse users. `to_string()` can be used instead.
-    // The same may be true for a SymbolAtom.
+    // TODO: for now name() is used to expose keys of Bindings via C API as
+    // strings (which are variable names). Looks like better approach is using
+    // Atom as a key in Bindings structure.
     /// Returns name of the variable.
-    pub fn name(&self) -> &str {
-        self.name.as_str()
+    pub fn name(&self) -> String {
+        if self.id == 0 {
+            format!("{}", self.name)
+        } else {
+            format!("{}#{}", self.name, self.id)
+        }
     }
 
     /// Returns an unique instance of the variable with the same name.
@@ -232,8 +236,8 @@ impl VariableAtom {
     /// let x1 = VariableAtom::new("x");
     /// let x2 = x1.make_unique();
     ///
-    /// assert_eq!(x2.name(), "x");
-    /// assert_eq!(x1.name(), x2.name());
+    /// assert_eq!(x1.name(), "x");
+    /// assert_ne!(x1.name(), x2.name());
     /// assert_ne!(x1, x2);
     /// ```
     pub fn make_unique(&self) -> Self {
@@ -243,11 +247,7 @@ impl VariableAtom {
 
 impl Display for VariableAtom {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.id == 0 {
-            write!(f, "${}", self.name)
-        } else {
-            write!(f, "${}#{}", self.name, self.id)
-        }
+        write!(f, "${}", self.name())
     }
 }
 

--- a/lib/src/atom/mod.rs
+++ b/lib/src/atom/mod.rs
@@ -119,7 +119,7 @@ use crate::common::collections::ImmutableString;
 // Symbol atom
 
 /// A symbol atom structure.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SymbolAtom {
     name: ImmutableString,
 }
@@ -200,7 +200,7 @@ fn next_variable_id() -> usize {
 }
 
 /// A variable atom structure
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct VariableAtom {
     name: String,
     id: usize,
@@ -216,7 +216,8 @@ impl VariableAtom {
 
     // TODO: for now name() is used to expose keys of Bindings via C API as
     // strings (which are variable names). Looks like better approach is using
-    // Atom as a key in Bindings structure.
+    // Atom as a key in Bindings structure but it requires implementing
+    // Hash trait for Atom.
     /// Returns name of the variable.
     pub fn name(&self) -> String {
         if self.id == 0 {

--- a/lib/src/atom/mod.rs
+++ b/lib/src/atom/mod.rs
@@ -246,7 +246,7 @@ impl Display for VariableAtom {
         if self.id == 0 {
             write!(f, "${}", self.name)
         } else {
-            write!(f, "${}-{}", self.name, self.id)
+            write!(f, "${}#{}", self.name, self.id)
         }
     }
 }

--- a/lib/src/atom/mod.rs
+++ b/lib/src/atom/mod.rs
@@ -209,7 +209,7 @@ pub struct VariableAtom {
 impl VariableAtom {
     /// Constructs new variable using `name` provided. Usually [Atom::var]
     /// should be preffered. But sometimes [VariableAtom] instance is required.
-    /// For example as a variable bindings instance.
+    /// For example for using as a key in variable bindings.
     pub fn new<T: Into<String>>(name: T) -> Self {
         Self{ name: name.into(), id: 0 }
     }
@@ -583,13 +583,13 @@ impl Clone for Box<dyn GroundedAtom> {
 
 // Atom enum
 
-/// Atom are main components of the atomspace. There are four meta-types of
+/// Atoms are main components of the atomspace. There are four meta-types of
 /// atoms: symbol, expression, variable and grounded.
 #[derive(Clone)]
 pub enum Atom {
     /// Symbol represents some idea or concept. Two symbols having
-    /// the same name are considered equal and represent the same concept. Name
-    /// of the symbol can be arbitrary string. Use [Atom::sym] to construct
+    /// the same name are considered equal and representing the same concept.
+    /// Name of the symbol can be arbitrary string. Use [Atom::sym] to construct
     /// new symbol.
     Symbol(SymbolAtom),
 

--- a/lib/src/metta/text.rs
+++ b/lib/src/metta/text.rs
@@ -61,7 +61,7 @@ impl<'a> SExprParser<'a> {
                 },
                 '$' => {
                     self.it.next();
-                    let token = next_word(&mut self.it);
+                    let token = next_var(&mut self.it);
                     return Some(Atom::var(token));
                 },
                 '(' => {
@@ -152,6 +152,21 @@ fn next_word(it: &mut Peekable<Chars<'_>>) -> String {
     while let Some(&c) = it.peek() {
         if c.is_whitespace() || c == '(' || c == ')' {
             break;
+        }
+        token.push(c);
+        it.next();
+    }
+    token 
+}
+
+fn next_var(it: &mut Peekable<Chars<'_>>) -> String {
+    let mut token = String::new();
+    while let Some(&c) = it.peek() {
+        if c.is_whitespace() || c == '(' || c == ')' {
+            break;
+        }
+        if c == '#' {
+            panic!("'#' char is reserved for internal usage");
         }
         token.push(c);
         it.next();
@@ -334,5 +349,12 @@ mod tests {
             result.push(atom);
         }
         result
+    }
+
+    #[test]
+    #[should_panic(expected = "'#' char is reserved for internal usage")]
+    fn test_panic_on_lattice_in_var_name() {
+        let mut parser = SExprParser::new("$a#");
+        while let Some(_) = parser.parse(&Tokenizer::new()) {}
     }
 }


### PR DESCRIPTION
Before this change two unique instances of the `VariableAtom` could still have same name. It affects C API call `grounding_space_query` because it returns `Bindings` using `VariableAtom.name()` string as a key. This PR prevents clashes.
It forbids using `#` symbol inside variable names assigned by user and uses this symbol to form unique variable name using `VariableAtom.id` field.
API also can be further changed by using `Atom` as a key in `Bindings`.