### PR TITLE
Call execute_non_executable() when execute is not defined

### DIFF
--- a/c/src/atom.rs
+++ b/c/src/atom.rs
@@ -267,7 +267,7 @@ impl Grounded for CGrounded {
                 log::trace!("CGrounded::execute: atom: {:?}, args: {:?}, ret: {:?}", self, args, ret);
                 ret
             },
-            None => panic!("Trying to execute non executable atom"),
+            None => execute_not_executable(self)
         }
     }
 


### PR DESCRIPTION
Small fix to define default behavior exactly same way as in Rust 
@h555yand FYI