### PR TITLE
Allow alternative space implementation

### DIFF
--- a/c/src/metta.rs
+++ b/c/src/metta.rs
@@ -91,12 +91,12 @@ pub unsafe extern "C" fn sexpr_parser_parse(parser: *mut sexpr_parser_t,
 
 #[no_mangle]
 pub unsafe extern "C" fn check_type(space: *const grounding_space_t, atom: *const atom_t, typ: *const atom_t) -> bool {
-    hyperon::metta::types::check_type(&(*space).borrow(), &(*atom).atom, &(*typ).atom)
+    hyperon::metta::types::check_type((*space).borrow().deref(), &(*atom).atom, &(*typ).atom)
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn validate_atom(space: *const grounding_space_t, atom: *const atom_t) -> bool {
-    hyperon::metta::types::validate_atom(&(*space).borrow(), &(*atom).atom)
+    hyperon::metta::types::validate_atom((*space).borrow().deref(), &(*atom).atom)
 }
 
 #[no_mangle]
@@ -104,7 +104,7 @@ pub extern "C" fn get_atom_types(space: *const grounding_space_t, atom: *const a
         callback: c_atoms_callback_t, context: *mut c_void) {
     let space = unsafe{ &(*space).borrow() };
     let atom = unsafe{ &(*atom).atom };
-    let types = hyperon::metta::types::get_atom_types(space, atom);
+    let types = hyperon::metta::types::get_atom_types(space.deref(), atom);
     return_atoms(&types, callback, context);
 }
 

--- a/lib/src/common/shared.rs
+++ b/lib/src/common/shared.rs
@@ -6,11 +6,11 @@ use std::fmt::{Debug, Display};
 use crate::atom::*;
 use crate::matcher::MatchResultIter;
 
-pub trait LockBorrow<T> {
+pub trait LockBorrow<T: ?Sized> {
     fn borrow(&self) -> Box<dyn Deref<Target=T> + '_>;
 }
 
-pub trait LockBorrowMut<T> : LockBorrow<T> {
+pub trait LockBorrowMut<T: ?Sized> {
     fn borrow_mut(&mut self) -> Box<dyn DerefMut<Target=T> + '_>;
 }
 

--- a/lib/src/metta/interpreter.rs
+++ b/lib/src/metta/interpreter.rs
@@ -238,7 +238,7 @@ struct InterpreterContextRef<'a, T: GroundingSpacePtr + 'a>(Rc<InterpreterContex
 impl<'a, T: GroundingSpacePtr + 'a> InterpreterContextRef<'a, T> {
     fn new(space: T) -> Self {
         let cache = Rc::new(RefCell::new(InterpreterCache::new()));
-        space.borrow().register_observer(Rc::clone(&cache));
+        space.borrow().register_observer(cache.clone());
         Self(Rc::new(InterpreterContext{ space, cache, phantom: PhantomData }))
     }
 }

--- a/lib/src/metta/interpreter.rs
+++ b/lib/src/metta/interpreter.rs
@@ -68,6 +68,7 @@ use crate::*;
 use crate::common::plan::*;
 use crate::atom::subexpr::*;
 use crate::atom::matcher::*;
+use crate::space::*;
 use crate::space::grounding::*;
 use crate::common::collections::ListMap;
 use crate::metta::*;

--- a/lib/src/metta/runner/mod.rs
+++ b/lib/src/metta/runner/mod.rs
@@ -174,7 +174,7 @@ impl Metta {
 
     fn type_check(&self, atom: Atom) -> Result<Atom, Atom> {
         let is_type_check_enabled = self.get_setting("type-check").map_or(false, |val| val == "auto");
-        if  is_type_check_enabled && !validate_atom(&self.space.borrow(), &atom) {
+        if  is_type_check_enabled && !validate_atom(self.space.borrow().deref(), &atom) {
             Err(Atom::expr([ERROR_SYMBOL, atom, BAD_TYPE_SYMBOL]))
         } else {
             Ok(atom)

--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -671,7 +671,7 @@ impl Grounded for GetTypeOp {
         let arg_error = || ExecError::from("get-type expects single atom as an argument");
         let atom = args.get(0).ok_or_else(arg_error)?;
 
-        Ok(get_atom_types(&self.space.borrow(), atom))
+        Ok(get_atom_types(self.space.borrow().deref(), atom))
     }
 
     fn match_(&self, other: &Atom) -> MatchResultIter {

--- a/lib/src/space/grounding.rs
+++ b/lib/src/space/grounding.rs
@@ -581,9 +581,6 @@ impl Space for GroundingSpace {
     fn subst(&self, pattern: &Atom, template: &Atom) -> Vec<Atom> {
         GroundingSpace::subst(self, pattern, template)
     }
-    fn iter(&self) -> SpaceIter {
-        GroundingSpace::iter(self)
-    }
 }
 
 impl SpaceMut for GroundingSpace {

--- a/lib/src/space/grounding.rs
+++ b/lib/src/space/grounding.rs
@@ -575,29 +575,26 @@ impl Space for GroundingSpace {
     fn register_observer(&self, observer: Rc<RefCell<dyn SpaceObserver>>) {
         GroundingSpace::register_observer(self, observer)
     }
-
-    fn add(&mut self, atom: Atom) {
-        GroundingSpace::add(self, atom)
-    }
-
-    fn remove(&mut self, atom: &Atom) -> bool {
-        GroundingSpace::remove(self, atom)
-    }
-
-    fn replace(&mut self, from: &Atom, to: Atom) -> bool {
-        GroundingSpace::replace(self, from, to)
-    }
-
     fn query(&self, query: &Atom) -> Vec<Bindings> {
         GroundingSpace::query(self, query)
     }
-
     fn subst(&self, pattern: &Atom, template: &Atom) -> Vec<Atom> {
         GroundingSpace::subst(self, pattern, template)
     }
-
     fn iter(&self) -> SpaceIter {
         GroundingSpace::iter(self)
+    }
+}
+
+impl SpaceMut for GroundingSpace {
+    fn add(&mut self, atom: Atom) {
+        GroundingSpace::add(self, atom)
+    }
+    fn remove(&mut self, atom: &Atom) -> bool {
+        GroundingSpace::remove(self, atom)
+    }
+    fn replace(&mut self, from: &Atom, to: Atom) -> bool {
+        GroundingSpace::replace(self, from, to)
     }
 }
 

--- a/lib/src/space/grounding.rs
+++ b/lib/src/space/grounding.rs
@@ -283,7 +283,7 @@ pub enum SpaceEvent {
 /// let mut space = GroundingSpace::new();
 /// let observer = Rc::new(RefCell::new(MyObserver{ events: Vec::new() }));
 ///
-/// space.register_observer(Rc::clone(&observer));
+/// space.register_observer(observer.clone());
 /// space.add(sym!("A"));
 /// space.replace(&sym!("A"), sym!("B"));
 /// space.remove(&sym!("B"));
@@ -366,8 +366,7 @@ impl GroundingSpace {
     /// Registers space modifications `observer`. Observer is automatically
     /// deregistered when `Rc` counter reaches zero. See [SpaceObserver] for
     /// examples.
-    pub fn register_observer<T>(&self, observer: Rc<RefCell<T>>)
-        where T: SpaceObserver + 'static
+    pub fn register_observer(&self, observer: Rc<RefCell<dyn SpaceObserver>>)
     {
         self.observers.borrow_mut().push(Rc::downgrade(&observer) as Weak<RefCell<dyn SpaceObserver>>);
     }
@@ -691,7 +690,7 @@ mod test {
     fn add_atom() {
         let mut space = GroundingSpace::new();
         let observer = Rc::new(RefCell::new(SpaceEventCollector::new()));
-        space.register_observer(Rc::clone(&observer));
+        space.register_observer(observer.clone());
 
         space.add(expr!("a"));
         space.add(expr!("b"));
@@ -706,7 +705,7 @@ mod test {
     fn remove_atom() {
         let mut space = GroundingSpace::new();
         let observer = Rc::new(RefCell::new(SpaceEventCollector::new()));
-        space.register_observer(Rc::clone(&observer));
+        space.register_observer(observer.clone());
 
         space.add(expr!("a"));
         space.add(expr!("b"));
@@ -723,7 +722,7 @@ mod test {
     fn remove_atom_not_found() {
         let mut space = GroundingSpace::new();
         let observer = Rc::new(RefCell::new(SpaceEventCollector::new()));
-        space.register_observer(Rc::clone(&observer));
+        space.register_observer(observer.clone());
 
         space.add(expr!("a"));
         assert_eq!(space.remove(&expr!("b")), false);
@@ -736,7 +735,7 @@ mod test {
     fn replace_atom() {
         let mut space = GroundingSpace::new();
         let observer = Rc::new(RefCell::new(SpaceEventCollector::new()));
-        space.register_observer(Rc::clone(&observer));
+        space.register_observer(observer.clone());
 
         space.add(expr!("a"));
         space.add(expr!("b"));
@@ -753,7 +752,7 @@ mod test {
     fn replace_atom_not_found() {
         let mut space = GroundingSpace::new();
         let observer = Rc::new(RefCell::new(SpaceEventCollector::new()));
-        space.register_observer(Rc::clone(&observer));
+        space.register_observer(observer.clone());
 
         space.add(expr!("a"));
         assert_eq!(space.replace(&expr!("b"), expr!("d")), false);
@@ -766,7 +765,7 @@ mod test {
     fn remove_replaced_atom() {
         let mut space = GroundingSpace::new();
         let observer = Rc::new(RefCell::new(SpaceEventCollector::new()));
-        space.register_observer(Rc::clone(&observer));
+        space.register_observer(observer.clone());
 
         space.add(expr!("a"));
         space.replace(&expr!("a"), expr!("b"));
@@ -928,7 +927,7 @@ mod test {
         let mut space = GroundingSpace::new();
         {
             let observer = Rc::new(RefCell::new(SpaceEventCollector::new()));
-            space.register_observer(Rc::clone(&observer));
+            space.register_observer(observer.clone());
             assert_eq!(space.observers.borrow().len(), 1);
         }
 

--- a/lib/src/space/mod.rs
+++ b/lib/src/space/mod.rs
@@ -121,9 +121,6 @@ pub trait Space {
     /// assert_eq_no_order!(result, vec![expr!("D" "B"), expr!("D" "C")]);
     /// ```
     fn subst(&self, pattern: &Atom, template: &Atom) -> Vec<Atom>;
-
-    /// Returns the iterator over content of the space.
-    fn iter(&self) -> SpaceIter;
 }
 
 /// Mutable space trait.
@@ -197,9 +194,6 @@ impl<T: Space> Space for Shared<T> {
     fn subst(&self, pattern: &Atom, template: &Atom) -> Vec<Atom> {
         self.borrow().subst(pattern, template)
     }
-    fn iter(&self) -> SpaceIter {
-        todo!("Not implemented")
-    }
 }
 
 impl<T: SpaceMut> SpaceMut for Shared<T> {
@@ -224,9 +218,6 @@ impl<T: Space> Space for &T {
     }
     fn subst(&self, pattern: &Atom, template: &Atom) -> Vec<Atom> {
         T::subst(*self, pattern, template)
-    }
-    fn iter(&self) -> SpaceIter {
-        todo!("Not implemented")
     }
 }
 

--- a/lib/src/space/mod.rs
+++ b/lib/src/space/mod.rs
@@ -2,3 +2,88 @@
 //! This module is intended to keep different space implementations.
 
 pub mod grounding;
+
+use std::rc::Rc;
+use std::cell::RefCell;
+
+use crate::atom::Atom;
+use crate::atom::matcher::Bindings;
+
+/// Contains information about space modification event.
+#[derive(Clone, Debug, PartialEq)]
+pub enum SpaceEvent {
+    /// Atom is added into a space.
+    Add(Atom),
+    /// Atom is removed from space.
+    Remove(Atom),
+    /// First atom is replaced by the second one.
+    Replace(Atom, Atom),
+}
+
+/// Space modification event observer trait.
+///
+/// # Examples
+///
+/// ```
+/// use hyperon::sym;
+/// use hyperon::space::*;
+/// use hyperon::space::grounding::*;
+/// use std::rc::Rc;
+/// use std::cell::RefCell;
+///
+/// struct MyObserver {
+///     events: Vec<SpaceEvent>
+/// }
+///
+/// impl SpaceObserver for MyObserver {
+///     fn notify(&mut self, event: &SpaceEvent) {
+///         self.events.push(event.clone());
+///     }
+/// }
+///
+/// let mut space = GroundingSpace::new();
+/// let observer = Rc::new(RefCell::new(MyObserver{ events: Vec::new() }));
+///
+/// space.register_observer(observer.clone());
+/// space.add(sym!("A"));
+/// space.replace(&sym!("A"), sym!("B"));
+/// space.remove(&sym!("B"));
+///
+/// assert_eq!(observer.borrow().events, vec![SpaceEvent::Add(sym!("A")),
+///     SpaceEvent::Replace(sym!("A"), sym!("B")),
+///     SpaceEvent::Remove(sym!("B"))]);
+/// ```
+pub trait SpaceObserver {
+    /// Notifies about space modification.
+    fn notify(&mut self, event: &SpaceEvent);
+}
+
+/// Space iterator.
+pub struct SpaceIter<'a> {
+    iter: Box<dyn Iterator<Item=&'a Atom> + 'a>
+}
+
+impl<'a> SpaceIter<'a> {
+    fn new<I: Iterator<Item=&'a Atom> + 'a>(iter: I) -> Self {
+        Self{ iter: Box::new(iter) }
+    }
+}
+
+impl<'a> Iterator for SpaceIter<'a> {
+    type Item = &'a Atom;
+
+    fn next(&mut self) -> Option<&'a Atom> {
+        self.iter.next()
+    }
+}
+
+/// Space trait.
+pub trait Space {
+    fn register_observer(&self, observer: Rc<RefCell<dyn SpaceObserver>>);
+    fn add(&mut self, atom: Atom);
+    fn remove(&mut self, atom: &Atom) -> bool;
+    fn replace(&mut self, from: &Atom, to: Atom) -> bool;
+    fn query(&self, query: &Atom) -> Vec<Bindings>;
+    fn subst(&self, pattern: &Atom, template: &Atom) -> Vec<Atom>;
+    fn iter(&self) -> SpaceIter;
+}

--- a/lib/src/space/mod.rs
+++ b/lib/src/space/mod.rs
@@ -80,10 +80,71 @@ impl<'a> Iterator for SpaceIter<'a> {
 /// Space trait.
 pub trait Space {
     fn register_observer(&self, observer: Rc<RefCell<dyn SpaceObserver>>);
-    fn add(&mut self, atom: Atom);
-    fn remove(&mut self, atom: &Atom) -> bool;
-    fn replace(&mut self, from: &Atom, to: Atom) -> bool;
     fn query(&self, query: &Atom) -> Vec<Bindings>;
     fn subst(&self, pattern: &Atom, template: &Atom) -> Vec<Atom>;
     fn iter(&self) -> SpaceIter;
+}
+
+/// Space trait.
+pub trait SpaceMut {
+    fn add(&mut self, atom: Atom);
+    fn remove(&mut self, atom: &Atom) -> bool;
+    fn replace(&mut self, from: &Atom, to: Atom) -> bool;
+}
+
+use crate::common::shared::Shared;
+
+impl<T: Space> Space for Shared<T> {
+    fn register_observer(&self, observer: Rc<RefCell<dyn SpaceObserver>>) {
+        self.borrow().register_observer(observer)
+    }
+    fn query(&self, query: &Atom) -> Vec<Bindings> {
+        self.borrow().query(query)
+    }
+    fn subst(&self, pattern: &Atom, template: &Atom) -> Vec<Atom> {
+        self.borrow().subst(pattern, template)
+    }
+    fn iter(&self) -> SpaceIter {
+        todo!("Not implemented")
+    }
+}
+
+impl<T: SpaceMut> SpaceMut for Shared<T> {
+    fn add(&mut self, atom: Atom) {
+        self.borrow_mut().add(atom)
+    }
+    fn remove(&mut self, atom: &Atom) -> bool {
+        self.borrow_mut().remove(atom)
+    }
+    fn replace(&mut self, from: &Atom, to: Atom) -> bool {
+        self.borrow_mut().replace(from, to)
+    }
+}
+
+
+impl<T: Space> Space for &T {
+    fn register_observer(&self, observer: Rc<RefCell<dyn SpaceObserver>>) {
+        T::register_observer(*self, observer)
+    }
+    fn query(&self, query: &Atom) -> Vec<Bindings> {
+        T::query(*self, query)
+    }
+    fn subst(&self, pattern: &Atom, template: &Atom) -> Vec<Atom> {
+        T::subst(*self, pattern, template)
+    }
+    fn iter(&self) -> SpaceIter {
+        todo!("Not implemented")
+    }
+}
+
+impl<T: SpaceMut> SpaceMut for &mut T {
+    fn add(&mut self, atom: Atom) {
+        (*self).add(atom)
+    }
+    fn remove(&mut self, atom: &Atom) -> bool {
+        (*self).remove(atom)
+    }
+    fn replace(&mut self, from: &Atom, to: Atom) -> bool {
+        (*self).replace(from, to)
+    }
 }


### PR DESCRIPTION
Introduce `Space` and `SpaceMut` traits, use `Space` as an input type restriction in interpreter and type checker API.