### PR TITLE
Interpret expression which return an operation

### DIFF
--- a/lib/src/atom/mod.rs
+++ b/lib/src/atom/mod.rs
@@ -442,6 +442,7 @@ pub fn match_by_equality<T: 'static + PartialEq>(this: &T, other: &Atom) -> matc
     }
 }
 
+// TODO: pass args to execute_not_executable(), rename to execute_non_executable()
 /// Returns [ExecError::NoReduce] which means this atom should not be reduced
 /// further. This is a default implementation of `execute()` for the
 /// grounded types wrapped automatically.

--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -75,7 +75,7 @@ impl Grounded for ImportOp {
                 let space = Shared::new(GroundingSpace::new());
                 let space_atom = Atom::gnd(space.clone());
                 let regex = Regex::new(name)
-                    .map_err(|err| format!("Could convert space name {} into regex: {}", name, err))?;
+                    .map_err(|err| format!("Could not convert space name {} into regex: {}", name, err))?;
                 self.tokenizer.borrow_mut()
                     .register_token(regex, move |_| { space_atom.clone() });
                 Ok(space)

--- a/lib/src/metta/types.rs
+++ b/lib/src/metta/types.rs
@@ -297,6 +297,8 @@ fn get_matched_types(space: &GroundingSpace, atom: &Atom, typ: &Atom) -> Vec<(At
     let mut types = get_reducted_types(space, atom);
     types.drain(0..).filter_map(|t| {
         let mut bindings = Bindings::new();
+        // FIXME: write a unit test
+        let t = make_variables_unique(&t);
         if match_reducted_types(&t, typ, &mut bindings) {
             Some((t, bindings))
         } else {

--- a/lib/tests/metta.rs
+++ b/lib/tests/metta.rs
@@ -1,0 +1,23 @@
+use hyperon::common::shared::Shared;
+use hyperon::space::grounding::GroundingSpace;
+use hyperon::metta::text::*;
+use hyperon::metta::runner::Metta;
+
+#[test]
+fn test_reduce_higher_order() {
+    let program = "
+        ; Curried plus
+        (: plus (-> Number (-> Number Number)))
+        (= ((plus $x) $y) (+ $x $y))
+        ; Define inc as partial evaluation of plus
+        (: inc (-> (-> Number Number)))
+        (= (inc) (plus 1))
+
+        !(assertEqualToResult ((inc) 2) (3))
+    ";
+    let metta = Metta::new(Shared::new(GroundingSpace::new()), Shared::new(Tokenizer::new()));
+
+    let result = metta.run(&mut SExprParser::new(program));
+
+    assert_eq!(result, Ok(vec![vec![]]));
+}

--- a/python/tests/scripts/d2_higherfunc.metta
+++ b/python/tests/scripts/d2_higherfunc.metta
@@ -55,7 +55,8 @@
 
 ; The same trick works for defining lambda
 ; (basically, `lambda` is curried `let`)
-(: lambda (-> $a $t (-> $a $t)))
+; FIXME: how to make parameterized type here?
+(: lambda (-> Atom $t (-> $a $t)))
 (= ((lambda $var $body) $arg)
    (let $var $arg $body))
 !(assertEqual


### PR DESCRIPTION
Interpret nested expression which return an operation. Make variables unique to fix type check in this case. Fix type of the lambda to make type-check successful.