### PR TITLE
Improve Rust crate directory tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,13 @@ cargo build
 cargo test
 ```
 
-To enable logging during tests execute:
+Run examples:
+```
+cargo run --example sorted_list
+```
+
+To enable logging during running tests or examples export `RUST_LOG`
+environment variable:
 ```
 RUST_LOG=hyperon=debug cargo test
 ```

--- a/lib/examples/sorted_list.rs
+++ b/lib/examples/sorted_list.rs
@@ -1,0 +1,25 @@
+use hyperon::metta::*;
+use hyperon::metta::interpreter::*;
+
+fn main() {
+    let space = metta_space("
+        (: List (-> $a Type))
+        (: Nil (List $a))
+        (: Cons (-> $a (List $a) (List $a)))
+
+        (: if (-> bool Any Any) Any)
+        (= (if true $then $else) $then)
+        (= (if false $then $else) $else)
+
+        (= (insert $x Nil) (Cons $x Nil))
+        (= (insert $x (Cons $head $tail)) (if (< $x $head)
+                                              (Cons $x (Cons $head $tail))
+                                              (Cons $head (insert $x $tail))))
+    ");
+
+
+    assert_eq!(interpret(&space, &metta_atom("(insert 1 Nil)")),
+        Ok(vec![metta_atom("(Cons 1 Nil)")]));
+    assert_eq!(interpret(&space, &metta_atom("(insert 3 (insert 2 (insert 1 Nil)))")),
+        Ok(vec![metta_atom("(Cons 1 (Cons 2 (Cons 3 Nil)))")]));
+}

--- a/lib/src/metta/examples/mod.rs
+++ b/lib/src/metta/examples/mod.rs
@@ -1,2 +1,0 @@
-#[cfg(test)]
-mod types;

--- a/lib/src/metta/mod.rs
+++ b/lib/src/metta/mod.rs
@@ -5,8 +5,6 @@ pub mod interpreter;
 pub mod types;
 pub mod runner;
 
-mod examples;
-
 use text::{SExprParser, Tokenizer};
 use regex::Regex;
 

--- a/lib/tests/types.rs
+++ b/lib/tests/types.rs
@@ -1,8 +1,7 @@
-use crate::*;
-use crate::common::*;
-use crate::metta::*;
-use crate::metta::interpreter::*;
-use crate::space::grounding::GroundingSpace;
+use hyperon::*;
+use hyperon::common::*;
+use hyperon::metta::interpreter::*;
+use hyperon::space::grounding::GroundingSpace;
 
 #[test]
 fn test_types_in_metta() {
@@ -22,28 +21,4 @@ fn test_types_in_metta() {
     assert_eq!(interpret(&space, &expr!("if" ("check" (":" {(-3)} "Nat")) "ok" "nok")), Ok(vec![expr!("nok")]));
     assert_eq!(interpret(&space, &expr!("fac" {1})), Ok(vec![expr!({1})]));
     assert_eq!(interpret(&space, &expr!("fac" {3})), Ok(vec![expr!({6})]));
-}
-
-#[test]
-fn test_insert_into_sorted_list() {
-    let space = metta_space("
-        (: List (-> $a Type))
-        (: Nil (List $a))
-        (: Cons (-> $a (List $a) (List $a)))
-
-        (: if (-> bool Any Any) Any)
-        (= (if true $then $else) $then)
-        (= (if false $then $else) $else)
-
-        (= (insert $x Nil) (Cons $x Nil))
-        (= (insert $x (Cons $head $tail)) (if (< $x $head)
-                                              (Cons $x (Cons $head $tail))
-                                              (Cons $head (insert $x $tail))))
-    ");
-
-
-    assert_eq!(interpret(&space, &metta_atom("(insert 1 Nil)")),
-        Ok(vec![metta_atom("(Cons 1 Nil)")]));
-    assert_eq!(interpret(&space, &metta_atom("(insert 3 (insert 2 (insert 1 Nil)))")),
-        Ok(vec![metta_atom("(Cons 1 (Cons 2 (Cons 3 Nil)))")]));
 }


### PR DESCRIPTION
Split examples module on integration test and example. Moving code into a proper place of the crate's directory tree. Thus standard locations for examples and integration tests are added.