### PR TITLE
Add grounded symbols to Metta intepreter in Rust

### DIFF
--- a/c/src/metta.rs
+++ b/c/src/metta.rs
@@ -173,6 +173,12 @@ pub extern "C" fn metta_space(metta: *mut metta_t) -> *mut grounding_space_t {
 }
 
 #[no_mangle]
+pub extern "C" fn metta_tokenizer(metta: *mut metta_t) -> *mut tokenizer_t {
+    let tokenizer = unsafe{ &*metta }.borrow().tokenizer();
+    tokenizer_t::from_shared(tokenizer)
+}
+
+#[no_mangle]
 pub extern "C" fn metta_run(metta: *mut metta_t, parser: *mut sexpr_parser_t,
         output: c_atoms_callback_t, out_context: *mut c_void) {
     let metta = unsafe{ &*metta }.borrow();

--- a/lib/src/common/shared.rs
+++ b/lib/src/common/shared.rs
@@ -132,6 +132,6 @@ impl<T> Clone for Shared<T> {
 
 impl<T: Debug> Debug for Shared<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{:?}", self.0)
+        write!(f, "{:?} addr {:?}", self.0, Rc::as_ptr(&self.0))
     }
 }

--- a/lib/src/metta/interpreter.rs
+++ b/lib/src/metta/interpreter.rs
@@ -617,7 +617,7 @@ impl<'a, T: Debug> Plan<'a, (), Vec<T>> for AlternativeInterpretationsPlan<'a, T
             if self.success {
                 StepResult::ret(self.results)
             } else {
-                StepResult::err("No successful alternatives")
+                StepResult::err(format!("No successful alternatives for atom: {}", self.atom))
             }
         } else {
             let plan = self.plans.pop_front().unwrap();
@@ -780,7 +780,7 @@ mod tests {
 
         let result = test_interpret(plan, ());
 
-        assert_eq!(Err("No successful alternatives".into()), result);
+        assert_eq!(Err("No successful alternatives for atom: Test".into()), result);
     }
 
     #[test]

--- a/lib/src/metta/mod.rs
+++ b/lib/src/metta/mod.rs
@@ -28,6 +28,7 @@ pub const EQUAL_SYMBOL : Atom = sym!("=");
 pub const ARROW_SYMBOL : Atom = sym!("->");
 pub const ERROR_SYMBOL : Atom = sym!("Error");
 pub const VOID_SYMBOL : Atom = sym!("%void%");
+pub const BAD_TYPE_SYMBOL : Atom = sym!("BadType");
 
 pub fn metta_space(text: &str) -> GroundingSpace {
     let tokenizer = common_tokenizer();

--- a/lib/src/metta/mod.rs
+++ b/lib/src/metta/mod.rs
@@ -27,6 +27,7 @@ pub const SUB_TYPE_SYMBOL : Atom = sym!(":<");
 pub const EQUAL_SYMBOL : Atom = sym!("=");
 pub const ARROW_SYMBOL : Atom = sym!("->");
 pub const ERROR_SYMBOL : Atom = sym!("Error");
+pub const VOID_SYMBOL : Atom = sym!("%void%");
 
 pub fn metta_space(text: &str) -> GroundingSpace {
     let tokenizer = common_tokenizer();

--- a/lib/src/metta/runner.rs
+++ b/lib/src/metta/runner.rs
@@ -148,10 +148,6 @@ impl Display for ImportOp {
     }
 }
 
-fn remove_quotes(text: &str) -> String {
-    text.chars().skip(1).take(text.len() - 2).collect()
-}
-
 impl Grounded for ImportOp {
     fn type_(&self) -> Atom {
         ATOM_TYPE_UNDEFINED

--- a/lib/src/metta/text.rs
+++ b/lib/src/metta/text.rs
@@ -7,7 +7,7 @@ use std::iter::Peekable;
 use regex::Regex;
 use std::rc::Rc;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Tokenizer {
     tokens: Vec<TokenDescr>,
 }
@@ -16,6 +16,12 @@ pub struct Tokenizer {
 struct TokenDescr {
     regex: Regex,
     constr: Rc<AtomConstr>,
+}
+
+impl std::fmt::Debug for TokenDescr {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "TokenDescr{{ regex: {:?}, constr: {:?} }}", self.regex, Rc::as_ptr(&self.constr))
+    }
 }
 
 type AtomConstr = dyn Fn(&str) -> Atom;

--- a/python/hyperon/__init__.py
+++ b/python/hyperon/__init__.py
@@ -184,7 +184,7 @@ class GroundingSpace:
 
     @staticmethod
     def _from_cspace(cspace):
-        GroundingSpace(cspace)
+        return GroundingSpace(cspace)
 
     def __del__(self):
         hp.grounding_space_free(self.cspace)
@@ -225,7 +225,7 @@ class Tokenizer:
 
     @staticmethod
     def _from_ctokenizer(ctokenizer):
-        Tokenizer(ctokenizer)
+        return Tokenizer(ctokenizer)
 
     def __del__(self):
         hp.tokenizer_free(self.ctokenizer)
@@ -291,10 +291,10 @@ class Metta:
         hp.metta_free(self.cmetta)
 
     def get_space(self):
-        return GroundingSpace._from_cspace(hp.metta_get_space(self.cmetta))
+        return GroundingSpace._from_cspace(hp.metta_space(self.cmetta))
 
     def get_tokenizer(self):
-        return Tokenizer._from_ctokenizer(hp.metta_get_tokenizer(self.cmetta))
+        return Tokenizer._from_ctokenizer(hp.metta_tokenizer(self.cmetta))
 
     def run(self, program):
         parser = SExprParser(program)

--- a/python/hyperon/__init__.py
+++ b/python/hyperon/__init__.py
@@ -296,7 +296,7 @@ class Metta:
     def get_tokenizer(self):
         return Tokenizer._from_ctokenizer(hp.metta_get_tokenizer(self.cmetta))
 
-    def run(self, parser):
+    def run(self, program):
+        parser = SExprParser(program)
         results = hp.metta_run(self.cmetta, parser.cparser)
         return [[Atom._from_catom(catom) for catom in result] for result in results]
-

--- a/python/hyperonpy.cpp
+++ b/python/hyperonpy.cpp
@@ -334,6 +334,8 @@ PYBIND11_MODULE(hyperonpy, m) {
     py::class_<CMetta>(m, "CMetta");
     m.def("metta_new", [](CGroundingSpace space, char const* cwd) { return CMetta(metta_new(space.ptr, cwd)); }, "New MeTTa interpreter instance");
     m.def("metta_free", [](CMetta metta) { metta_free(metta.ptr); }, "Free MeTTa interpreter");
+    m.def("metta_space", [](CMetta metta) { return CGroundingSpace(metta_space(metta.ptr)); }, "Get space of MeTTa interpreter");
+    m.def("metta_tokenizer", [](CMetta metta) { return CTokenizer(metta_tokenizer(metta.ptr)); }, "Get tokenizer of MeTTa interpreter");
     m.def("metta_run", [](CMetta metta, CSExprParser& parser) {
             py::list lists_of_atom;
             metta_run(metta.ptr, parser.ptr, copy_lists_of_atom, &lists_of_atom);

--- a/python/tests/test_metta.py
+++ b/python/tests/test_metta.py
@@ -35,6 +35,6 @@ class MettaTest(unittest.TestCase):
         '''
         space = GroundingSpace()
         repl = Metta(space)
-        result = repl.run(SExprParser(program))
+        result = repl.run(program)
 
         self.assertEqual([[S('T')]], result)


### PR DESCRIPTION
Implement `match`, `self`, `bind!`, `new-space`, `case`, `assert-equal`, `collapse`, `pragma!` in Rust.