### PR TITLE
Add ability to return errornous atom and error symbol from interpreter

### DIFF
--- a/c/src/metta.rs
+++ b/c/src/metta.rs
@@ -1,3 +1,4 @@
+use hyperon::Atom;
 use hyperon::metta::text::*;
 use hyperon::metta::interpreter;
 use hyperon::metta::interpreter::InterpretedAtom;
@@ -110,7 +111,7 @@ pub extern "C" fn get_atom_types(space: *const grounding_space_t, atom: *const a
 // MeTTa interpreter API
 
 pub struct step_result_t<'a> {
-    result: StepResult<'a, Vec<InterpretedAtom>>,
+    result: StepResult<'a, Vec<InterpretedAtom>, (Atom, Atom)>,
 }
 
 #[no_mangle]

--- a/lib/src/metta/mod.rs
+++ b/lib/src/metta/mod.rs
@@ -29,6 +29,9 @@ pub const ARROW_SYMBOL : Atom = sym!("->");
 pub const ERROR_SYMBOL : Atom = sym!("Error");
 pub const VOID_SYMBOL : Atom = sym!("%void%");
 pub const BAD_TYPE_SYMBOL : Atom = sym!("BadType");
+pub const INCORRECT_NUMBER_OF_ARGUMENTS_SYMBOL : Atom = sym!("IncorrectNumberOfArguments");
+pub const NOT_REDUCIBLE_SYMBOL : Atom = sym!("NotReducible");
+pub const NO_VALID_ALTERNATIVES : Atom = sym!("NoValidAlternatives");
 
 pub fn metta_space(text: &str) -> GroundingSpace {
     let tokenizer = common_tokenizer();


### PR DESCRIPTION
Add error type parameter to StepResult, use (Atom, Atom) as a parameter. This is to add ability return type and other errors properly from the interpreter. It cannot be implemented right now as it breaks tests like `b5_types_prelim.metta` and I am going to continue this after moving runner into Rust completely.