### PR TITLE
Fix C++ build on Mac OS X

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Install Conan
         uses: turtlebrowser/get-conan@v1.0
+        with:
+          version: 1.53
 
       - name: Install cbindgen
         uses: actions-rs/cargo@v1.0.1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,12 @@ project(hyperon)
 # minimum version required by $<IF..> generator expression
 cmake_minimum_required(VERSION 3.10.2)
 
+# Fix behavior of CMAKE_CXX_STANDARD when targeting macOS.
+if (POLICY CMP0025)
+    cmake_policy(SET CMP0025 NEW)
+endif ()
+set(CMAKE_CXX_STANDARD 11)
+
 enable_testing()
 add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN sh /tmp/rustup.sh -y && rm /tmp/rustup.sh
 ENV PATH="${PATH}:/home/user/.cargo/bin"
 RUN cargo install cbindgen
 
-RUN python3 -m pip install conan==1.50
+RUN python3 -m pip install conan==1.53
 ENV PATH="${PATH}:/home/user/.local/bin"
 RUN conan profile new --detect default
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ cargo install --force cbindgen
 
 Install Conan and make default Conan profile:
 ```
-python3 -m pip install conan==1.50
+python3 -m pip install conan==1.53
 conan profile new --detect default
 ```
 


### PR DESCRIPTION
Upgrade Conan to 1.53 because dependency was updated.
Require C++ 11 in compiler.