### PR TITLE
Fix GroundingSpace::remove() method

### DIFF
--- a/c/src/space.rs
+++ b/c/src/space.rs
@@ -45,12 +45,15 @@ pub unsafe extern "C" fn grounding_space_replace(space: *mut grounding_space_t, 
 
 #[no_mangle]
 pub unsafe extern "C" fn grounding_space_len(space: *const grounding_space_t) -> usize {
-    (*space).borrow().content().len()
+    (*space).borrow().iter().count()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn grounding_space_get(space: *const grounding_space_t, idx: usize) -> *mut atom_t {
-    atom_to_ptr((*space).borrow().content()[idx].clone())
+    // TODO: highly ineffective implementation, should be reworked after replacing
+    // the GroundingSpace struct by Space trait in code.
+    atom_to_ptr((*space).borrow().iter().skip(idx).next()
+        .expect(format!("Index is out of bounds: {}", idx).as_str()).clone())
 }
 
 #[repr(C)]

--- a/lib/src/common/assert.rs
+++ b/lib/src/common/assert.rs
@@ -2,13 +2,13 @@ use super::collections::ListMap;
 
 use std::cmp::Ordering;
 
-pub fn vec_eq_no_order<T: PartialEq + std::fmt::Debug>(left: &Vec<T>, right: &Vec<T>) -> Result<(), String> {
+pub fn vec_eq_no_order<'a, T: PartialEq + std::fmt::Debug + 'a, A: Iterator<Item=&'a T>, B: Iterator<Item=&'a T>>(left: A, right: B) -> Result<(), String> {
     let mut left_count: ListMap<&T, usize> = ListMap::new();
     let mut right_count: ListMap<&T, usize> = ListMap::new();
-    for i in left.iter() {
+    for i in left {
         *left_count.entry(&i).or_insert(0) += 1;
     }
-    for i in right.iter() {
+    for i in right {
         *right_count.entry(&i).or_insert(0) += 1;
     }
     counter_eq_explanation(&left_count, &right_count)
@@ -44,10 +44,8 @@ fn counter_eq_explanation<T: PartialEq + std::fmt::Debug>(left: &ListMap<&T, usi
 macro_rules! assert_eq_no_order {
     ($left:expr, $right:expr) => {
         {
-            let left = &$left;
-            let right = &$right;
-            assert!($crate::common::assert::vec_eq_no_order(left, right) == Ok(()),
-                "(left == right some order)\n  left: {:?}\n right: {:?}", left, right);
+            assert!($crate::common::assert::vec_eq_no_order($left.iter(), $right.iter()) == Ok(()),
+                "(left == right some order)\n  left: {:?}\n right: {:?}", $left, $right);
         }
     }
 }
@@ -58,7 +56,7 @@ pub fn metta_results_eq<T: PartialEq + std::fmt::Debug>(
     match (left, right) {
         (Ok(left), Ok(right)) if left.len() == right.len() => {
             for (left, right) in left.iter().zip(right.iter()) {
-                if let Err(_) = vec_eq_no_order(left, right) {
+                if let Err(_) = vec_eq_no_order(left.iter(), right.iter()) {
                     return false;
                 }
             }

--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -282,7 +282,7 @@ impl Grounded for GetAtomsOp {
         let arg_error = || ExecError::from("get-atoms expects one argument: space");
         let space = args.get(0).ok_or_else(arg_error)?;
         let space = Atom::as_gnd::<Shared<GroundingSpace>>(space).ok_or("get-atoms expects a space as its argument")?;
-        Ok(space.borrow().content().clone())
+        Ok(space.borrow().iter().cloned().collect())
     }
 
     fn match_(&self, other: &Atom) -> MatchResultIter {
@@ -454,7 +454,7 @@ impl Grounded for CaseOp {
 fn assert_results_equal(actual: &Vec<Atom>, expected: &Vec<Atom>, atom: &Atom) -> Result<Vec<Atom>, ExecError> {
     log::debug!("assert_results_equal: actual: {:?}, expected: {:?}, actual atom: {:?}", actual, expected, atom);
     let report = format!("\nExpected: {:?}\nGot: {:?}", expected, actual);
-    match vec_eq_no_order(actual, expected) {
+    match vec_eq_no_order(actual.iter(), expected.iter()) {
         Ok(()) => Ok(vec![]),
         Err(diff) => Err(ExecError::Runtime(format!("{}\n{}", report, diff)))
     }
@@ -903,7 +903,7 @@ mod tests {
         let res = NewSpaceOp{}.execute(&mut vec![]).expect("No result returned");
         let space = res.get(0).expect("Result is empty");
         let space = space.as_gnd::<Shared<GroundingSpace>>().expect("Result is not space");
-        assert_eq!(*space.borrow().content(), vec![]);
+        assert_eq_no_order!(space.borrow().deref(), Vec::<Atom>::new());
     }
 
     #[test]
@@ -912,7 +912,7 @@ mod tests {
         let satom = Atom::gnd(space.clone());
         let res = AddAtomOp{}.execute(&mut vec![satom, expr!(("foo" "bar"))]).expect("No result returned");
         assert!(res.is_empty());
-        assert_eq!(*space.borrow().content(), vec![expr!(("foo" "bar"))]);
+        assert_eq_no_order!(space.borrow().deref(), vec![expr!(("foo" "bar"))]);
     }
 
     #[test]
@@ -925,7 +925,7 @@ mod tests {
         let res = RemoveAtomOp{}.execute(&mut vec![satom, expr!(("foo" "bar"))]).expect("No result returned");
         // REM: can return Bool in future
         assert!(res.is_empty());
-        assert_eq!(*space.borrow().content(), vec![expr!(("bar" "foo"))]);
+        assert_eq_no_order!(space.borrow().deref(), vec![expr!(("bar" "foo"))]);
     }
 
     #[test]
@@ -936,8 +936,8 @@ mod tests {
         "));
         let satom = Atom::gnd(space.clone());
         let res = GetAtomsOp{}.execute(&mut vec![satom]).expect("No result returned");
-        assert_eq!(res, *space.borrow().content());
-        assert_eq!(res, vec![expr!(("foo" "bar")), expr!(("bar" "foo"))]);
+        assert_eq_no_order!(res, space.borrow().deref());
+        assert_eq_no_order!(res, vec![expr!(("foo" "bar")), expr!(("bar" "foo"))]);
     }
 
     #[test]
@@ -1046,7 +1046,7 @@ mod tests {
         let actual = collapse_op.execute(&mut vec![expr!(("foo"))]).unwrap();
         assert_eq!(actual.len(), 1);
         assert_eq_no_order!(
-            atom_as_expr(&actual[0]).unwrap().children(),
+            *atom_as_expr(&actual[0]).unwrap().children(),
             vec![expr!("B" "C"), expr!("A" "B")]);
     }
 


### PR DESCRIPTION
GroundingSpace::remove() changed indexes after removing leading element from GroundingSpace::content vector. Implementing more complex logic with GroundingSpace::content having free cells. Free cells are filled by adding new atoms. Add iter() method to iterate the GroundingSpace skipping free cells in content.