### PR TITLE
Metta interpreter in rust: preparations

### DIFF
--- a/c/src/metta.rs
+++ b/c/src/metta.rs
@@ -108,7 +108,7 @@ pub unsafe extern "C" fn sexpr_space_add_str(space: *mut sexpr_space_t, text: *c
 #[no_mangle]
 pub unsafe extern "C" fn sexpr_space_into_grounding_space(sexpr: *const sexpr_space_t,
         gnd: *mut grounding_space_t) {
-    (*sexpr).space.into_grounding_space(&mut (*gnd).space);
+    (*sexpr).space.into_grounding_space(&mut (*gnd).space.borrow_mut());
 }
 
 #[no_mangle] pub static ATOM_TYPE_UNDEFINED: &atom_t = &atom_t{ atom: hyperon::metta::ATOM_TYPE_UNDEFINED };
@@ -121,18 +121,18 @@ pub unsafe extern "C" fn sexpr_space_into_grounding_space(sexpr: *const sexpr_sp
 
 #[no_mangle]
 pub unsafe extern "C" fn check_type(space: *const grounding_space_t, atom: *const atom_t, typ: *const atom_t) -> bool {
-    hyperon::metta::types::check_type(&(*space).space, &(*atom).atom, &(*typ).atom)
+    hyperon::metta::types::check_type(&(*space).space.borrow(), &(*atom).atom, &(*typ).atom)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn validate_atom(space: *const grounding_space_t, atom: *const atom_t) -> bool {
-    hyperon::metta::types::validate_atom(&(*space).space, &(*atom).atom)
+    hyperon::metta::types::validate_atom(&(*space).space.borrow(), &(*atom).atom)
 }
 
 #[no_mangle]
 pub extern "C" fn get_atom_types(space: *const grounding_space_t, atom: *const atom_t,
         callback: c_atoms_callback_t, context: *mut c_void) {
-    let space = unsafe{ &(*space).space };
+    let space = unsafe{ &(*space).space.borrow() };
     let atom = unsafe{ &(*atom).atom };
     let types = hyperon::metta::types::get_atom_types(space, atom);
     return_atoms(&types, callback, context);
@@ -148,12 +148,7 @@ pub struct step_result_t<'a> {
 pub extern "C" fn interpret_init<'a>(space: *mut grounding_space_t, expr: *const atom_t) -> *mut step_result_t<'a> {
     let space = unsafe{ &(*space) };
     let expr = unsafe{ &(*expr) };
-    // FIXME: here code works compiles because it is a C API and lifetime checker
-    // cannot verify that pointer to the space outlives pointer to the step result.
-    // Consequently C API can call interpret_init, free space and after that call
-    // interpret_step which will lead to panic as step_result_t contains a reference
-    // to the space.
-    let step = interpreter::interpret_init(&space.space, &expr.atom);
+    let step = interpreter::interpret_init(space.space.clone(), &expr.atom);
     Box::into_raw(Box::new(step_result_t{ result: step }))
 }
 

--- a/c/src/space.rs
+++ b/c/src/space.rs
@@ -47,12 +47,12 @@ pub unsafe extern "C" fn grounding_space_replace(space: *mut grounding_space_t, 
 
 #[no_mangle]
 pub unsafe extern "C" fn grounding_space_len(space: *const grounding_space_t) -> usize {
-    (*space).space.borrow_vec().len()
+    (*space).space.content().len()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn grounding_space_get(space: *const grounding_space_t, idx: usize) -> *mut atom_t {
-    atom_to_ptr((*space).space.borrow_vec()[idx].clone())
+    atom_to_ptr((*space).space.content()[idx].clone())
 }
 
 #[repr(C)]

--- a/c/src/space.rs
+++ b/c/src/space.rs
@@ -1,5 +1,6 @@
 use hyperon::*;
 use hyperon::space::grounding::*;
+use hyperon::common::ptr::ArcMutex;
 
 use crate::atom::*;
 use crate::util::*;
@@ -10,12 +11,12 @@ use std::ffi::CString;
 // GroundingSpace
 
 pub struct grounding_space_t {
-    pub space: GroundingSpace,
+    pub space: ArcMutex<GroundingSpace>,
 }
 
 #[no_mangle]
 pub extern "C" fn grounding_space_new() -> *mut grounding_space_t {
-    Box::into_raw(Box::new(grounding_space_t{ space: GroundingSpace::new() })) 
+    Box::into_raw(Box::new(grounding_space_t{ space: ArcMutex::new(GroundingSpace::new()) }))
 }
 
 #[no_mangle]
@@ -31,28 +32,28 @@ pub unsafe extern "C" fn grounding_space_eq(a: *const grounding_space_t, b: *con
 #[no_mangle]
 pub unsafe extern "C" fn grounding_space_add(space: *mut grounding_space_t, atom: *mut atom_t) {
     let c_atom = Box::from_raw(atom);
-    (*space).space.add(c_atom.atom);
+    (*space).space.borrow_mut().add(c_atom.atom);
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn grounding_space_remove(space: *mut grounding_space_t, atom: *const atom_t) -> bool {
-    (*space).space.remove(&(*atom).atom)
+    (*space).space.borrow_mut().remove(&(*atom).atom)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn grounding_space_replace(space: *mut grounding_space_t, from: *const atom_t, to: *mut atom_t) -> bool {
     let c_to = Box::from_raw(to);
-    (*space).space.replace(&(*from).atom, c_to.atom)
+    (*space).space.borrow_mut().replace(&(*from).atom, c_to.atom)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn grounding_space_len(space: *const grounding_space_t) -> usize {
-    (*space).space.content().len()
+    (*space).space.borrow().content().len()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn grounding_space_get(space: *const grounding_space_t, idx: usize) -> *mut atom_t {
-    atom_to_ptr((*space).space.content()[idx].clone())
+    atom_to_ptr((*space).space.borrow().content()[idx].clone())
 }
 
 #[repr(C)]
@@ -66,7 +67,7 @@ pub type binding_array_t = array_t<binding_t>;
 #[no_mangle]
 pub extern "C" fn grounding_space_query(space: *const grounding_space_t,
         pattern: *const atom_t, callback: lambda_t<binding_array_t>, context: *mut c_void) {
-    let results = unsafe { (*space).space.query(&((*pattern).atom)) };
+    let results = unsafe { (*space).space.borrow().query(&((*pattern).atom)) };
     for result in results {
         let mut vars : Vec<CString> = Vec::new();
         let vec = result.iter().map(|(k, v)| {
@@ -86,7 +87,7 @@ pub extern "C" fn grounding_space_query(space: *const grounding_space_t,
 pub extern "C" fn grounding_space_subst(space: *const grounding_space_t,
         pattern: *const atom_t, templ: *const atom_t,
         callback: c_atoms_callback_t, context: *mut c_void) {
-    let results = unsafe { (*space).space.subst(&((*pattern).atom), &((*templ).atom)) };
+    let results = unsafe { (*space).space.borrow().subst(&((*pattern).atom), &((*templ).atom)) };
     return_atoms(&results, callback, context);
 }
 

--- a/lib/src/common/arithmetics.rs
+++ b/lib/src/common/arithmetics.rs
@@ -97,7 +97,7 @@ mod tests {
         // (+ 3 5)
         let expr = expr!({SUM} {3} {5});
 
-        assert_eq!(interpret(space, &expr), Ok(vec![Atom::value(8)]));
+        assert_eq!(interpret(&space, &expr), Ok(vec![Atom::value(8)]));
     }
 
     #[test]
@@ -106,7 +106,7 @@ mod tests {
         // (+ 4 (+ 3 5))
         let expr = expr!({SUM} {4} ({SUM} {3} {5}));
 
-        assert_eq!(interpret(space, &expr), Ok(vec![Atom::value(12)]));
+        assert_eq!(interpret(&space, &expr), Ok(vec![Atom::value(12)]));
     }
 
     #[test]
@@ -140,6 +140,6 @@ mod tests {
                    {1})));
 
         let expr = expr!("fac" {3});
-        assert_eq!(interpret(space, &expr), Ok(vec![Atom::value(6)]));
+        assert_eq!(interpret(&space, &expr), Ok(vec![Atom::value(6)]));
     }
 }

--- a/lib/src/common/mod.rs
+++ b/lib/src/common/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod plan;
 pub mod collections;
+pub mod ptr;
 mod arithmetics;
 
 pub use arithmetics::*;

--- a/lib/src/common/ptr.rs
+++ b/lib/src/common/ptr.rs
@@ -100,17 +100,25 @@ impl<T> ArcMutex<T> {
     pub fn as_arc(&self) -> Arc<Mutex<T>> {
         self.0.clone()
     }
+
+    pub fn borrow(&self) -> Box<dyn Deref<Target=T> + '_> {
+        Box::new(self.0.lock().expect("Mutex is poisoned"))
+    }
+
+    pub fn borrow_mut(&mut self) -> Box<dyn DerefMut<Target=T> + '_> {
+        Box::new(self.0.lock().expect("Mutex is poisoned"))
+    }
 }
 
 impl<T> SmartPtr<T> for ArcMutex<T> {
     fn borrow(&self) -> Box<dyn Deref<Target=T> + '_> {
-        Box::new(self.0.lock().expect("Mutex is poisoned"))
+        self.borrow()
     }
 }
 
 impl<T> SmartPtrMut<T> for ArcMutex<T> {
     fn borrow_mut(&mut self) -> Box<dyn DerefMut<Target=T> + '_> {
-        Box::new(self.0.lock().expect("Mutex is poisoned"))
+        self.borrow_mut()
     }
 }
 

--- a/lib/src/common/ptr.rs
+++ b/lib/src/common/ptr.rs
@@ -1,0 +1,133 @@
+use std::sync::{Arc, Mutex};
+use std::ops::{Deref, DerefMut};
+use std::rc::Rc;
+use std::cell::RefCell;
+use std::fmt::Debug;
+
+pub trait SmartPtr<T> {
+    fn borrow(&self) -> Box<dyn Deref<Target=T> + '_>;
+}
+
+pub trait SmartPtrMut<T> : SmartPtr<T> {
+    fn borrow_mut(&mut self) -> Box<dyn DerefMut<Target=T> + '_>;
+}
+
+impl<T> SmartPtr<T> for Arc<Mutex<T>> {
+    fn borrow(&self) -> Box<dyn Deref<Target=T> + '_> {
+        Box::new(self.lock().expect("Mutex is poisoned"))
+    }
+}
+
+impl<T> SmartPtrMut<T> for Arc<Mutex<T>> {
+    fn borrow_mut(&mut self) -> Box<dyn DerefMut<Target=T> + '_> {
+        Box::new(self.lock().expect("Mutex is poisoned"))
+    }
+}
+
+impl<T> SmartPtr<T> for Rc<RefCell<T>> {
+    fn borrow(&self) -> Box<dyn Deref<Target=T> + '_> {
+        Box::new(RefCell::borrow(self))
+    }
+}
+
+impl<T> SmartPtrMut<T> for Rc<RefCell<T>> {
+    fn borrow_mut(&mut self) -> Box<dyn DerefMut<Target=T> + '_> {
+        Box::new(RefCell::borrow_mut(self))
+    }
+}
+
+struct RefHolder<'a, T: 'a>(&'a &'a T);
+
+impl<'a, T: 'a> Deref for RefHolder<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        *(self.0)
+    }
+}
+
+impl<T> SmartPtr<T> for &T {
+    fn borrow<'a>(&'a self) -> Box<dyn Deref<Target=T> + '_> {
+        Box::new(RefHolder(self))
+    }
+}
+
+struct RefHolderMut<'a, T: 'a>(&'a &'a mut T);
+
+impl<'a, T: 'a> Deref for RefHolderMut<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        *(self.0)
+    }
+}
+
+impl<T> SmartPtr<T> for &mut T {
+    fn borrow<'a>(&'a self) -> Box<dyn Deref<Target=T> + '_> {
+        Box::new(RefHolderMut(self))
+    }
+}
+
+struct RefHolderMutMut<'a, 'b: 'a, T: 'a>(&'a mut &'b mut T);
+
+impl<'a, 'b: 'a, T: 'a> Deref for RefHolderMutMut<'a, 'b, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        *(self.0)
+    }
+}
+
+impl<'a, 'b: 'a, T: 'a> DerefMut for RefHolderMutMut<'a, 'b, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        *(self.0)
+    }
+}
+
+impl<T> SmartPtrMut<T> for &mut T {
+    fn borrow_mut(&mut self) -> Box<dyn DerefMut<Target=T> + '_> {
+        Box::new(RefHolderMutMut(self))
+    }
+}
+
+pub struct ArcMutex<T>(Arc<Mutex<T>>);
+
+impl<T> ArcMutex<T> {
+    pub fn new(value: T) -> Self {
+        Self(Arc::new(Mutex::new(value)))
+    }
+
+    pub fn as_arc(&self) -> Arc<Mutex<T>> {
+        self.0.clone()
+    }
+}
+
+impl<T> SmartPtr<T> for ArcMutex<T> {
+    fn borrow(&self) -> Box<dyn Deref<Target=T> + '_> {
+        Box::new(self.0.lock().expect("Mutex is poisoned"))
+    }
+}
+
+impl<T> SmartPtrMut<T> for ArcMutex<T> {
+    fn borrow_mut(&mut self) -> Box<dyn DerefMut<Target=T> + '_> {
+        Box::new(self.0.lock().expect("Mutex is poisoned"))
+    }
+}
+
+impl<T> PartialEq for ArcMutex<T> {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::as_ptr(&self.0) == Arc::as_ptr(&other.0)
+    }
+}
+
+impl<T> Clone for ArcMutex<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<T: Debug> Debug for ArcMutex<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
+}

--- a/lib/src/metta/examples/types.rs
+++ b/lib/src/metta/examples/types.rs
@@ -13,16 +13,15 @@ fn test_types_in_metta() {
     space.add(expr!("=" ("if" {false} then else) else));
     space.add(expr!(":" "if" ("->" "bool" "Atom" "Atom" "Atom")));
     space.add(expr!("=" ("fac" n) ("if" ("check" (":" n "Nat")) ("if" ({EQ} n {1}) {1} ({MUL} n ("fac" ({SUB} n {1})))) ({ERR}))));
-    let space = space;
 
-    assert_eq!(interpret(space.clone(), &expr!("check" (":" {3} "Int"))), Ok(vec![expr!({true})]));
-    assert_eq!(interpret(space.clone(), &expr!("check" (":" {(-3)} "Int"))), Ok(vec![expr!({true})]));
-    assert_eq!(interpret(space.clone(), &expr!("check" (":" {3} "Nat"))), Ok(vec![expr!({true})]));
-    assert_eq!(interpret(space.clone(), &expr!("check" (":" {(-3)} "Nat"))), Ok(vec![expr!({false})]));
-    assert_eq!(interpret(space.clone(), &expr!("if" ("check" (":" {(3)} "Nat")) "ok" "nok")), Ok(vec![expr!("ok")]));
-    assert_eq!(interpret(space.clone(), &expr!("if" ("check" (":" {(-3)} "Nat")) "ok" "nok")), Ok(vec![expr!("nok")]));
-    assert_eq!(interpret(space.clone(), &expr!("fac" {1})), Ok(vec![expr!({1})]));
-    assert_eq!(interpret(space.clone(), &expr!("fac" {3})), Ok(vec![expr!({6})]));
+    assert_eq!(interpret(&space, &expr!("check" (":" {3} "Int"))), Ok(vec![expr!({true})]));
+    assert_eq!(interpret(&space, &expr!("check" (":" {(-3)} "Int"))), Ok(vec![expr!({true})]));
+    assert_eq!(interpret(&space, &expr!("check" (":" {3} "Nat"))), Ok(vec![expr!({true})]));
+    assert_eq!(interpret(&space, &expr!("check" (":" {(-3)} "Nat"))), Ok(vec![expr!({false})]));
+    assert_eq!(interpret(&space, &expr!("if" ("check" (":" {(3)} "Nat")) "ok" "nok")), Ok(vec![expr!("ok")]));
+    assert_eq!(interpret(&space, &expr!("if" ("check" (":" {(-3)} "Nat")) "ok" "nok")), Ok(vec![expr!("nok")]));
+    assert_eq!(interpret(&space, &expr!("fac" {1})), Ok(vec![expr!({1})]));
+    assert_eq!(interpret(&space, &expr!("fac" {3})), Ok(vec![expr!({6})]));
 }
 
 #[test]
@@ -43,8 +42,8 @@ fn test_insert_into_sorted_list() {
     ");
 
 
-    assert_eq!(interpret(space.clone(), &metta_atom("(insert 1 Nil)")),
+    assert_eq!(interpret(&space, &metta_atom("(insert 1 Nil)")),
         Ok(vec![metta_atom("(Cons 1 Nil)")]));
-    assert_eq!(interpret(space.clone(), &metta_atom("(insert 3 (insert 2 (insert 1 Nil)))")),
+    assert_eq!(interpret(&space, &metta_atom("(insert 3 (insert 2 (insert 1 Nil)))")),
         Ok(vec![metta_atom("(Cons 1 (Cons 2 (Cons 3 Nil)))")]));
 }

--- a/lib/src/metta/interpreter.rs
+++ b/lib/src/metta/interpreter.rs
@@ -122,7 +122,7 @@ impl Debug for InterpretedAtom {
 }
 
 type Results = Vec<InterpretedAtom>;
-type NoInputPlan = Box<dyn Plan<(), Results>>;
+type NoInputPlan<'a> = Box<dyn Plan<'a, (), Results> + 'a>;
 
 /// Initialize interpreter and returns the result of the zero step.
 /// It can be error, immediate result or interpretation plan to be executed.
@@ -131,7 +131,7 @@ type NoInputPlan = Box<dyn Plan<(), Results>>;
 /// # Arguments
 /// * `space` - atomspace to query for interpretation
 /// * `expr` - atom to interpret
-pub fn interpret_init(space: GroundingSpace, expr: &Atom) -> StepResult<Vec<InterpretedAtom>> {
+pub fn interpret_init<'a>(space: &'a GroundingSpace, expr: &Atom) -> StepResult<'a, Vec<InterpretedAtom>> {
     let context = InterpreterContextRef::new(space);
     interpret_as_type_plan(context,
         InterpretedAtom(expr.clone(), Bindings::new()),
@@ -144,7 +144,7 @@ pub fn interpret_init(space: GroundingSpace, expr: &Atom) -> StepResult<Vec<Inte
 ///
 /// # Arguments
 /// * `step` - [StepResult::Execute] result from the previous step.
-pub fn interpret_step(step: StepResult<Vec<InterpretedAtom>>) -> StepResult<Vec<InterpretedAtom>> {
+pub fn interpret_step<'a>(step: StepResult<'a, Vec<InterpretedAtom>>) -> StepResult<'a, Vec<InterpretedAtom>> {
     log::debug!("current plan:\n{:?}", step);
     match step {
         StepResult::Execute(plan) => plan.step(()),
@@ -159,7 +159,7 @@ pub fn interpret_step(step: StepResult<Vec<InterpretedAtom>>) -> StepResult<Vec<
 /// # Arguments
 /// * `space` - atomspace to query for interpretation
 /// * `expr` - atom to interpret
-pub fn interpret(space: GroundingSpace, expr: &Atom) -> Result<Vec<Atom>, String> {
+pub fn interpret(space: &GroundingSpace, expr: &Atom) -> Result<Vec<Atom>, String> {
     let mut step = interpret_init(space, expr);
     while step.has_next() {
         step = interpret_step(step);
@@ -219,24 +219,24 @@ impl SpaceObserver for InterpreterCache {
     }
 }
 
-struct InterpreterContext {
-    space: GroundingSpace,
+struct InterpreterContext<'a> {
+    space: &'a GroundingSpace,
     cache: Rc<RefCell<InterpreterCache>>,
 }
 
 #[derive(Clone)]
-struct InterpreterContextRef(Rc<InterpreterContext>);
+struct InterpreterContextRef<'a>(Rc<InterpreterContext<'a>>);
 
-impl InterpreterContextRef {
-    fn new(mut space: GroundingSpace) -> Self {
+impl<'a> InterpreterContextRef<'a> {
+    fn new(space: &'a GroundingSpace) -> Self {
         let cache = Rc::new(RefCell::new(InterpreterCache::new()));
         space.register_observer(Rc::clone(&cache));
         Self(Rc::new(InterpreterContext{ space, cache }))
     }
 }
 
-impl Deref for InterpreterContextRef {
-    type Target = InterpreterContext;
+impl<'a> Deref for InterpreterContextRef<'a> {
+    type Target = InterpreterContext<'a>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -260,8 +260,8 @@ fn has_grounded_sub_expr(expr: &Atom) -> bool {
         });
 }
 
-fn interpret_as_type_plan(context: InterpreterContextRef,
-        input: InterpretedAtom, typ: Atom) -> StepResult<Results> {
+fn interpret_as_type_plan<'a>(context: InterpreterContextRef<'a>,
+        input: InterpretedAtom, typ: Atom) -> StepResult<'a, Results> {
     log::debug!("interpret_as_type_plan: input: {}, type: {}", input, typ);
     match input.atom() {
         Atom::Symbol(_) | Atom::Grounded(_) =>
@@ -284,8 +284,8 @@ fn interpret_as_type_plan(context: InterpreterContextRef,
     }
 }
 
-fn cast_atom_to_type_plan(context: InterpreterContextRef,
-        input: InterpretedAtom, typ: Atom) -> StepResult<Results> {
+fn cast_atom_to_type_plan<'a>(context: InterpreterContextRef<'a>,
+        input: InterpretedAtom, typ: Atom) -> StepResult<'a, Results> {
     // TODO: implement this via interpreting of the (:cast atom typ) expression
     let typ = apply_bindings_to_atom(&typ, input.bindings());
     let mut results = get_type_bindings(&context.space, input.atom(), &typ);
@@ -310,13 +310,13 @@ fn cast_atom_to_type_plan(context: InterpreterContextRef,
     }
 }
 
-fn get_type_of_atom_plan(context: InterpreterContextRef, atom: Atom) -> StepResult<Vec<Atom>> {
+fn get_type_of_atom_plan<'a>(context: InterpreterContextRef<'a>, atom: Atom) -> StepResult<'a, Vec<Atom>> {
     // TODO: implement this via interpreting of the (:? atom)
     StepResult::ret(get_atom_types(&context.space, &atom))
 }
 
-fn interpret_expression_as_type_plan(context: InterpreterContextRef,
-        input: InterpretedAtom, typ: Atom) -> OperatorPlan<Vec<Atom>, Results> {
+fn interpret_expression_as_type_plan<'a>(context: InterpreterContextRef<'a>,
+        input: InterpretedAtom, typ: Atom) -> OperatorPlan<'a, Vec<Atom>, Results> {
     let descr = format!("form alternative plans for expression {} using types", input);
     OperatorPlan::new(move |op_types: Vec<Atom>| {
         make_alternives_plan(input.clone(), op_types, move |op_typ| {
@@ -340,8 +340,8 @@ fn get_expr_mut(atom: &mut Atom) -> &mut ExpressionAtom {
     }
 }
 
-fn interpret_expression_as_type_op(context: InterpreterContextRef,
-        input: InterpretedAtom, op_typ: Atom, ret_typ: Atom) -> NoInputPlan {
+fn interpret_expression_as_type_op<'a>(context: InterpreterContextRef<'a>,
+        input: InterpretedAtom, op_typ: Atom, ret_typ: Atom) -> NoInputPlan<'a> {
     log::debug!("interpret_expression_as_type_op: input: {}, operation type: {}, expected return type: {}", input, op_typ, ret_typ);
     if ret_typ == ATOM_TYPE_ATOM || ret_typ == ATOM_TYPE_EXPRESSION {
         Box::new(StepResult::ret(vec![input]))
@@ -404,8 +404,8 @@ fn interpret_expression_as_type_op(context: InterpreterContextRef,
     }
 }
 
-fn call_alternatives_plan(plan: NoInputPlan, context: InterpreterContextRef,
-    input: InterpretedAtom) -> NoInputPlan {
+fn call_alternatives_plan<'a>(plan: NoInputPlan<'a>, context: InterpreterContextRef<'a>,
+    input: InterpretedAtom) -> NoInputPlan<'a> {
     Box::new(SequencePlan::new(plan, OperatorPlan::new(move |results: Results| {
         make_alternives_plan(input, results, move |result| {
             call_plan(context.clone(), result)
@@ -413,12 +413,12 @@ fn call_alternatives_plan(plan: NoInputPlan, context: InterpreterContextRef,
     }, "interpret each alternative")))
 }
 
-fn insert_reducted_arg_plan(expr: InterpretedAtom, atom_idx: usize) -> OperatorPlan<Results, Results> {
+fn insert_reducted_arg_plan<'a>(expr: InterpretedAtom, atom_idx: usize) -> OperatorPlan<'a, Results, Results> {
     let descr = format!("insert right element as child {} of left element", atom_idx);
     OperatorPlan::new(move |arg_variants| insert_reducted_arg_op(expr, atom_idx, arg_variants), descr)
 }
 
-fn insert_reducted_arg_op(expr: InterpretedAtom, atom_idx: usize, mut arg_variants: Results) -> StepResult<Results> {
+fn insert_reducted_arg_op<'a>(expr: InterpretedAtom, atom_idx: usize, mut arg_variants: Results) -> StepResult<'a, Results> {
     let result = arg_variants.drain(0..).map(|arg| {
         let InterpretedAtom(arg, bindings) = arg;
         let mut expr_with_arg = expr.atom().clone();
@@ -429,12 +429,12 @@ fn insert_reducted_arg_op(expr: InterpretedAtom, atom_idx: usize, mut arg_varian
     StepResult::ret(result)
 }
 
-fn call_plan(context: InterpreterContextRef, input: InterpretedAtom) -> NoInputPlan {
+fn call_plan<'a>(context: InterpreterContextRef<'a>, input: InterpretedAtom) -> NoInputPlan<'a> {
     let descr = format!("call {}", input);
     Box::new(OperatorPlan::new(|_| call_op(context, input), descr))
 }
 
-fn call_op(context: InterpreterContextRef, input: InterpretedAtom) -> StepResult<Results> {
+fn call_op<'a>(context: InterpreterContextRef<'a>, input: InterpretedAtom) -> StepResult<'a, Results> {
     log::debug!("call_op: {}", input);
 
     let cached = context.cache.borrow().get(input.atom(), input.bindings());
@@ -461,12 +461,12 @@ fn call_op(context: InterpreterContextRef, input: InterpretedAtom) -> StepResult
     }
 }
 
-fn return_cached_result_plan(results: Results) -> StepResult<Results> {
+fn return_cached_result_plan<'a>(results: Results) -> StepResult<'a, Results> {
     let descr = format!("return cached results {:?}", results);
     StepResult::execute(OperatorPlan::new(|_| StepResult::ret(results), descr))
 }
 
-fn save_result_in_cache_plan(context: InterpreterContextRef, key: Atom) -> OperatorPlan<Results, Results> {
+fn save_result_in_cache_plan<'a>(context: InterpreterContextRef<'a>, key: Atom) -> OperatorPlan<'a, Results, Results> {
     let descr = format!("save results in cache for key {}", key);
     OperatorPlan::new(move |results: Results| {
         context.cache.borrow_mut().insert(key, results.clone());
@@ -474,8 +474,8 @@ fn save_result_in_cache_plan(context: InterpreterContextRef, key: Atom) -> Opera
     }, descr)
 }
 
-fn interpret_reducted_plan(context: InterpreterContextRef,
-        input: InterpretedAtom) -> NoInputPlan {
+fn interpret_reducted_plan<'a>(context: InterpreterContextRef<'a>,
+        input: InterpretedAtom) -> NoInputPlan<'a> {
     if let Atom::Expression(ref expr) = input.atom() {
         if is_grounded_op(expr) {
             Box::new(execute_plan(context, input))
@@ -488,12 +488,12 @@ fn interpret_reducted_plan(context: InterpreterContextRef,
 }
 
 
-fn execute_plan(context: InterpreterContextRef, input: InterpretedAtom) -> OperatorPlan<(), Results> {
+fn execute_plan<'a>(context: InterpreterContextRef<'a>, input: InterpretedAtom) -> OperatorPlan<'a, (), Results> {
     let descr = format!("execute {}", input);
     OperatorPlan::new(|_| execute_op(context, input), descr)
 }
 
-fn execute_op(context: InterpreterContextRef, input: InterpretedAtom) -> StepResult<Results> {
+fn execute_op<'a>(context: InterpreterContextRef<'a>, input: InterpretedAtom) -> StepResult<'a, Results> {
     log::debug!("execute_op: {}", input);
     match input {
         InterpretedAtom(Atom::Expression(ref expr), ref bindings) => {
@@ -527,12 +527,12 @@ fn execute_op(context: InterpreterContextRef, input: InterpretedAtom) -> StepRes
     }
 }
 
-fn match_plan(context: InterpreterContextRef, input: InterpretedAtom) -> OperatorPlan<(), Results> {
+fn match_plan<'a>(context: InterpreterContextRef<'a>, input: InterpretedAtom) -> OperatorPlan<'a, (), Results> {
     let descr = format!("match {}", input);
     OperatorPlan::new(|_| match_op(context, input), descr)
 }
 
-fn match_op(context: InterpreterContextRef, input: InterpretedAtom) -> StepResult<Results> {
+fn match_op<'a>(context: InterpreterContextRef<'a>, input: InterpretedAtom) -> StepResult<'a, Results> {
     log::debug!("match_op: {}", input);
     let var_x = VariableAtom::new("%X%");
     // TODO: unique variable?
@@ -563,11 +563,11 @@ fn match_op(context: InterpreterContextRef, input: InterpretedAtom) -> StepResul
     })
 }
 
-fn make_alternives_plan<T, F, P>(input: InterpretedAtom, mut results: Vec<T>,
-    plan: F) -> StepResult<Results>
+fn make_alternives_plan<'a, T, F, P>(input: InterpretedAtom, mut results: Vec<T>,
+    plan: F) -> StepResult<'a, Results>
 where
-    F: Fn(T) -> P,
-    P: 'static + Plan<(), Results>
+    F: 'a + Fn(T) -> P,
+    P: 'a + Plan<'a, (), Results>
 {
     match results.len() {
         0 => StepResult::err("No alternatives to interpret further"),
@@ -587,26 +587,26 @@ use std::collections::VecDeque;
 /// Plan which interprets in parallel alternatives of the expression.
 /// Each successful result is appended to the overall result of the plan.
 /// If no alternatives returned successful result the plan returns error. 
-pub struct AlternativeInterpretationsPlan<T> {
+pub struct AlternativeInterpretationsPlan<'a, T> {
     atom: Atom,
-    plans: VecDeque<Box<dyn Plan<(), Vec<T>>>>,
+    plans: VecDeque<Box<dyn Plan<'a, (), Vec<T>> + 'a>>,
     results: Vec<T>,
     success: bool,
 }
 
-impl<T> AlternativeInterpretationsPlan<T> {
+impl<'a, T> AlternativeInterpretationsPlan<'a, T> {
     /// Create new instance of [AlternativeInterpretationsPlan]. 
     ///
     /// # Arguments
     /// `atom` - atom to be printed as root of the alternative interpretations
     /// `plan` - altenative plans for the atom
-    pub fn new(atom: Atom, plans: Vec<Box<dyn Plan<(), Vec<T>>>>) -> Self {
+    pub fn new(atom: Atom, plans: Vec<Box<dyn Plan<'a, (), Vec<T>> + 'a>>) -> Self {
         Self{ atom, plans: plans.into(), results: Vec::new(), success: false }
     }
 }
 
-impl<T: 'static + Debug> Plan<(), Vec<T>> for AlternativeInterpretationsPlan<T> {
-    fn step(mut self: Box<Self>, _: ()) -> StepResult<Vec<T>> {
+impl<'a, T: Debug> Plan<'a, (), Vec<T>> for AlternativeInterpretationsPlan<'a, T> {
+    fn step(mut self: Box<Self>, _: ()) -> StepResult<'a, Vec<T>> {
         if self.plans.len() == 0 {
             if self.success {
                 StepResult::ret(self.results)
@@ -634,7 +634,7 @@ impl<T: 'static + Debug> Plan<(), Vec<T>> for AlternativeInterpretationsPlan<T> 
     }
 }
 
-impl<T: Debug> Debug for AlternativeInterpretationsPlan<T> {  
+impl<T: Debug> Debug for AlternativeInterpretationsPlan<'_, T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut res = write!(f, "interpret alternatives for {} (current results: {:?}):\n", self.atom, self.results);
         for (i, plan) in self.plans.iter().enumerate() {
@@ -663,7 +663,7 @@ mod tests {
         space.add(expr!("=" ("color") "green"));
         let expr = expr!(("color"));
 
-        assert_eq!(interpret(space, &expr),
+        assert_eq!(interpret(&space, &expr),
             Ok(vec![expr!("blue"), expr!("red"), expr!("green")]));
     }
 
@@ -681,7 +681,7 @@ mod tests {
         let expr = expr!("if" ("and" (x "croaks") (x "eats-flies"))
             ("=" (x "frog") "True") "nop");
 
-        assert_eq!(interpret(space, &expr),
+        assert_eq!(interpret(&space, &expr),
             Ok(vec![expr!("=" ("Fritz" "frog") "True")]));
     }
 
@@ -704,15 +704,15 @@ mod tests {
         space.add(expr!("=" ("plus" "Z" y) y));
         space.add(expr!("=" ("plus" ("S" k) y) ("S" ("plus" k y))));
 
-        assert_eq!(interpret(space.clone(), &expr!("eq" ("plus" "Z" n) n)),
+        assert_eq!(interpret(&space, &expr!("eq" ("plus" "Z" n) n)),
             Ok(vec![expr!("True")]));
-        let actual = interpret(space.clone(), &expr!("eq" ("plus" ("S" "Z") n) n));
+        let actual = interpret(&space, &expr!("eq" ("plus" ("S" "Z") n) n));
         let expected = Ok(vec![expr!("eq" ("S" y) y)]);
         assert!(results_are_equivalent(&actual, &expected),
             "actual: {:?} and expected: {:?} are not equivalent", actual, expected);
     }
 
-    fn test_interpret<T, R, P: Plan<T, R>>(plan: P, arg: T) -> Result<R, String> {
+    fn test_interpret<'a, T, R: 'a, P: Plan<'a, T, R> + 'a>(plan: P, arg: T) -> Result<R, String> {
         let mut step = Box::new(plan).step(arg);
         loop {
             match step {
@@ -786,7 +786,7 @@ mod tests {
         space.add(expr!("=" ("b" "d") "False"));
         let expr = expr!("if" ("a" x) x);
 
-        assert_eq!(interpret(space, &expr), Ok(vec![expr!("d")]));
+        assert_eq!(interpret(&space, &expr), Ok(vec![expr!("d")]));
     }
 
     #[test]
@@ -795,7 +795,7 @@ mod tests {
         space.add(expr!("=" ("a" (W)) {true}));
         let expr = expr!("a" W);
 
-        assert_eq!(interpret(space, &expr), Ok(vec![expr!({true})]));
+        assert_eq!(interpret(&space, &expr), Ok(vec![expr!({true})]));
     }
 
     #[test]
@@ -805,7 +805,7 @@ mod tests {
         ");
         let expr = metta_atom("(a (b $a) $x $y)");
 
-        let result = interpret(space, &expr);
+        let result = interpret(&space, &expr);
 
         assert!(results_are_equivalent(&result,
             &Ok(vec![metta_atom("(a (c $a $b) $c $d)")])));
@@ -837,7 +837,7 @@ mod tests {
         let space = GroundingSpace::new();
         let expr = Atom::expr([Atom::gnd(ThrowError()), Atom::value("Runtime test error")]);
 
-        assert_eq!(interpret(space, &expr), 
+        assert_eq!(interpret(&space, &expr), 
             Ok(vec![Atom::expr([ERROR_SYMBOL, expr, Atom::sym("Runtime test error")])]));
     }
 
@@ -867,7 +867,7 @@ mod tests {
         let space = GroundingSpace::new();
         let expr = Atom::expr([Atom::gnd(NonReducible()), Atom::value("32")]);
 
-        assert_eq!(interpret(space, &expr), Ok(vec![expr]));
+        assert_eq!(interpret(&space, &expr), Ok(vec![expr]));
     }
 
     #[test]
@@ -875,7 +875,7 @@ mod tests {
         let space = GroundingSpace::new();
         let expr = Atom::expr([]);
 
-        assert_eq!(interpret(space, &expr), Ok(vec![expr]));
+        assert_eq!(interpret(&space, &expr), Ok(vec![expr]));
     }
 
     #[test]
@@ -883,7 +883,7 @@ mod tests {
         let space = GroundingSpace::new();
         let expr = Atom::expr([Atom::value(1)]);
 
-        assert_eq!(interpret(space, &expr), Ok(vec![expr]));
+        assert_eq!(interpret(&space, &expr), Ok(vec![expr]));
     }
 
     #[derive(PartialEq, Clone, Debug)]
@@ -912,7 +912,7 @@ mod tests {
         let space = GroundingSpace::new();
         let expr = expr!({MulXUndefinedType(3)} {2});
 
-        assert_eq!(interpret(space, &expr), Ok(vec![Atom::value(6)]));
+        assert_eq!(interpret(&space, &expr), Ok(vec![Atom::value(6)]));
     }
 }
 

--- a/lib/src/metta/text.rs
+++ b/lib/src/metta/text.rs
@@ -231,7 +231,7 @@ mod tests {
         text.add_str("$n").unwrap();
         let space = GroundingSpace::from(&text);
 
-        assert_eq!(vec![expr!(n)], *space.borrow_vec());
+        assert_eq!(vec![expr!(n)], *space.content());
     }
 
     #[test]
@@ -241,7 +241,7 @@ mod tests {
         text.add_str("test").unwrap();
         let space = GroundingSpace::from(&text);
 
-        assert_eq!(vec![expr!("test")], *space.borrow_vec());
+        assert_eq!(vec![expr!("test")], *space.content());
     }
 
     #[test]
@@ -251,7 +251,7 @@ mod tests {
         text.add_str("\"te st\"").unwrap();
         let space = GroundingSpace::from(&text);
 
-        assert_eq!(vec![expr!("\"te st\"")], *space.borrow_vec());
+        assert_eq!(vec![expr!("\"te st\"")], *space.content());
     }
 
     #[test]
@@ -264,7 +264,7 @@ mod tests {
         text.add_str("ab").unwrap();
         let space = GroundingSpace::from(&text);
 
-        assert_eq!(vec![expr!("ab")], *space.borrow_vec());
+        assert_eq!(vec![expr!("ab")], *space.content());
     }
 
     #[test]
@@ -277,7 +277,7 @@ mod tests {
         text.add_str("(3d 42)").unwrap();
         let space = GroundingSpace::from(&text);
 
-        assert_eq!(vec![expr!("3d" {42})], *space.borrow_vec());
+        assert_eq!(vec![expr!("3d" {42})], *space.content());
     }
 
     #[test]
@@ -288,7 +288,7 @@ mod tests {
         let space = GroundingSpace::from(&text);
 
         assert_eq!(vec![expr!("=" ("fac" n) ("*" n ("fac" ("-" n "1"))))],
-            *space.borrow_vec());
+            *space.content());
     }
 
     #[test]
@@ -298,7 +298,7 @@ mod tests {
         text.add_str("(a) (b)").unwrap();
         let space = GroundingSpace::from(&text);
 
-        assert_eq!(vec![expr!(("a")), expr!(("b"))], *space.borrow_vec());
+        assert_eq!(vec![expr!(("a")), expr!(("b"))], *space.content());
     }
 
     #[test]

--- a/lib/src/space/grounding.rs
+++ b/lib/src/space/grounding.rs
@@ -93,7 +93,7 @@ impl GroundingSpace {
     /// Registers space modifications `observer`. Observer is automatically
     /// deregistered when `Rc` counter reaches zero. See [SpaceObserver] for
     /// examples.
-    pub fn register_observer<T>(&mut self, observer: Rc<RefCell<T>>)
+    pub fn register_observer<T>(&self, observer: Rc<RefCell<T>>)
         where T: SpaceObserver + 'static
     {
         self.observers.borrow_mut().push(Rc::downgrade(&observer) as Weak<RefCell<dyn SpaceObserver>>);

--- a/python/tests/test_atom.py
+++ b/python/tests/test_atom.py
@@ -69,21 +69,19 @@ class AtomTest(unittest.TestCase):
     def test_expr_type(self):
         self.assertEqual(E(x2Atom, ValueAtom(1.0)).get_type(), AtomKind.EXPR)
 
-    # def test_expr_get_children(self):
-        # self.assertEqual(E(X2Atom(), ValueAtom(1.0)).get_children(),
-                # [X2Atom(), ValueAtom(1.0)])
-
-    # def test_groundingspace_str(self):
-        # kb = GroundingSpace()
-        # kb.add_atom(E(S("+"), S("1"), S("2")))
-        # self.assertEqual(str(kb), "<(+ 1 2)>")
+    def test_expr_get_children(self):
+        self.assertEqual(E(x2Atom, ValueAtom(1.0)).get_children(),
+                [x2Atom, ValueAtom(1.0)])
 
     def test_groundingspace_equals(self):
         kb_a = GroundingSpace()
         kb_a.add_atom(E(S("+"), S("1"), S("2")))
         kb_b = GroundingSpace()
         kb_b.add_atom(E(S("+"), S("1"), S("2")))
-        self.assertEqual(kb_a, kb_b)
+        kb_c = kb_a
+        self.assertEqual(kb_a.get_atoms(), kb_b.get_atoms())
+        self.assertEqual(kb_a, kb_c)
+        self.assertNotEqual(kb_a, kb_b)
 
     def test_sexprspace_symbol(self):
         text = SExprSpace(Tokenizer())
@@ -91,9 +89,8 @@ class AtomTest(unittest.TestCase):
         kb = GroundingSpace()
         text.add_to(kb)
 
-        expected = GroundingSpace()
-        expected.add_atom(E(S("+"), S("1"), S("2")))
-        self.assertEqual(kb, expected)
+        expected = [E(S("+"), S("1"), S("2"))]
+        self.assertEqual(kb.get_atoms(), expected)
 
     def test_sexprspace_token(self):
         tokenizer = Tokenizer()
@@ -103,9 +100,8 @@ class AtomTest(unittest.TestCase):
         kb = GroundingSpace()
         text.add_to(kb)
 
-        expected = GroundingSpace()
-        expected.add_atom(E(S("+"), ValueAtom(1), ValueAtom(2)))
-        self.assertEqual(kb, expected)
+        expected = [E(S("+"), ValueAtom(1), ValueAtom(2))]
+        self.assertEqual(kb.get_atoms(), expected)
 
     def test_interpret(self):
         space = GroundingSpace()


### PR DESCRIPTION
Refactoring of the code in before implementing Metta interpreting loop in Rust:
- add `SmartPtr` trait to make it possible passing both intrinsic references and smart pointers to the Metta interpreter;
- represent `GroundingSpace` as a smart pointer in C API.