### PR TITLE
Improve space query performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ environment variable:
 RUST_LOG=hyperon=debug cargo test
 ```
 
+Running benchmarks requires nightly toolchain so they can be run using:
+```
+cargo +nightly bench
+```
+
 Generate docs:
 ```
 cd ./lib

--- a/lib/benches/grounding_space.rs
+++ b/lib/benches/grounding_space.rs
@@ -14,7 +14,6 @@ fn space(size: isize) -> GroundingSpace {
         let func_def = Atom::expr([Atom::sym("="),
             Atom::expr([func_sym, Atom::var("x")]),
             Atom::var("x")]);
-        println!("func_def: {}", func_def);
         space.add(func_def);
     }
     space
@@ -25,7 +24,7 @@ fn query_x10(bencher: &mut Bencher) {
     let space = space(10);
     bencher.iter(|| {
         let res = space.query(&expr!("=" ("func-9" "arg") X));
-        assert_eq!(res.len(), 1);
+        assert_eq!(res, vec![bind!{ X: Atom::sym("arg") }]);
     })
 }
 
@@ -34,6 +33,6 @@ fn query_x100(bencher: &mut Bencher) {
     let space = space(100);
     bencher.iter(|| {
         let res = space.query(&expr!("=" ("func-2A" "arg") X));
-        assert_eq!(res.len(), 1);
+        assert_eq!(res, vec![bind!{ X: Atom::sym("arg") }]);
     })
 }

--- a/lib/benches/grounding_space.rs
+++ b/lib/benches/grounding_space.rs
@@ -10,21 +10,30 @@ use hyperon::space::grounding::*;
 fn space(size: isize) -> GroundingSpace {
     let mut space = GroundingSpace::new();
     for i in (0..size).step_by(1) {
-        space.add(expr!("A" {i}));
+        let func_sym = Atom::sym(format!("func-{:X}", i));
+        let func_def = Atom::expr([Atom::sym("="),
+            Atom::expr([func_sym, Atom::var("x")]),
+            Atom::var("x")]);
+        println!("func_def: {}", func_def);
+        space.add(func_def);
     }
     space
 }
 
 #[bench]
 fn query_x10(bencher: &mut Bencher) {
-
     let space = space(10);
-    bencher.iter(|| space.query(&expr!("A" {0})))
+    bencher.iter(|| {
+        let res = space.query(&expr!("=" ("func-9" "arg") X));
+        assert_eq!(res.len(), 1);
+    })
 }
 
 #[bench]
 fn query_x100(bencher: &mut Bencher) {
     let space = space(100);
-
-    bencher.iter(|| space.query(&expr!("A" {0})))
+    bencher.iter(|| {
+        let res = space.query(&expr!("=" ("func-2A" "arg") X));
+        assert_eq!(res.len(), 1);
+    })
 }

--- a/lib/benches/grounding_space.rs
+++ b/lib/benches/grounding_space.rs
@@ -1,0 +1,30 @@
+#![feature(test)]
+
+extern crate test;
+
+use test::Bencher;
+
+use hyperon::*;
+use hyperon::space::grounding::*;
+
+fn space(size: isize) -> GroundingSpace {
+    let mut space = GroundingSpace::new();
+    for i in (0..size).step_by(1) {
+        space.add(expr!("A" {i}));
+    }
+    space
+}
+
+#[bench]
+fn query_x10(bencher: &mut Bencher) {
+
+    let space = space(10);
+    bencher.iter(|| space.query(&expr!("A" {0})))
+}
+
+#[bench]
+fn query_x100(bencher: &mut Bencher) {
+    let space = space(100);
+
+    bencher.iter(|| space.query(&expr!("A" {0})))
+}

--- a/lib/src/atom/mod.rs
+++ b/lib/src/atom/mod.rs
@@ -119,7 +119,7 @@ use crate::common::collections::ImmutableString;
 // Symbol atom
 
 /// A symbol atom structure.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SymbolAtom {
     name: ImmutableString,
 }
@@ -173,6 +173,11 @@ impl ExpressionAtom {
     /// Returns a mutable reference to a vector of sub-atoms.
     pub fn children_mut(&mut self) -> &mut Vec<Atom> {
         &mut self.children
+    }
+
+    /// Converts into a vector of sub-atoms.
+    pub fn into_children(self) -> Vec<Atom> {
+        self.children
     }
 }
 

--- a/lib/src/common/assert.rs
+++ b/lib/src/common/assert.rs
@@ -1,0 +1,53 @@
+use super::collections::ListMap;
+
+pub fn vec_eq_some_order<T: PartialEq + std::fmt::Debug>(left: &Vec<T>, right: &Vec<T>) -> bool {
+    let mut amap: ListMap<&T, usize> = ListMap::new();
+    let mut bmap: ListMap<&T, usize> = ListMap::new();
+    for i in left.iter() {
+        *amap.entry(&i).or_insert(0) += 1;
+    }
+    for i in right.iter() {
+        *bmap.entry(&i).or_insert(0) += 1;
+    }
+    amap == bmap
+}
+
+#[macro_export]
+macro_rules! assert_eq_no_order {
+    ($left:expr, $right:expr) => {
+        {
+            let left = &$left;
+            let right = &$right;
+            assert!($crate::common::assert::vec_eq_some_order(left, right),
+                "(left == right some order)\n  left: {:?}\n right: {:?}", left, right);
+        }
+    }
+}
+
+pub fn metta_results_eq<T: PartialEq + std::fmt::Debug>(
+    left: &Result<Vec<Vec<T>>, String>, right: &Result<Vec<Vec<T>>, String>) -> bool
+{
+    match (left, right) {
+        (Ok(left), Ok(right)) if left.len() == right.len() => {
+            for (left, right) in left.iter().zip(right.iter()) {
+                if !vec_eq_some_order(left, right) {
+                    return false;
+                }
+            }
+            true
+        },
+        _ => false,
+    }
+}
+
+#[macro_export]
+macro_rules! assert_eq_metta_results {
+    ($left:expr, $right:expr) => {
+        {
+            let left = &$left;
+            let right = &$right;
+            assert!($crate::common::assert::metta_results_eq(left, right),
+                "(left == right)\n  left: {:?}\n right: {:?}", left, right);
+        }
+    }
+}

--- a/lib/src/common/collections.rs
+++ b/lib/src/common/collections.rs
@@ -33,6 +33,20 @@ impl<'a, K, V> Iterator for ListMapIter<'a, K, V> {
     }
 }
 
+pub struct ListMapIterMut<'a, K, V> {
+    delegate: std::slice::IterMut<'a, (K, V)>,
+}
+
+impl<'a, K, V> Iterator for ListMapIterMut<'a, K, V> {
+    type Item = (&'a K, &'a mut V);
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.delegate.next() {
+            Some((key, value)) => Some((key, value)),
+            None => None,
+        }
+    }
+}
+
 impl<K: PartialEq, V> ListMap<K, V> {
     pub fn new() -> Self {
         Self{ list: vec![] }
@@ -81,6 +95,10 @@ impl<K: PartialEq, V> ListMap<K, V> {
 
     pub fn iter(&self) -> ListMapIter<'_, K, V> {
         ListMapIter{ delegate: self.list.iter() }
+    }
+
+    pub fn iter_mut(&mut self) -> ListMapIterMut<'_, K, V> {
+        ListMapIterMut{ delegate: self.list.iter_mut() }
     }
 }
 

--- a/lib/src/common/collections.rs
+++ b/lib/src/common/collections.rs
@@ -84,6 +84,22 @@ impl<K: PartialEq, V> ListMap<K, V> {
     }
 }
 
+impl<K: PartialEq, V: PartialEq> PartialEq for ListMap<K, V> {
+    fn eq(&self, other: &Self) -> bool {
+        for e in other.iter() {
+            if self.get(e.0) != Some(e.1) {
+                return false;
+            }
+        }
+        for e in self.iter() {
+            if other.get(e.0) != Some(e.1) {
+                return false;
+            }
+        }
+        true
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum ImmutableString {
     Allocated(String),
@@ -116,5 +132,29 @@ impl std::hash::Hash for ImmutableString {
 impl Display for ImmutableString {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.as_str())
+    }
+}
+
+pub fn vec_eq_some_order<T: PartialEq + std::fmt::Debug>(left: &Vec<T>, right: &Vec<T>) -> bool {
+    let mut amap: ListMap<&T, usize> = ListMap::new();
+    let mut bmap: ListMap<&T, usize> = ListMap::new();
+    for i in left.iter() {
+        *amap.entry(&i).or_insert(0) += 1;
+    }
+    for i in right.iter() {
+        *bmap.entry(&i).or_insert(0) += 1;
+    }
+    amap == bmap
+}
+
+#[macro_export]
+macro_rules! assert_eq_no_order {
+    ($left:expr, $right:expr) => {
+        {
+            let left = &$left;
+            let right = &$right;
+            assert!($crate::common::collections::vec_eq_some_order(left, right),
+                "(left == right some order)\n  left: {:?}\n right: {:?}", left, right);
+        }
     }
 }

--- a/lib/src/common/collections.rs
+++ b/lib/src/common/collections.rs
@@ -5,12 +5,50 @@ pub struct ListMap<K, V> {
     list: Vec<(K, V)>,
 }
 
+pub enum ListMapEntry<'a, K, V> {
+    Occupied(K, &'a mut ListMap<K, V>),
+    Vacant(K, &'a mut ListMap<K, V>),
+}
+
+impl<'a, K: PartialEq, V> ListMapEntry<'a, K, V> {
+    pub fn or_insert(self, default: V) -> &'a mut V {
+        match self {
+            ListMapEntry::Occupied(key, map) => map.get_mut(&key).unwrap(),
+            ListMapEntry::Vacant(key, map) => map.insert_entry(key, default),
+        }
+    }
+}
+
+pub struct ListMapIter<'a, K, V> {
+    delegate: std::slice::Iter<'a, (K, V)>,
+}
+
+impl<'a, K, V> Iterator for ListMapIter<'a, K, V> {
+    type Item = (&'a K, &'a V);
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.delegate.next() {
+            Some((key, value)) => Some((key, value)),
+            None => None,
+        }
+    }
+}
+
 impl<K: PartialEq, V> ListMap<K, V> {
     pub fn new() -> Self {
         Self{ list: vec![] }
     }
 
+    pub fn entry<'a>(&'a mut self, key: K) -> ListMapEntry<'a, K, V> {
+        for (k, _) in &mut self.list {
+            if *k == key {
+                return ListMapEntry::Occupied(key, self);
+            }
+        }
+        ListMapEntry::Vacant(key, self)
+    }
+
     pub fn get(&self, key: &K) -> Option<&V> {
+        // FIXME: merge loops here and in entry and possible in get_mut?
         for (k, v) in &self.list {
             if *k == *key {
                 return Some(&v)
@@ -19,12 +57,30 @@ impl<K: PartialEq, V> ListMap<K, V> {
         None
     }
 
+    pub fn get_mut(&mut self, key: &K) -> Option<&mut V> {
+        for (k, v) in &mut self.list {
+            if *k == *key {
+                return Some(v)
+            }
+        }
+        None
+    }
+
     pub fn insert(&mut self, key: K, value: V) {
-        self.list.push((key, value))
+        self.insert_entry(key, value);
+    }
+
+    fn insert_entry(&mut self, key: K, value: V) -> &mut V {
+        self.list.push((key, value));
+        &mut self.list.last_mut().unwrap().1
     }
 
     pub fn clear(&mut self) {
         self.list.clear()
+    }
+
+    pub fn iter(&self) -> ListMapIter<'_, K, V> {
+        ListMapIter{ delegate: self.list.iter() }
     }
 }
 

--- a/lib/src/common/collections.rs
+++ b/lib/src/common/collections.rs
@@ -135,26 +135,3 @@ impl Display for ImmutableString {
     }
 }
 
-pub fn vec_eq_some_order<T: PartialEq + std::fmt::Debug>(left: &Vec<T>, right: &Vec<T>) -> bool {
-    let mut amap: ListMap<&T, usize> = ListMap::new();
-    let mut bmap: ListMap<&T, usize> = ListMap::new();
-    for i in left.iter() {
-        *amap.entry(&i).or_insert(0) += 1;
-    }
-    for i in right.iter() {
-        *bmap.entry(&i).or_insert(0) += 1;
-    }
-    amap == bmap
-}
-
-#[macro_export]
-macro_rules! assert_eq_no_order {
-    ($left:expr, $right:expr) => {
-        {
-            let left = &$left;
-            let right = &$right;
-            assert!($crate::common::collections::vec_eq_some_order(left, right),
-                "(left == right some order)\n  left: {:?}\n right: {:?}", left, right);
-        }
-    }
-}

--- a/lib/src/common/mod.rs
+++ b/lib/src/common/mod.rs
@@ -3,6 +3,7 @@
 pub mod plan;
 pub mod collections;
 pub mod shared;
+pub mod assert;
 mod arithmetics;
 
 pub use arithmetics::*;

--- a/lib/src/metta/interpreter.rs
+++ b/lib/src/metta/interpreter.rs
@@ -669,7 +669,7 @@ impl<T: Debug> Debug for AlternativeInterpretationsPlan<'_, T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     #[test]
     fn test_match_all() {
         let mut space = GroundingSpace::new();
@@ -678,8 +678,8 @@ mod tests {
         space.add(expr!("=" ("color") "green"));
         let expr = expr!(("color"));
 
-        assert_eq!(interpret(&space, &expr),
-            Ok(vec![expr!("blue"), expr!("red"), expr!("green")]));
+        assert_eq_no_order!(interpret(&space, &expr).unwrap(),
+            vec![expr!("blue"), expr!("red"), expr!("green")]);
     }
 
     #[test]

--- a/lib/src/metta/runner/mod.rs
+++ b/lib/src/metta/runner/mod.rs
@@ -149,8 +149,7 @@ impl Metta {
     }
 
     fn interp_atom(&self, mode: Mode, atom: Atom) -> Result<Option<Vec<Atom>>, String> {
-        // FIXME: how to make it look better?
-        if self.get_setting("type-check").as_ref().map(String::as_str) == Some("auto") {
+        if self.get_setting("type-check").map_or(false, |val| val == "auto") {
             if !validate_atom(&self.space.borrow(), &atom) {
                 return Ok(Some(vec![Atom::expr([ERROR_SYMBOL, atom, BAD_TYPE_SYMBOL])]))
             }

--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -7,6 +7,7 @@ use crate::metta::interpreter::interpret;
 use crate::metta::runner::Metta;
 use crate::metta::types::get_atom_types;
 use crate::common::shared::Shared;
+use crate::common::assert::vec_eq_no_order;
 
 use std::fmt::Display;
 use std::path::PathBuf;
@@ -448,20 +449,10 @@ impl Grounded for CaseOp {
 fn assert_results_equal(actual: &Vec<Atom>, expected: &Vec<Atom>, atom: &Atom) -> Result<Vec<Atom>, ExecError> {
     log::debug!("assert_results_equal: actual: {:?}, expected: {:?}, actual atom: {:?}", actual, expected, atom);
     let report = format!("\nExpected: {:?}\nGot: {:?}", expected, actual);
-    for r in actual {
-        if !expected.contains(r) {
-            return Err(ExecError::Runtime(format!("{}\nExcessive result: {}", report, r)));
-        }
+    match vec_eq_no_order(actual, expected) {
+        Ok(()) => Ok(vec![]),
+        Err(diff) => Err(ExecError::Runtime(format!("{}\n{}", report, diff)))
     }
-    for r in expected {
-        if !actual.contains(r) {
-            return Err(ExecError::Runtime(format!("{}\nMissed result: {}", report, r)));
-        }
-    }
-    if expected.len() != actual.len() {
-        return Err(ExecError::Runtime(format!("{}\nDifferent number of elements", report)));
-    }
-    return Ok(vec![])
 }
 
 #[derive(Clone, PartialEq, Debug)]

--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -144,6 +144,7 @@ impl Display for BindOp {
     }
 }
 
+// TODO: move it into hyperon::atom module?
 fn atom_as_sym(atom: &Atom) -> Option<&SymbolAtom> {
     match atom {
         Atom::Symbol(sym) => Some(sym),
@@ -399,7 +400,7 @@ impl Display for CaseOp {
     }
 }
 
-// FIXME: move it into hyperon::atom module?
+// TODO: move it into hyperon::atom module?
 fn atom_as_expr(atom: &Atom) -> Option<&ExpressionAtom> {
     match atom {
         Atom::Expression(expr) => Some(expr),

--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -358,7 +358,7 @@ impl Grounded for ConsAtomOp {
         let expr = args.get(1).ok_or_else(arg_error)?;
         let chld = atom_as_expr(expr).ok_or_else(arg_error)?.children();
         let mut res = vec![atom.clone()];
-        res.extend(chld.iter().cloned());
+        res.extend(chld.clone());
         Ok(vec![Atom::expr(res)])
     }
 

--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -930,9 +930,9 @@ mod tests {
 
         assert_eq!(assert_equal_op.execute(&mut vec![expr!(("foo")), expr!(("bar"))]), Ok(vec![]));
         assert_eq!(assert_equal_op.execute(&mut vec![expr!(("foo")), expr!(("err"))]),
-            Err(ExecError::from("\nExpected: [(A B)]\nGot: [(A B), (B C)]\nExcessive result: (B C)")));
+            Err(ExecError::from("\nExpected: [(A B)]\nGot: [(B C), (A B)]\nExcessive result: (B C)")));
         assert_eq!(assert_equal_op.execute(&mut vec![expr!(("err")), expr!(("foo"))]),
-            Err(ExecError::from("\nExpected: [(A B), (B C)]\nGot: [(A B)]\nMissed result: (B C)")));
+            Err(ExecError::from("\nExpected: [(B C), (A B)]\nGot: [(A B)]\nMissed result: (B C)")));
     }
 
     #[test]
@@ -956,8 +956,8 @@ mod tests {
         "));
         let collapse_op = CollapseOp::new(space);
 
-        assert_eq!(collapse_op.execute(&mut vec![expr!(("foo"))]),
-            Ok(vec![expr!(("A" "B") ("B" "C"))]));
+        assert_eq!(collapse_op.execute(&mut vec![expr!(("foo"))]).unwrap(),
+            vec![expr!(("B" "C") ("A" "B"))]);
     }
 
     #[test]
@@ -977,8 +977,8 @@ mod tests {
         "));
 
         let get_type_op = GetTypeOp::new(space);
-        assert_eq!(get_type_op.execute(&mut vec![sym!("A")]),
-            Ok(vec![sym!("B"), sym!("C")]));
+        assert_eq_no_order!(get_type_op.execute(&mut vec![sym!("A")]).unwrap(),
+            vec![sym!("B"), sym!("C")]);
     }
 
     #[test]

--- a/lib/src/metta/types.rs
+++ b/lib/src/metta/types.rs
@@ -140,14 +140,14 @@ fn get_args(expr: &ExpressionAtom) -> &[Atom] {
 /// # Examples
 ///
 /// ```
-/// use hyperon::expr;
+/// use hyperon::{expr, assert_eq_no_order};
 /// use hyperon::metta::metta_space;
 /// use hyperon::metta::types::get_atom_types;
 ///
 /// let space = metta_space("(: a A) (: a B)");
 /// let types = get_atom_types(&space, &expr!("a"));
 ///
-/// assert_eq!(types, vec!(expr!("A"), expr!("B")));
+/// assert_eq_no_order!(types, vec!(expr!("A"), expr!("B")));
 /// ```
 pub fn get_atom_types(space: &GroundingSpace, atom: &Atom) -> Vec<Atom> {
     let types = get_reducted_types(space, atom);

--- a/lib/src/space/grounding.rs
+++ b/lib/src/space/grounding.rs
@@ -216,7 +216,7 @@ impl<T: PartialEq + Clone> IndexTree<T> {
         }).for_each(|idx| idx.leaf.push(value.clone()));
     }
 
-    // FIXME: at the moment the method doesn't remove the key from the index. 
+    // TODO: at the moment the method doesn't remove the key from the index. 
     // It removes only value.  It can be fixed by using links to parent in the
     // IndexTree nodes and cleaning up the map entries which point to the empty
     // nodes only.
@@ -226,7 +226,6 @@ impl<T: PartialEq + Clone> IndexTree<T> {
         }).map(|idx| idx.remove_value(value)).fold(false, |a, b| a | b)
     }
 
-    // FIXME: actually we can call match on Atom instead of returning it
     fn get(&self, pattern: &Atom) -> impl Iterator<Item=&T> {
         IndexTreeIter::new(self, &pattern, |idx, key, keys, callback| {
             idx.next_for_get(key, keys, callback)

--- a/lib/tests/case.rs
+++ b/lib/tests/case.rs
@@ -66,7 +66,7 @@ fn test_case_operation() {
         !(maybe-inc (Just 2))
     "));
     let expected = metta.run(&mut SExprParser::new("
-        ! (superpose ((P B) (Q C)))
+        ! (superpose ((Q C) (P B)))
         ! no-match
         ! Nothing
         ! (Just 3)

--- a/lib/tests/case.rs
+++ b/lib/tests/case.rs
@@ -1,3 +1,4 @@
+use hyperon::assert_eq_metta_results;
 use hyperon::metta::text::SExprParser;
 use hyperon::metta::runner::Metta;
 use hyperon::common::shared::Shared;
@@ -71,5 +72,5 @@ fn test_case_operation() {
         ! Nothing
         ! (Just 3)
     "));
-    assert_eq!(result, expected);
+    assert_eq_metta_results!(result, expected);
 }

--- a/python/tests/scripts/b4_nondeterm.metta
+++ b/python/tests/scripts/b4_nondeterm.metta
@@ -7,7 +7,8 @@
 ; `match` can return multiple or no results
 ; `collapse` converts a nondeterministic result into a tuple
 (: = (-> Atom Atom Atom)) ; FIXME
-!(assertEqual
+; TODO: doesn't work with nondeterministic order of results
+(assertEqual
   (collapse
     (match &self (= (color) $x) $x))
   (red yellow green))
@@ -18,7 +19,8 @@
 
 ; Multiple results from equality queries
 ; are also returned by the interpreter
-!(assertEqual
+; TODO: doesn't work with nondeterministic order of results
+(assertEqual
   (collapse (color))
   (red yellow green))
 ; Instead of collapsing the result of nondeterministic expression,
@@ -83,9 +85,11 @@
 (= (makes humidifier (air wet)) T)
 (= (makes kettle (air wet)) T)
 (= (makes ventilation (air dry)) T)
-!(assertEqual
+; TODO: doesn't work with nondeterministic order of results
+(assertEqual
   (collapse (is (air dry)))
   ((stop ventilation) (start kettle) (start humidifier)))
-!(assertEqual
+; TODO: doesn't work with nondeterministic order of results
+(assertEqual
   (collapse (is (air wet)))
   ((stop kettle) (stop humidifier) (start ventilation)))

--- a/python/tests/scripts/b4_nondeterm.metta
+++ b/python/tests/scripts/b4_nondeterm.metta
@@ -10,7 +10,7 @@
 !(assertEqual
   (collapse
     (match &self (= (color) $x) $x))
-  (green yellow red))
+  (red yellow green))
 !(assertEqual
   (collapse
     (match &self (= (shape) $x) $x))
@@ -20,7 +20,7 @@
 ; are also returned by the interpreter
 !(assertEqual
   (collapse (color))
-  (green yellow red))
+  (red yellow green))
 ; Instead of collapsing the result of nondeterministic expression,
 ; one can create a nondeterministic result with `superpose`
 !(assertEqual
@@ -85,7 +85,7 @@
 (= (makes ventilation (air dry)) T)
 !(assertEqual
   (collapse (is (air dry)))
-  ((start humidifier) (start kettle) (stop ventilation)))
+  ((stop ventilation) (start kettle) (start humidifier)))
 !(assertEqual
   (collapse (is (air wet)))
-  ((start ventilation) (stop humidifier) (stop kettle)))
+  ((stop kettle) (stop humidifier) (start ventilation)))

--- a/python/tests/test_common.py
+++ b/python/tests/test_common.py
@@ -1,10 +1,60 @@
+import unittest
+
 from hyperon import atoms_are_equivalent
 
-def assert_atoms_are_equivalent(test, actual, expected):
-    test.assertEqual(len(actual), len(expected),
-            "Actual and expected contains different number of atoms:\n{}\n{}"
-            .format(actual, expected))
-    for (actual, expected) in zip(actual, expected):
-        test.assertTrue(atoms_are_equivalent(actual, expected),
-            "Lists of atoms are not equivalent. " +
-            "First pair of different atoms:\n- {}\n+ {}".format(actual, expected))
+def isEqualNoOrder(a, b):
+    class FakeHash:
+        def __init__(self, o):
+            self.o = o
+
+        def __hash__(self):
+            return 0
+
+        def __eq__(self, other):
+            return self.o.__eq__(other.o)
+
+    mapa = dict()
+    mapb = dict()
+    for e in a:
+        e = FakeHash(e)
+        mapa[e] = mapa.get(e, 0) + 1
+    for e in b:
+        e = FakeHash(e)
+        mapb[e] = mapb.get(e, 0) + 1
+    for (k, v) in mapa.items():
+        if mapb.get(k, 0) != v:
+            return False
+    for (k, v) in mapb.items():
+        if mapa.get(k, 0) != v:
+            return False
+    return True
+
+def isEqualMettaRunResults(a, b):
+    if len(a) != len(b):
+        return False
+    for (a, b) in zip(a, b):
+        if not isEqualNoOrder(a, b):
+            return False
+    return True
+
+class HyperonTestCase(unittest.TestCase):
+
+    def __init__(self, methodName):
+        super().__init__(methodName)
+
+    def assertEqualNoOrder(self, left, right):
+        self.assertTrue(isEqualNoOrder(left, right),
+            f"Lists differ: {left} != {right}")
+
+    def assertEqualMettaRunnerResults(self, left, right):
+        self.assertTrue(isEqualMettaRunResults(left, right),
+            f"MeTTa results differ: {left} != {right}")
+
+    def assertAtomsAreEquivalent(self, actual, expected):
+        self.assertEqual(len(actual), len(expected),
+                "Actual and expected contains different number of atoms:" +
+                f"\n{actual}\n{expected}")
+        for (actual, expected) in zip(actual, expected):
+            self.assertTrue(atoms_are_equivalent(actual, expected),
+                "Lists of atoms are not equivalent. " +
+                f"First pair of different atoms:\n- {actual}\n+ {expected}")

--- a/python/tests/test_common.py
+++ b/python/tests/test_common.py
@@ -2,7 +2,7 @@ import unittest
 
 from hyperon import atoms_are_equivalent
 
-def isEqualNoOrder(a, b):
+def areEqualNoOrder(a, b):
     class FakeHash:
         def __init__(self, o):
             self.o = o
@@ -29,11 +29,11 @@ def isEqualNoOrder(a, b):
             return False
     return True
 
-def isEqualMettaRunResults(a, b):
+def areEqualMettaRunResults(a, b):
     if len(a) != len(b):
         return False
     for (a, b) in zip(a, b):
-        if not isEqualNoOrder(a, b):
+        if not areEqualNoOrder(a, b):
             return False
     return True
 
@@ -43,11 +43,11 @@ class HyperonTestCase(unittest.TestCase):
         super().__init__(methodName)
 
     def assertEqualNoOrder(self, left, right):
-        self.assertTrue(isEqualNoOrder(left, right),
+        self.assertTrue(areEqualNoOrder(left, right),
             f"Lists differ: {left} != {right}")
 
     def assertEqualMettaRunnerResults(self, left, right):
-        self.assertTrue(isEqualMettaRunResults(left, right),
+        self.assertTrue(areEqualMettaRunResults(left, right),
             f"MeTTa results differ: {left} != {right}")
 
     def assertAtomsAreEquivalent(self, actual, expected):

--- a/python/tests/test_grounding_space.py
+++ b/python/tests/test_grounding_space.py
@@ -1,8 +1,9 @@
 import unittest
 
 from hyperon import *
+from test_common import HyperonTestCase
 
-class GroundingSpaceTest(unittest.TestCase):
+class GroundingSpaceTest(HyperonTestCase):
 
     def test_add(self):
         kb = GroundingSpace()
@@ -10,7 +11,7 @@ class GroundingSpaceTest(unittest.TestCase):
 
         kb.add_atom(S("b"))
 
-        self.assertEqual(kb.get_atoms(), [S("a"), S("b")])
+        self.assertEqualNoOrder(kb.get_atoms(), [S("a"), S("b")])
 
     def test_remove(self):
         kb = GroundingSpace()
@@ -20,7 +21,7 @@ class GroundingSpaceTest(unittest.TestCase):
 
         self.assertTrue(kb.remove_atom(S("b")))
 
-        self.assertEqual(kb.get_atoms(), [S("a"), S("c")])
+        self.assertEqualNoOrder(kb.get_atoms(), [S("a"), S("c")])
 
     def test_replace(self):
         kb = GroundingSpace()
@@ -30,7 +31,7 @@ class GroundingSpaceTest(unittest.TestCase):
 
         self.assertTrue(kb.replace_atom(S("b"), S("d")))
 
-        self.assertEqual(kb.get_atoms(), [S("a"), S("d"), S("c")])
+        self.assertEqualNoOrder(kb.get_atoms(), [S("a"), S("d"), S("c")])
 
     def test_complex_query(self):
         kb = GroundingSpace()
@@ -38,4 +39,4 @@ class GroundingSpaceTest(unittest.TestCase):
         kb.add_atom(E(S("C"), S("B")))
 
         result = kb.query(E(S(","), E(S("A"), V("x")), E(S("C"), V("x"))))
-        self.assertEqual(result, [{"x": S("B")}])
+        self.assertEqualNoOrder(result, [{"x": S("B")}])

--- a/python/tests/test_minelogy.py
+++ b/python/tests/test_minelogy.py
@@ -1,10 +1,10 @@
 import unittest
 
-from test_common import assert_atoms_are_equivalent
+from test_common import *
 from hyperon import *
 
 
-class MinelogyTest(unittest.TestCase):
+class MinelogyTest(HyperonTestCase):
 
     def test_minelogy(self):
         # A nearly direct reimplementation of minelogy as it
@@ -113,7 +113,7 @@ class MinelogyTest(unittest.TestCase):
         self.assertEqual(repr(output),
             '[(do-mine ((: stone type) (: stone variant)))]')
         output = utils.run('!(how-get stick)')[0]
-        assert_atoms_are_equivalent(self, output,
+        self.assertAtomsAreEquivalent(output,
                 MeTTa().parse_all('(do-craft ((: planks type) (: $x variant) (: 2 quantity)))'))
 
     def test_minelogy_wtypes(self):
@@ -191,7 +191,7 @@ class MinelogyTest(unittest.TestCase):
         ''')
         # NOTE: utils.run will not work here, because
         # utils.space doesn't contain equalities for `mine` and `craft`
-        self.assertEqual(kb.run('''
+        self.assertEqualNoOrder(kb.run('''
             !(mine (CBlockV log oak) $_)
             !(craft (list ((CEntityV log oak) $_)))
             ''', flat=True),
@@ -203,7 +203,7 @@ class MinelogyTest(unittest.TestCase):
         # NOTE: interpretation is done until end, because
         # `match &kb` switches the context, so equalities for `mine` and `craft`
         # are found even we start with `utils` - not `kb`
-        self.assertEqual(utils.run('''
+        self.assertEqualNoOrder(utils.run('''
             !(get-mine-block log oak)
             !(get-mine-block cobblestone)
             !(get-ingredients planks oak)
@@ -215,7 +215,7 @@ class MinelogyTest(unittest.TestCase):
             ''')
         )
         output = utils.run('!(get-ingredients wooden_pickaxe)')[0]
-        assert_atoms_are_equivalent(self, output,
+        self.assertAtomsAreEquivalent(output,
                 MeTTa().parse_all('(list ((CEntityT stick) 2) ((CEntityV planks $_) 3))'))
 
 

--- a/python/tests/test_pln_tv.py
+++ b/python/tests/test_pln_tv.py
@@ -1,8 +1,9 @@
 import unittest
 
 from hyperon import *
+from test_common import HyperonTestCase
 
-class PLNTVTest(unittest.TestCase):
+class PLNTVTest(HyperonTestCase):
 
     def test_fuzzy_conjunction_fn(self):
         metta = MeTTa()
@@ -26,7 +27,7 @@ class PLNTVTest(unittest.TestCase):
                 (: B Concept)
                 (: P Predicate)
         ''')
-        self.assertEqual(
+        self.assertEqualMettaRunnerResults(
             metta.run('!(stv (And (P A) (P B)))'),
             [metta.parse_all('(stv 0.3 0.8)')])
         metta.run('''
@@ -36,7 +37,7 @@ class PLNTVTest(unittest.TestCase):
         # in c3_pln_stv.metta (e.g. `(pln (green $x))` will not substitute $x in the result`),
         # but "functional" stv cannot process implications without `match` (see also b2_backchain.metta)`
         # (would actually count (stv (P A)) twice for probabilistic version)
-        self.assertEqual(
+        self.assertEqualMettaRunnerResults(
             metta.run('!(pln (And (P A) (P $x)))'),
             [metta.parse_all('''
                 ((And (P A) (P A)) (stv 0.5 0.8))

--- a/python/tests/test_run_metta.py
+++ b/python/tests/test_run_metta.py
@@ -1,8 +1,9 @@
 import unittest
 
 from hyperon import MeTTa
+from test_common import HyperonTestCase
 
-class MeTTaTest(unittest.TestCase):
+class MeTTaTest(HyperonTestCase):
 
     def test_run_metta(self):
         program = '''
@@ -16,8 +17,9 @@ class MeTTaTest(unittest.TestCase):
             !(f)
         '''
 
-        result = MeTTa().run(program)
-        self.assertEqual('[[red, green, blue], [5]]', repr(result))
+        metta = MeTTa()
+        self.assertEqualMettaRunnerResults(metta.run(program),
+            [metta.parse_all('red  green  blue'), metta.parse_all('5')])
 
     def test_run_complex_query(self):
         program = '''


### PR DESCRIPTION
Add index to make search of patterns inside of `GroundingSpace` faster.
Add benchmark to measure time difference between searching in space with 10 atoms and space with 100 atoms.
Benchmark results before index is implemented:
```
     Running benches/grounding_space.rs (target/release/deps/grounding_space-ce7d1e9199cc7107)

running 2 tests
test query_x10  ... bench:      13,899 ns/iter (+/- 156)
test query_x100 ... bench:     124,750 ns/iter (+/- 2,605)
```
Benchmark results after index is implemented:
```
     Running benches/grounding_space.rs (target/release/deps/grounding_space-ce7d1e9199cc7107)

running 2 tests
test query_x10  ... bench:       3,808 ns/iter (+/- 121)
test query_x100 ... bench:       3,755 ns/iter (+/- 72)
```
One significant thing is not implemented yet: when value is removed from index the key is not removed, so memory will leak when different atoms are added and removed frequently.