### PR TITLE
use  in unit tests

### DIFF
--- a/python/tests/common.py
+++ b/python/tests/common.py
@@ -274,14 +274,6 @@ class MeTTa:
     def parse_single(self, program):
         return next(self._parse_all(program))
 
-    def add_parse(self, program):
-        for atom in self._parse_all(program):
-            self.space.add_atom(atom)
-
-    def interpret(self, program):
-        target = self.parse_single(program)
-        return interpret(self.space, target)
-
     def import_file(self, fname):
         path = fname.split(os.sep)
         f = open(os.sep.join(self.cwd + path), "r")
@@ -295,7 +287,7 @@ class MeTTa:
         self.cwd = prev_cwd
         return result
 
-    def run(self, program):
+    def run(self, program, flat=False):
         self.settings = {'type-check': None}
         status = "normal"
         result = []
@@ -310,9 +302,8 @@ class MeTTa:
             if status == "interp":
                 r = interpret(self.space, expr)
                 # Empty results are also results.
-                # Can be filtered later if needed.
-                # if r != []: result += [r]
-                result += [r]
+                # They disappear if `flat` is `True`
+                result += r if flat else [r]
             else:
                 self.space.add_atom(expr)
             status = "normal"

--- a/python/tests/test_examples.py
+++ b/python/tests/test_examples.py
@@ -20,8 +20,8 @@ class ExamplesTest(unittest.TestCase):
         self.assertTrue(obj.called)
         self.assertEqual(result, [])
         # But it will not work if &obj is parsed in another space
-        result = metta2.interpret('(call:foo &obj)')
-        self.assertEqual(repr(result[0]), '(call:foo &obj)')
+        result = metta2.run('!(call:foo &obj)')[0]
+        self.assertEqual(repr(result), '[(call:foo &obj)]')
 
     # TODO: when (change-state ...) inside (, (change-state ...) ...) returns
     # an empty result (for instance when variable is absent) then Interpreter
@@ -30,7 +30,7 @@ class ExamplesTest(unittest.TestCase):
     @unittest.skip("TODO")
     def test_self_modify(self):
         metta = MeTTa()
-        metta.add_parse(
+        metta.run(
         '''
             (= (remove-state $var)
                (match &self (state $var $y)
@@ -41,12 +41,12 @@ class ExamplesTest(unittest.TestCase):
             (= (get-state $var)
                (match &self (state $var $value) $value))
         ''')
-        metta.interpret('(change-state (name id-001) Fritz)')
-        self.assertEqual(metta.interpret('(get-state (name id-001))'),
-                         [S('Fritz')])
-        metta.interpret('(change-state (name id-001) Sam)')
-        self.assertEqual(metta.interpret('(get-state (name id-001))'),
-                         [S('Sam')])
+        metta.run('!(change-state (name id-001) Fritz)')
+        self.assertEqual(metta.run('!(get-state (name id-001))'),
+                         [[S('Fritz')]])
+        metta.run('!(change-state (name id-001) Sam)')
+        self.assertEqual(metta.run('!(get-state (name id-001))'),
+                         [[S('Sam')]])
 
     def test_new_object(self):
         metta = MeTTa()
@@ -59,45 +59,45 @@ class ExamplesTest(unittest.TestCase):
         kb = GroundingSpace()
         # Just checking that interpretation of "pglob" gives us
         # a grounded atom that stores 10
-        self.assertEqual(metta.interpret('pglob')[0].get_object().value.get(), 10)
+        self.assertEqual(metta.run('! pglob')[0][0].get_object().value.get(), 10)
         # Checking that:
         # - we create an atom on fly
         # - we change the value stored by the Python object
         # - interpretation of "pglob" will also give us this new value
-        metta.interpret('(call:act (Setter pglob 5))')
+        metta.run('!(call:act (Setter pglob 5))')
         self.assertEqual(pglob.get(), 5)
-        self.assertEqual(metta.interpret('pglob')[0].get_object().value.get(), 5)
+        self.assertEqual(metta.run('! pglob')[0][0].get_object().value.get(), 5)
         # Now check that "ploc" will not change, since
         # it is passed by value - not reference
-        metta.interpret('(call:let (Setter ploc 5))')
+        metta.run('!(call:let (Setter ploc 5))')
         self.assertEqual(ploc, 10)
-        self.assertEqual(metta.interpret('ploc')[0].get_object().value, 10)
+        self.assertEqual(metta.run('! ploc')[0][0].get_object().value, 10)
         # Now we try to change the grounded atom value directly
-        # (equivalent to metta.interpret but keeping target)
+        # (equivalent to metta.run but keeping target)
         target = metta.parse_single('(call:latom (SetAtom ploc 5))')
         interpret(metta.space, target)
         # "ploc" value in the "target" is changed
         self.assertEqual(target.get_children()[1].get_children()[1].get_object().value, 5)
         # But it is still not changed in another target, because
         # "ploc" creates ValueAtom(ploc) on each occurrence
-        self.assertEqual(metta.interpret('ploc')[0].get_object().value, 10)
+        self.assertEqual(metta.run('! ploc')[0][0].get_object().value, 10)
         # Another way is to return the same atom each time
         ploca = ValueAtom(ploc)
         metta.add_token("ploca", lambda _: ploca)
         # It will be not affected by assigning unwrapped values:
         # we are still copying values while unwrapping
-        metta.interpret('(call:let (Setter ploca 5))')
-        self.assertEqual(metta.interpret('ploca')[0].get_object().value, 10)
+        metta.run('!(call:let (Setter ploca 5))')
+        self.assertEqual(metta.run('! ploca')[0][0].get_object().value, 10)
         self.assertEqual(ploca.get_object().value, 10)
         # However, it will be affected by assigning atom values
-        metta.interpret('(call:latom (SetAtom ploca 5))')
-        self.assertEqual(metta.interpret('ploca')[0].get_object().value, 5)
+        metta.run('!(call:latom (SetAtom ploca 5))')
+        self.assertEqual(metta.run('! ploca')[0][0].get_object().value, 5)
         self.assertEqual(ploca.get_object().value, 5)
 
     def test_frog_reasoning(self):
         metta = MeTTa()
 
-        metta.add_parse('''
+        metta.run('''
             (: if (-> Bool Atom Atom $t))
             (= (if True $then $else) $then)
             (= (if False $then $else) $else)
@@ -108,17 +108,17 @@ class ExamplesTest(unittest.TestCase):
             (= (Fritz eats_flies) True)
         ''')
 
-        fritz_frog = metta.interpret('(if (and ($x croaks) ($x eats_flies)) (= ($x frog) True) nop)')
+        fritz_frog = metta.run('!(if (and ($x croaks) ($x eats_flies)) (= ($x frog) True) nop)')[0]
         self.assertEqual(metta.parse_all('(= (Fritz frog) True)'), fritz_frog)
         metta.space.add_atom(fritz_frog[0])
 
-        self.assertEqual(metta.parse_all('(= (Fritz green) True)'),
-                metta.interpret('(if ($x frog) (= ($x green) True) nop)'))
+        self.assertEqual([metta.parse_all('(= (Fritz green) True)')],
+                metta.run('!(if ($x frog) (= ($x green) True) nop)'))
 
     def test_infer_function_application_type(self):
         metta = MeTTa()
 
-        metta.add_parse('''
+        metta.run('''
            (= (if True $then) $then)
 
            (= (: (apply $f $x) $r) (and (: $f (=> $a $r)) (: $x $a)))
@@ -127,29 +127,30 @@ class ExamplesTest(unittest.TestCase):
            (= (: "Hello" String) True)
         ''')
 
-        output = metta.interpret('(if (: (apply reverse "Hello") $t) $t)')
-        self.assertEqual(output, [S('String')])
+        output = metta.run('!(if (: (apply reverse "Hello") $t) $t)')
+        self.assertEqual(output, [[S('String')]])
 
     def test_plus_reduces_Z(self):
         metta = MeTTa()
 
-        metta.add_parse('''
+        metta.run('''
            (= (eq $x $x) True)
            (= (plus Z $y) $y)
            (= (plus (S $k) $y) (S (plus $k $y)))
         ''')
 
-        output = metta.interpret('(eq (+ 2 2) 4)')
-        self.assertEqual(output, [ValueAtom(True)])
-
-        output = metta.interpret('(eq (+ 2 3) 4)')
-        self.assertEqual(output, metta.parse_all('(eq 5 4)'))
-
-        output = metta.interpret('(eq (plus Z $n) $n)')
-        self.assertEqual(output, [ValueAtom(True)])
-
-        output = metta.interpret('(eq (plus (S Z) $n) $n)')
-        assert_atoms_are_equivalent(self, output, metta.parse_all('(eq (S $y) $y)'))
+        self.assertEqual(metta.run('''
+            !(eq (+ 2 2) 4)
+            !(eq (+ 2 3) 4)
+            !(eq (plus Z $n) $n)
+            '''),
+            [[ValueAtom(True)],
+             metta.parse_all('(eq 5 4)'),
+             [ValueAtom(True)]
+            ]
+        )
+        output = metta.run('!(eq (plus (S Z) $n) $n)')
+        assert_atoms_are_equivalent(self, output[0], metta.parse_all('(eq (S $y) $y)'))
 
     def test_multi_space(self):
         # NOTE: it is not recommended to split code into multiple spaces, because
@@ -159,7 +160,7 @@ class ExamplesTest(unittest.TestCase):
         # NOTE: these tests are not indended to remain valid, but are needed to
         # detect, if something is changes in the interpreter
         metta1 = MeTTa()
-        metta1.add_parse('''
+        metta1.run('''
             (= A B)
             (= (f-in-s2) failure)
             (= (how-it-works?) (f-in-s2))
@@ -167,27 +168,27 @@ class ExamplesTest(unittest.TestCase):
         ''')
         metta2 = MeTTa()
         metta2.add_atom("&space1", SpaceAtom(metta1.space, "&space1"))
-        metta2.add_parse('''
+        metta2.run('''
             (= C B)
             (= (f-in-s2) success)
             (= (find-in $s $x) (match $s (= $y $x) $y))
             (= (borrow $s $e) (match $s (= $e $r) $r))
         ''')
-        self.assertEqual(metta1.interpret('(inverse B)'), [S('A')])
-        self.assertEqual(metta2.interpret('(find-in &space1 B)'), [S('A')])
-        self.assertEqual(metta2.interpret('(find-in &self B)'), [S('C')])
+        self.assertEqual(metta1.run('!(inverse B)'), [[S('A')]])
+        self.assertEqual(metta2.run('!(find-in &space1 B)'), [[S('A')]])
+        self.assertEqual(metta2.run('!(find-in &self B)'), [[S('C')]])
         # `inverse` is successfully found in `&space1`
         # it resolves `&self` to metta1.space and matches against `(= A B)`
-        self.assertEqual(metta2.interpret('(borrow &space1 (inverse B))'), [S('A')])
+        self.assertEqual(metta2.run('!(borrow &space1 (inverse B))'), [[S('A')]])
         # `borrow` executes `how-it-works?` in context of `&space1` via `match`
         # but then the interpreter evaluates `(how-it-works?)` via equality query
         # in the original metta2.space
-        self.assertEqual(metta2.interpret('(borrow &space1 (how-it-works?))'), [S('success')])
-        self.assertEqual(metta1.interpret('(how-it-works?)'), [S('failure')])
+        self.assertEqual(metta2.run('!(borrow &space1 (how-it-works?))'), [[S('success')]])
+        self.assertEqual(metta1.run('!(how-it-works?)'), [[S('failure')]])
 
     def test_custom_deptypes(self):
         metta = MeTTa()
-        metta.add_parse('''
+        metta.run('''
             (= (:? $c)
                (match &self (:= $c $t) $t))
             (= (:? ($c $a))
@@ -228,34 +229,42 @@ class ExamplesTest(unittest.TestCase):
             (:= SamIsGreen (Green Sam))
             (:= SamCroaks (Croaks Sam))
         ''')
-        self.assertEqual(metta.interpret("(:? (HumansAreMortal SocratesIsHuman))"),
-                                        [E(S('Mortal'), S('Socrates'))])
-        self.assertEqual(metta.interpret("(:check (HumansAreMortal SocratesIsHuman) (Mortal Socrates))"),
-                                        [S('T')])
-        self.assertEqual(metta.interpret("(:? (= SocratesIsMortal (HumansAreMortal SocratesIsHuman)))"),
-                                        [S('Prop')])
-        self.assertEqual(metta.interpret("(:check (= (Mortal Plato) (Mortal Socrates)) Prop)"),
-                                        [S('T')])
-        self.assertEqual(metta.interpret("(:check (= (Human Socrates) (Mortal Socrates)) Prop)"),
-                                        [S('T')]) # they are both of Prop type and can be equated
-        self.assertEqual(metta.interpret("(:? (GreenAndCroaksIsFrog SamIsGreen SamCroaks))"),
-                                        [E(S('Frog'), S('Sam'))])
+        self.assertEqual(metta.run('''
+            !(:? (HumansAreMortal SocratesIsHuman))
+            !(:check (HumansAreMortal SocratesIsHuman) (Mortal Socrates))
+            !(:? (= SocratesIsMortal (HumansAreMortal SocratesIsHuman)))
+            !(:check (= (Mortal Plato) (Mortal Socrates)) Prop)
+            !(:check (= (Human Socrates) (Mortal Socrates)) Prop)
+            !(:? (GreenAndCroaksIsFrog SamIsGreen SamCroaks))
+            '''),
+            [[E(S('Mortal'), S('Socrates'))],
+             [S('T')],
+             [S('Prop')],
+             [S('T')],
+             [S('T')], # they are both of Prop type and can be equated
+             [E(S('Frog'), S('Sam'))]
+            ]
+        )
         # some negative examples
-        self.assertEqual(metta.interpret("(:check (= SocratesIsHuman SocratesIsMortal) Prop)"), [])
-        self.assertEqual(metta.interpret("(:? (SocratesIsHuman (Human Socrates)))"), [])
-        self.assertEqual(metta.interpret("(:? (Human Time))"), [])
+        self.assertEqual(metta.run('''
+            !(:check (= SocratesIsHuman SocratesIsMortal) Prop)
+            !(:? (SocratesIsHuman (Human Socrates)))
+            !(:? (Human Time))
+            '''),
+            [[], [], []]
+        )
         # The following doesn't work: `(:? (HumansAreMortal (Human Time)))` is matched against `(:? $c)`
         # Then, `(:= $c $t)` is matched against `(:= (HumansAreMortal (Human $t)) (Mortal $t))`
         # immediately resulting in `(Mortal Time)`. Thus, it doesn't matter that matching against
         # `(= (:? ($c $a))` doesn't work (since `(:? $a)` is incorrect).
-        # self.assertEqual(metta.interpret("(:? (HumansAreMortal (Human Time)))"),
-        #                                  [])
+        # self.assertEqual(metta.run("!(:? (HumansAreMortal (Human Time)))"),
+        #                                  [[]])
         # It should be noted that `(HumansAreMortal (Human Socrates))` is also an incorrectly typed
         # expression, since HumansAreMortal expects an element of (Human Socrates) - not the type itself
 
         # Another syntax
         metta = MeTTa()
-        metta.add_parse('''
+        metta.run('''
             (= (:? $c)
                (match &self (:: $c $t) $t))
             (= (:? ($c $a))
@@ -278,31 +287,41 @@ class ExamplesTest(unittest.TestCase):
             (:: SocratesIsMortal (Mortal Socrates))
         ''')
         # :? just infers the type of the expression - not its inhabitance
-        self.assertEqual(metta.interpret("(:? (Human Plato))"), [S('Type')])
-        self.assertEqual(metta.interpret("(:? (Human Time))"), [])
-        self.assertEqual(metta.interpret("(:? (HumansAreMortal SocratesIsHuman))"),
-                                        [E(S('Mortal'), S('Socrates'))])
-        self.assertEqual(metta.interpret("(:? (= SocratesIsMortal (HumansAreMortal SocratesIsHuman)))"),
-                                        [S('Type')])
-        self.assertEqual(metta.interpret("(:? (= Human Entity))"), [])
-        self.assertEqual(metta.interpret("(:? (= (Human Socrates) Plato))"), [])
-        self.assertEqual(metta.interpret("(:? (= SocratesIsHuman SocratesIsMortal))"), [])
-        # `(Human Socrates)` and `(Human Plato)` are different types, but they are elements
-        # of the same Type, so they can be equated
-        self.assertEqual(metta.interpret("(:? (= (Human Socrates) (Human Plato)))"),
-                                        [S('Type')])
-        self.assertEqual(metta.interpret("(:? (= Human Mortal))"),
-                                        [S('Type')])
-        self.assertEqual(metta.interpret("(:? (= HumansAreMortal Mortal))"), [])
+        # Note: `(Human Socrates)` and `(Human Plato)` are different types, but they are
+        # elements of the same Type, so they can be equated
+        self.assertEqual(metta.run('''
+            !(:? (Human Plato))
+            !(:? (Human Time))
+            !(:? (HumansAreMortal SocratesIsHuman))
+            !(:? (= SocratesIsMortal (HumansAreMortal SocratesIsHuman)))
+            !(:? (= Human Entity))
+            !(:? (= (Human Socrates) Plato))
+            !(:? (= SocratesIsHuman SocratesIsMortal))
+            !(:? (= (Human Socrates) (Human Plato)))
+            !(:? (= Human Mortal))
+            !(:? (= HumansAreMortal Mortal))
+            '''),
+            [[S('Type')],
+             [],
+             [E(S('Mortal'), S('Socrates'))],
+             [S('Type')],
+             [],
+             [],
+             [],
+             [S('Type')],
+             [S('Type')],
+             []
+            ]
+        )
         # Interestingly, the following example works correctly in this syntax, because
         # application `(Human Socrates)` is not mixed up with dependent type definition
-        self.assertEqual(metta.interpret("(:? (HumansAreMortal (Human Socrates)))"), [])
+        self.assertEqual(metta.run("!(:? (HumansAreMortal (Human Socrates)))"), [[]])
 
     def test_visit_kim(self):
         # legacy test
         # can be moved to b4_nondeterm.metta or removed
         metta = MeTTa()
-        metta.add_parse('''
+        metta.run('''
             (= (perform (visit $x)) (perform (lunch-order $x)))
             (= (perform (visit $x)) (perform (health-check $x)))
 
@@ -317,16 +336,19 @@ class ExamplesTest(unittest.TestCase):
             (= (achieve (health-check Kim)) True)
             (= (achieve (lunch-order Kim)) False)
         ''')
-        self.assertEqual(metta.interpret('(perform (visit Kim))'),
-            metta.parse_all('(perform (lunch-order Kim)) (perform (health-check Kim))'))
-        self.assertEqual(metta.interpret('(achieve (visit Kim))'),
-            metta.parse_all('(do (lunch-order Kim) (health-check Kim))'))
-        metta.add_parse('''
+        self.assertEqual(metta.run('''
+            !(perform (visit Kim))
+            !(achieve (visit Kim))
+            '''),
+            [metta.parse_all('(perform (lunch-order Kim)) (perform (health-check Kim))'),
+             metta.parse_all('(do (lunch-order Kim) (health-check Kim))')]
+        )
+        metta.run('''
             (= (do $goal1 $goal2) (achieve $goal1))
             (= (do $goal1 $goal2) (achieve $goal2))
         ''')
-        self.assertEqual(metta.interpret('(achieve (visit Kim))'),
-            metta.parse_all('False True'))
+        self.assertEqual(metta.run('!(achieve (visit Kim))'),
+            [metta.parse_all('False True')])
 
 class SomeObject():
 

--- a/python/tests/test_grounded_type.py
+++ b/python/tests/test_grounded_type.py
@@ -11,25 +11,25 @@ class GroundedTypeTest(unittest.TestCase):
             metta.parse_single("+").get_grounded_type(),
             metta.parse_single("*").get_grounded_type())
         self.assertEqual(
-            metta.interpret("(+ (* 1 4) 2)")[0].get_grounded_type(),
+            metta.run("!(+ (* 1 4) 2)")[0][0].get_grounded_type(),
             metta.parse_single("0").get_grounded_type())
         self.assertEqual(
-            metta.interpret("(or True False)")[0].get_grounded_type(),
+            metta.run("!(or True False)")[0][0].get_grounded_type(),
             metta.parse_single("False").get_grounded_type())
         self.assertEqual(
-            metta.interpret("(> (* 2 2) 1)")[0].get_grounded_type(),
-            metta.interpret("(or True True)")[0].get_grounded_type())
+            metta.run("!(> (* 2 2) 1)")[0][0].get_grounded_type(),
+            metta.run("!(or True True)")[0][0].get_grounded_type())
         metta.add_atom("untyped", ValueAtom(None))
         metta.add_atom("untop", OperationAtom("untop", lambda: None))
         self.assertEqual(
-            metta.interpret("(untop)")[0].get_grounded_type(),
+            metta.run("!(untop)")[0][0].get_grounded_type(),
             metta.parse_single("untyped").get_grounded_type())
         self.assertNotEqual(
-            metta.interpret("(untop)")[0].get_grounded_type(),
-            metta.interpret("(+ 1 1)")[0].get_grounded_type())
+            metta.run("!(untop)")[0][0].get_grounded_type(),
+            metta.run("!(+ 1 1)")[0][0].get_grounded_type())
         self.assertNotEqual(
-            metta.interpret("(> 1 1)")[0].get_grounded_type(),
-            metta.interpret("(+ 1 1)")[0].get_grounded_type())
+            metta.run("!(> 1 1)")[0][0].get_grounded_type(),
+            metta.run("!(+ 1 1)")[0][0].get_grounded_type())
 
     def test_higher_func(self):
         metta = MeTTa()
@@ -44,46 +44,66 @@ class GroundedTypeTest(unittest.TestCase):
                 #FIXME: interpreter refuses to execute typed curry_num
                 #[['Number', 'Number', 'Number'], 'Number', ['Number', 'Number']],
                 unwrap=False))
-        self.assertEqual(metta.interpret("((curry_num + 1) 2)"),
-                         metta.interpret("3"))
+        self.assertEqual(metta.run("!((curry_num + 1) 2)"),
+                         metta.run("! 3"))
 
     def test_meta_types(self):
         metta = MeTTa()
         ### Basic functional types
         metta.add_atom(r"id_num", OperationAtom("id_num", lambda x: x, ['Number', 'Number']))
         metta.add_atom(r"as_int", OperationAtom("as_int", lambda x: x, ['Number', 'Int']))
-        v1 = metta.interpret("(id_num (+ 2 2))")
-        v2 = metta.interpret("4")
-        v3 = metta.interpret("(as_int (+ 2 2))")
+        v1 = metta.run("!(id_num (+ 2 2))")[0]
+        v2 = metta.run("! 4")[0]
+        v3 = metta.run("!(as_int (+ 2 2))")[0]
         self.assertEqual(v1, v2)
         self.assertEqual(v1[0].get_grounded_type(), v2[0].get_grounded_type())
         self.assertNotEqual(v1[0].get_grounded_type(), v3[0].get_grounded_type())
         # Untyped symbols don't cause type error, but the expression is not reduced
-        self.assertEqual(metta.interpret("(id_num untyp)"), metta.parse_all("(id_num untyp)"))
+        self.assertEqual(metta.run("!(id_num untyp)"), [metta.parse_all("(id_num untyp)")])
         # Typed symbols cause empty results due to type mismatch
-        metta.add_parse("(: myAtom myType)")
-        self.assertEqual(metta.interpret("(id_num myAtom)"), [])
-        self.assertEqual(metta.interpret("(id_num False)"), [])
+        metta.run("(: myAtom myType)")
+        self.assertEqual(metta.run('''
+            !(id_num myAtom)
+            !(id_num False)
+            '''),
+            [[], []])
         ### Grounded functions over Atom
         ### (should use unwrap=False to deal with non-grounded atoms)
         # All grounded and ungrounded, typed and untyped symbols should be processed
         metta.add_atom(r"id_atom", OperationAtom("id_atom",
             lambda x: [x], [AtomType.ATOM, AtomType.ATOM], unwrap=False))
-        self.assertEqual(metta.interpret("(id_atom 1)"), metta.parse_all("1"))
-        self.assertEqual(metta.interpret("(id_atom myAtom)"), metta.parse_all("myAtom"))
-        self.assertEqual(metta.interpret("(id_atom untyp)"), metta.parse_all("untyp"))
+        self.assertEqual(metta.run('''
+            !(id_atom 1)
+            !(id_atom myAtom)
+            !(id_atom untyp)
+            ''', flat=True),
+            metta.parse_all('''
+            1
+            myAtom
+            untyp
+            '''))
         # FIXME: why does it get reduced?
-        # self.assertEqual(metta.interpret("(id_atom (+ 1 1))"), metta.parse_all("(+ 1 1)"))
+        # self.assertEqual(metta.run("!(id_atom (+ 1 1))"), [metta.parse_all("(+ 1 1)")])
         ### Polymorphic without unwrapping
         # Nothing is done with `$t` on the Grounded side, but we check that:
         # - the argument has really a variable type
         # - the interpreter doesn't reject to process this grounded function
         metta.add_atom(r"id_poly_w", OperationAtom("id_poly_w", lambda x: [x], ['$t', '$t'], unwrap=False))
-        self.assertEqual(metta.interpret("(id_poly_w 1)"), metta.parse_all("1"))
-        self.assertEqual(metta.interpret("(id_poly_w myAtom)"), metta.parse_all("myAtom"))
-        self.assertEqual(metta.interpret("(id_poly_w untyp)"), metta.parse_all("untyp"))
-        self.assertEqual(metta.interpret("(id_poly_w (+ 1 1))"), metta.parse_all("2"))
-        self.assertEqual(metta.interpret("(+ 1 (id_poly_w 2))"), metta.parse_all("3"))
+        self.assertEqual(metta.run('''
+            !(id_poly_w 1)
+            !(id_poly_w myAtom)
+            !(id_poly_w untyp)
+            !(id_poly_w (+ 1 1))
+            !(+ 1 (id_poly_w 2))
+            ''', flat=True),
+            metta.parse_all('''
+             1
+             myAtom
+             untyp
+             2
+             3
+            ''')
+        )
         ### Polymorphic with unwrapping
         # TODO: automatic unwrapping of arguments of grounded polymorphic function
         #       is not supported on the Python side
@@ -91,12 +111,22 @@ class GroundedTypeTest(unittest.TestCase):
         ### Undefined arguments
         # It is a bad idea to have an undefined result with automatic wrapping, but it's ok here
         metta.add_atom(r"id_undef", OperationAtom("id_undef", lambda x: x, [AtomType.UNDEFINED, AtomType.UNDEFINED]))
-        self.assertEqual(metta.interpret("(id_undef 1)"), metta.parse_all("1"))
-        self.assertEqual(metta.interpret("(id_undef False)"), metta.parse_all("False"))
+        self.assertEqual(metta.run('''
+            !(id_undef 1)
+            !(id_undef False)
+            !(id_undef (+ 1 1))
+            ''', flat=True),
+            metta.parse_all("1 False 2"))
         # This will not be reduced, because unwrapping expects a grounded atom
-        self.assertEqual(metta.interpret("(id_undef myAtom)"), metta.parse_all("(id_undef myAtom)"))
-        self.assertEqual(metta.interpret("(id_undef untyp)"), metta.parse_all("(id_undef untyp)"))
-        self.assertEqual(metta.interpret("(id_undef (+ 1 1))"), metta.parse_all("2"))
+        self.assertEqual(metta.run('''
+            !(id_undef myAtom)
+            !(id_undef untyp)
+            ''', flat=True),
+            metta.parse_all('''
+             (id_undef myAtom)
+             (id_undef untyp)
+            ''')
+        )
 
     # TODO: For now OperationAtom without type has Undefined type. We discussed
     # that it would be nice to have something like *args in the future. The

--- a/python/tests/test_list_definition.py
+++ b/python/tests/test_list_definition.py
@@ -13,7 +13,7 @@ class ListDefinitionTest(unittest.TestCase):
     # not interfere with executing functions operating on List.
     def test_list_definition(self):
         metta = MeTTa()
-        metta.add_parse('''
+        metta.run('''
                 ;; Define conditional
                 (= (if True $x $y) $x)
                 (= (if False $x $y) $y)
@@ -36,26 +36,29 @@ class ListDefinitionTest(unittest.TestCase):
         ''')
 
         # Test insert
-        self.assertEqual(
-            metta.interpret('(insert 1 Nil)'),
-            metta.parse_all('(Cons 1 Nil)'))
-        self.assertEqual(
-            metta.interpret('(insert 2 (insert 1 Nil))'),
-            metta.parse_all('(Cons 1 (Cons 2 Nil))'))
-        self.assertEqual(
-            metta.interpret('(insert 3 (insert 2 (insert 1 Nil)))'),
-            metta.parse_all('(Cons 1 (Cons 2 (Cons 3 Nil)))'))
+        self.assertEqual(metta.run('''
+            !(insert 1 Nil)
+            !(insert 2 (insert 1 Nil))
+            !(insert 3 (insert 2 (insert 1 Nil)))
+            ''', flat=True),
+            metta.parse_all('''
+             (Cons 1 Nil)
+             (Cons 1 (Cons 2 Nil))
+             (Cons 1 (Cons 2 (Cons 3 Nil)))
+            '''))
 
         # Test sort
-        self.assertEqual(
-            metta.interpret('(sort (Cons 1 Nil))'),
-            metta.parse_all('(Cons 1 Nil)'))
-        self.assertEqual(
-            metta.interpret('(sort (Cons 2 (Cons 1 Nil)))'),
-            metta.parse_all('(Cons 1 (Cons 2 Nil))'))
-        self.assertEqual(
-            metta.interpret('(sort (Cons 3 (Cons 1 (Cons 2 Nil))))'),
-            metta.parse_all('(Cons 1 (Cons 2 (Cons 3 Nil)))'))
+        self.assertEqual(metta.run('''
+            !(sort (Cons 1 Nil))
+            !(sort (Cons 2 (Cons 1 Nil)))
+            !(sort (Cons 3 (Cons 1 (Cons 2 Nil))))
+            ''', flat=True),
+            metta.parse_all('''
+             (Cons 1 Nil)
+             (Cons 1 (Cons 2 Nil))
+             (Cons 1 (Cons 2 (Cons 3 Nil)))
+            ''')
+        )
 
 
 if __name__ == "__main__":

--- a/python/tests/test_minecraft.py
+++ b/python/tests/test_minecraft.py
@@ -41,7 +41,7 @@ class MinecraftTest(unittest.TestCase):
         metta.add_token("craft", lambda _: newCraftOp(inventory))
         metta.add_token("mine", lambda _: newMineOp(inventory))
 
-        metta.add_parse('''
+        metta.run('''
             (: if (-> Bool Atom Atom Atom))
             (= (if True $then $else) $then)
             (= (if False $then $else) $else)
@@ -68,7 +68,7 @@ class MinecraftTest(unittest.TestCase):
         ''')
 
         self.assertFalse(S('wooden-pickaxe') in inventory)
-        metta.interpret('(wooden-pickaxe)')
+        metta.run('!(wooden-pickaxe)')
         self.assertTrue(S('four-planks') in inventory)
         self.assertTrue(S('crafting-table') in inventory)
         self.assertTrue(S('wooden-pickaxe') in inventory)
@@ -80,7 +80,7 @@ class MinecraftTest(unittest.TestCase):
                      S('iron-ingot'), S('iron-pickaxe')]
         metta.add_token("in-inventory", lambda _: newInInventory(inventory))
 
-        metta.add_parse('''
+        metta.run('''
             (= (can-be-mined diamond) True)
             (= (can-be-made diamond) False)
             (= (diamond mined-using iron-pickaxe) True)
@@ -114,7 +114,7 @@ class MinecraftTest(unittest.TestCase):
             (= (get $x) (if (and (not (in-inventory $x)) (can-be-made $x)) (make $x) nop))
         ''')
 
-        metta.interpret('(get diamond)')
+        metta.run('!(get diamond)')
         # (, (get iron-pickaxe) (find diamond-ore)
         #    (do-mine diamond diamond-ore iron-pickaxe))
 

--- a/python/tests/test_nondeterm.py
+++ b/python/tests/test_nondeterm.py
@@ -7,18 +7,18 @@ class NondetermTest(unittest.TestCase):
 
     def test_collapse(self):
         metta = MeTTa()
-        metta.add_parse('''
+        metta.run('''
             (= (f) a)
             (= (f) b)
         ''')
-        self.assertEqual(metta.interpret("(collapse (f))"),
-                         metta.parse_all("(a b)"))
+        self.assertEqual(metta.run("!(collapse (f))"),
+                         [metta.parse_all("(a b)")])
 
     def test_superpose(self):
         metta = MeTTa()
-        metta.add_parse('''
+        metta.run('''
             (= (f $x) (+ $x 1))
         ''')
-        self.assertEqual(metta.interpret("(f (superpose (1 2)))"),
-                         metta.parse_all("2 3"))
+        self.assertEqual(metta.run("!(f (superpose (1 2)))"),
+                         [metta.parse_all("2 3")])
 

--- a/python/tests/test_pln_tv.py
+++ b/python/tests/test_pln_tv.py
@@ -13,7 +13,7 @@ class PLNTVTest(unittest.TestCase):
         # `get-tv` "metarule" based on `match` to run
         # FIXME? `(PA)` and `(PB)` are used because otherwise
         # substitution wasn't invoked (atm of test creation)
-        metta.add_parse('''
+        metta.run('''
                 (= (if True $then $else) $then)
                 (= (if False $then $else) $else)
                 (= (min $a $b) (if (< $a $b) $a $b))
@@ -32,10 +32,10 @@ class PLNTVTest(unittest.TestCase):
                 (= (PB) (Evaluation (Predicate P) (Concept B)))
         ''')
         self.assertEqual(
-            metta.interpret('(get-tv (AndLink (PA) (PB)))'),
-            metta.parse_all('(stv 0.3 0.8)'))
+            metta.run('!(get-tv (AndLink (PA) (PB)))'),
+            [metta.parse_all('(stv 0.3 0.8)')])
 
-        metta.add_parse('''
+        metta.run('''
             (= (get-tv $x)
                (match &self (.tv (Implication $y $x) (stv $str $conf))
                             (stv (* (s-tv (get-tv $y)) $str)
@@ -45,14 +45,14 @@ class PLNTVTest(unittest.TestCase):
                  (stv 0.9 0.9))
         ''')
         self.assertEqual(
-            metta.interpret('(get-tv (PA))'),
-            metta.parse_all('(stv 0.5 0.8)'))
+            metta.run('!(get-tv (PA))'),
+            [metta.parse_all('(stv 0.5 0.8)')])
 
     def test_fuzzy_conjunction_fn(self):
         metta = MeTTa()
         # `stv` as a mix of function and constructor
         # working through ordinary equalities
-        metta.add_parse('''
+        metta.run('''
                 (= (if True $then $else) $then)
                 (= (if False $then $else) $else)
                 (= (min $a $b) (if (< $a $b) $a $b))
@@ -65,24 +65,24 @@ class PLNTVTest(unittest.TestCase):
                 (= (stv (P B)) (stv 0.3 0.9))
         ''')
         # JIC, if somebody wants "type annotations"
-        metta.add_parse('''
+        metta.run('''
                 (: A Concept)
                 (: B Concept)
                 (: P Predicate)
         ''')
         self.assertEqual(
-            metta.interpret('(stv (And (P A) (P B)))'),
-            metta.parse_all('(stv 0.3 0.8)'))
-        metta.add_parse('''
+            metta.run('!(stv (And (P A) (P B)))'),
+            [metta.parse_all('(stv 0.3 0.8)')])
+        metta.run('''
                 (= (pln $expr) ($expr (stv $expr)))
         ''')
         # (would actually count (stv (P A)) twice for probabilistic version)
         self.assertEqual(
-            metta.interpret('(pln (And (P A) (P $x)))'),
-            metta.parse_all('''
+            metta.run('!(pln (And (P A) (P $x)))'),
+            [metta.parse_all('''
                 ((And (P A) (P A)) (stv 0.5 0.8))
                 ((And (P A) (P B)) (stv 0.3 0.8))
-            '''))
+            ''')])
 
 
 if __name__ == "__main__":

--- a/python/tests/test_unification.py
+++ b/python/tests/test_unification.py
@@ -8,12 +8,10 @@ class UnificationTest(unittest.TestCase):
 
     def test_factorial_via_unification(self):
         metta = MeTTa()
-        metta.add_parse('''
+        metta.run('''
             (: if (-> Bool Atom Atom Atom))
             (= (if True $then $else) $then)
             (= (if False $then $else) $else)
             (= (fact $n) (if (== $n 0) 1 (* (fact (- $n 1)) $n)))
         ''')
-        result = metta.interpret('(fact 5)')
-
-        self.assertEqual(result, [ValueAtom(120)])
+        self.assertEqual(metta.run('!(fact 5)'), [[ValueAtom(120)]])


### PR DESCRIPTION
Use `metta.run` in unit-tests instead of `metta.interpret` and `metta.add_parse`. The reason for this is that we want a unified behavior for the process of interpretation and insertion of expressions, in particular, controllable by `pragma`'s (which are processed by `run`, e.g. for type-checking). This means that we need to get rid of interface functions, which bypass the runner.