### PR TITLE
Implement arithmetics operations in Rust

### DIFF
--- a/lib/src/metta/mod.rs
+++ b/lib/src/metta/mod.rs
@@ -27,7 +27,6 @@ pub const SUB_TYPE_SYMBOL : Atom = sym!(":<");
 pub const EQUAL_SYMBOL : Atom = sym!("=");
 pub const ARROW_SYMBOL : Atom = sym!("->");
 pub const ERROR_SYMBOL : Atom = sym!("Error");
-pub const VOID_SYMBOL : Atom = sym!("%void%");
 pub const BAD_TYPE_SYMBOL : Atom = sym!("BadType");
 pub const INCORRECT_NUMBER_OF_ARGUMENTS_SYMBOL : Atom = sym!("IncorrectNumberOfArguments");
 pub const NOT_REDUCIBLE_SYMBOL : Atom = sym!("NotReducible");

--- a/lib/src/metta/runner/arithmetics.rs
+++ b/lib/src/metta/runner/arithmetics.rs
@@ -1,0 +1,198 @@
+use crate::*;
+use crate::metta::*;
+use crate::matcher::MatchResultIter;
+
+use std::fmt::Display;
+
+pub const ATOM_TYPE_NUMBER : Atom = sym!("Number");
+pub const ATOM_TYPE_BOOL : Atom = sym!("Bool");
+
+#[derive(Clone, PartialEq, Debug)]
+pub enum Number {
+    Integer(i64),
+    Float(f64), 
+}
+
+impl Number {
+    pub fn from_int_str(num: &str) -> Self {
+        let n = num.parse::<i64>().expect("Could not parse integer");
+        Self::Integer(n)
+    }
+
+    pub fn from_float_str(num: &str) -> Self {
+        let n = num.parse::<f64>().expect("Could not parse float");
+        Self::Float(n)
+    }
+}
+
+impl Display for Number {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Integer(n) => write!(f, "{}", n),
+            Self::Float(n) => write!(f, "{}", n),
+        }
+    }
+}
+
+impl Grounded for Number {
+    fn type_(&self) -> Atom {
+        ATOM_TYPE_NUMBER
+    }
+
+    fn execute(&self, _args: &mut Vec<Atom>) -> Result<Vec<Atom>, ExecError> {
+        execute_not_executable(self)
+    }
+
+    fn match_(&self, other: &Atom) -> MatchResultIter {
+        match_by_equality(self, other)
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct Bool(bool);
+
+impl Bool {
+    pub fn from_str(b: &str) -> Self {
+        match b {
+            "True" => Self(true),
+            "False" => Self(false),
+            _ => panic!("Could not parse Bool value: {}", b),
+        }
+    }
+}
+
+impl Display for Bool {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.0 {
+            true => write!(f, "True"),
+            false => write!(f, "False"),
+        }
+    }
+}
+
+impl Grounded for Bool {
+    fn type_(&self) -> Atom {
+        ATOM_TYPE_BOOL
+    }
+
+    fn execute(&self, _args: &mut Vec<Atom>) -> Result<Vec<Atom>, ExecError> {
+        execute_not_executable(self)
+    }
+
+    fn match_(&self, other: &Atom) -> MatchResultIter {
+        match_by_equality(self, other)
+    }
+}
+
+macro_rules! def_binary_number_op {
+    ($name:ident, $op:tt) => {
+        #[derive(Clone, PartialEq, Debug)]
+        pub struct $name{}
+
+        impl Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, stringify!($op))
+            }
+        }
+
+        impl Grounded for $name {
+            fn type_(&self) -> Atom {
+                Atom::expr([ARROW_SYMBOL, ATOM_TYPE_NUMBER, ATOM_TYPE_NUMBER, ATOM_TYPE_NUMBER])
+            }
+
+            fn execute(&self, args: &mut Vec<Atom>) -> Result<Vec<Atom>, ExecError> {
+                let arg_error = || ExecError::from(concat!(stringify!($op), " expects two number arguments"));
+                let a = args.get(0).ok_or_else(arg_error)?.as_gnd::<Number>().ok_or_else(arg_error)?;
+                let b = args.get(1).ok_or_else(arg_error)?.as_gnd::<Number>().ok_or_else(arg_error)?;
+
+                let res = match (a, b) {
+                    (Number::Integer(a), Number::Integer(b)) => Number::Integer(a $op b),
+                    (Number::Integer(a), Number::Float(b)) => Number::Float((*a as f64) $op b),
+                    (Number::Float(a), Number::Integer(b)) => Number::Float(a $op (*b as f64)),
+                    (Number::Float(a), Number::Float(b)) => Number::Float(a $op b),
+                };
+
+                Ok(vec![Atom::gnd(res)])
+            }
+
+            fn match_(&self, other: &Atom) -> MatchResultIter {
+                match_by_equality(self, other)
+            }
+        }
+    }
+}
+
+def_binary_number_op!(SumOp, +);
+def_binary_number_op!(SubOp, -);
+def_binary_number_op!(MulOp, *);
+def_binary_number_op!(DivOp, /);
+def_binary_number_op!(ModOp, %);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn number() {
+        assert_eq!(Number::from_int_str("12345"), Number::Integer(12345i64));
+        assert_eq!(Number::from_float_str("123.45"), Number::Float(123.45f64));
+        assert_eq!(Number::from_float_str("12345e-02"), Number::Float(123.45f64));
+        assert_eq!(Number::from_float_str("1.2345e+2"), Number::Float(123.45f64));
+        assert_eq!(format!("{}", Number::Integer(12345i64)), "12345");
+        assert_eq!(format!("{}", Number::Float(123.45f64)), "123.45");
+    }
+
+    #[test]
+    fn bool() {
+        assert_eq!(Bool::from_str("True"), Bool(true));
+        assert_eq!(Bool::from_str("False"), Bool(false));
+        assert_eq!(format!("{}", Bool(true)), "True");
+        assert_eq!(format!("{}", Bool(false)), "False");
+    }
+
+    macro_rules! assert_number_binary_op {
+        ($name:ident, $a: expr, $b: expr, $r: expr) => {
+            assert_eq!($name{}.execute(&mut vec![Atom::gnd($a), Atom::gnd($b)]), Ok(vec![Atom::gnd($r)]));
+        }
+    }
+
+    #[test]
+    fn sum_op() {
+        assert_number_binary_op!(SumOp, Number::Integer(40), Number::Integer(2), Number::Integer(42));
+        assert_number_binary_op!(SumOp, Number::Integer(40), Number::Float(2.42), Number::Float(42.42));
+        assert_number_binary_op!(SumOp, Number::Float(40.42), Number::Integer(2), Number::Float(42.42));
+        assert_number_binary_op!(SumOp, Number::Float(40.40), Number::Float(2.02), Number::Float(42.42));
+    }
+
+    #[test]
+    fn sub_op() {
+        assert_number_binary_op!(SubOp, Number::Integer(44), Number::Integer(2), Number::Integer(42));
+        assert_number_binary_op!(SubOp, Number::Integer(44), Number::Float(2.42), Number::Float(41.58));
+        assert_number_binary_op!(SubOp, Number::Float(44.42), Number::Integer(2), Number::Float(42.42));
+        assert_number_binary_op!(SubOp, Number::Float(44.5), Number::Float(2.5), Number::Float(42.0));
+    }
+
+    #[test]
+    fn mul_op() {
+        assert_number_binary_op!(MulOp, Number::Integer(6), Number::Integer(7), Number::Integer(42));
+        assert_number_binary_op!(MulOp, Number::Integer(4), Number::Float(10.5), Number::Float(42.0));
+        assert_number_binary_op!(MulOp, Number::Float(10.5), Number::Integer(4), Number::Float(42.0));
+        assert_number_binary_op!(MulOp, Number::Float(2.5), Number::Float(16.8), Number::Float(42.0));
+    }
+
+    #[test]
+    fn div_op() {
+        assert_number_binary_op!(DivOp, Number::Integer(84), Number::Integer(2), Number::Integer(42));
+        assert_number_binary_op!(DivOp, Number::Integer(441), Number::Float(10.5), Number::Float(42.0));
+        assert_number_binary_op!(DivOp, Number::Float(84.0), Number::Integer(2), Number::Float(42.0));
+        assert_number_binary_op!(DivOp, Number::Float(430.5), Number::Float(10.25), Number::Float(42.0));
+    }
+
+    #[test]
+    fn mod_op() {
+        assert_number_binary_op!(ModOp, Number::Integer(85), Number::Integer(43), Number::Integer(42));
+        assert_number_binary_op!(ModOp, Number::Integer(85), Number::Float(43.5), Number::Float(41.5));
+        assert_number_binary_op!(ModOp, Number::Float(85.5), Number::Integer(43), Number::Float(42.5));
+        assert_number_binary_op!(ModOp, Number::Float(85.5), Number::Float(43.5), Number::Float(42.0));
+    }
+}

--- a/lib/src/metta/runner/mod.rs
+++ b/lib/src/metta/runner/mod.rs
@@ -14,6 +14,9 @@ use std::collections::HashMap;
 mod stdlib;
 use stdlib::*;
 
+mod arithmetics;
+use arithmetics::*;
+
 const EXEC_SYMBOL : Atom = sym!("!");
 
 pub struct Metta {
@@ -41,6 +44,7 @@ impl Metta {
             }
 
             let mut tref = tokenizer.borrow_mut();
+
             let match_op = Atom::gnd(MatchOp{});
             tref.register_token(regex(r"match"), move |_| { match_op.clone() });
             let space_val = Atom::value(space.clone());
@@ -73,6 +77,13 @@ impl Metta {
             tref.register_token(regex(r"let"), move |_| { let_op.clone() });
             let let_var_op = Atom::gnd(LetVarOp{});
             tref.register_token(regex(r"let\*"), move |_| { let_var_op.clone() });
+
+            tref.register_token(regex(r"\d+"),
+                |token| { Atom::gnd(Number::from_int_str(token)) });
+            tref.register_token(regex(r"\d+(.\d+)([eE][\-\+]?\d+)?"),
+                |token| { Atom::gnd(Number::from_float_str(token)) });
+            tref.register_token(regex(r"True|False"),
+                |token| { Atom::gnd(Bool::from_str(token)) });
         }
         Self{ space, tokenizer, settings }
     }

--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -13,6 +13,8 @@ use std::path::PathBuf;
 use std::collections::HashMap;
 use regex::Regex;
 
+pub const VOID_SYMBOL : Atom = sym!("%void%");
+
 // TODO: remove hiding errors completely after making it possible passing
 // them to the user
 fn interpret_no_error(space: Shared<GroundingSpace>, expr: &Atom) -> Result<Vec<Atom>, String> {

--- a/lib/src/metta/text.rs
+++ b/lib/src/metta/text.rs
@@ -33,11 +33,11 @@ impl Tokenizer {
     }
 
     pub fn register_token<C: 'static + Fn(&str) -> Atom>(&mut self, regex: Regex, constr: C) {
-        self.tokens.push(TokenDescr{ regex, constr: Rc::new(constr) });
+        self.tokens.push(TokenDescr{ regex, constr: Rc::new(constr) })
     }
 
     pub fn find_token(&self, token: &str) -> Option<&AtomConstr> {
-        self.tokens.iter().find(|descr| {
+        self.tokens.iter().rfind(|descr| {
             match descr.regex.find_at(token, 0) {
                 Some(m) => m.start() == 0 && m.end() == token.len(),
                 None => false,
@@ -292,5 +292,14 @@ mod tests {
     fn test_panic_on_lattice_in_var_name() {
         let mut parser = SExprParser::new("$a#");
         while let Some(_) = parser.parse(&Tokenizer::new()) {}
+    }
+
+    #[test]
+    fn override_token_definition() {
+        let mut tokenizer = Tokenizer::new();
+        tokenizer.register_token(Regex::new(r"A").unwrap(), |_| Atom::sym("A"));
+        assert_eq!(tokenizer.find_token("A").unwrap()("A"), Atom::sym("A"));
+        tokenizer.register_token(Regex::new(r"A").unwrap(), |_| Atom::sym("B"));
+        assert_eq!(tokenizer.find_token("A").unwrap()("A"), Atom::sym("B"));
     }
 }

--- a/python/tests/test_metta.py
+++ b/python/tests/test_metta.py
@@ -15,12 +15,9 @@ class MettaTest(unittest.TestCase):
         atom = metta.parse_single('(A B)')
         self.assertEqual(atom, E(S('C'), S('B')))
 
-        # NOTE: currently, adding another atom for the same token
-        #       doesn't change the previous binding
-        # This can be changed later
         metta.add_atom('A', S('F'))
         atom = metta.parse_single('(A B)')
-        self.assertEqual(atom, E(S('C'), S('B')))
+        self.assertEqual(atom, E(S('F'), S('B')))
 
     def test_metta_runner(self):
         program = '''


### PR DESCRIPTION
Add ability to override the token definition. Use this to keep Python values in Python MeTTa implementation.