### PR TITLE
Enable running tests written in Rust C API implementation

### DIFF
--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -52,3 +52,6 @@ add_subdirectory(tests)
 
 install(FILES ${HYPERONC_LIB_PATH} DESTINATION lib)
 install(DIRECTORY ${HYPERONC_INCLUDE_DIR} DESTINATION include)
+
+add_test(NAME rust_c_api COMMAND cargo test --target-dir ${RUST_TARGET_DIR}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
This is to be able adding unit tests into Rust implementation of Hyperon C API. This part of code is built only by cmake scripts and before this commit any unit test added into this code was not executed. Right now there are no unit tests but anyway we may want to add them for the utility classes which are written specifically for C API, like `CGrounded`.