### PR TITLE
Fix index memory overflow

### DIFF
--- a/lib/src/common/multitrie.rs
+++ b/lib/src/common/multitrie.rs
@@ -25,7 +25,7 @@
 //! `[ Exact(A), LeftPar, Exact(B), RightPar ]` keys.
 //!
 //! Wildcard can be used not only for getting value but also as a key for
-//! keeping value. Thus a singly key in the [MultiTrie] can match many different keys
+//! keeping value. Thus a single key in the [MultiTrie] can match many different keys
 //! for retrieve value. In the example above we could put two
 //! values with `[ Exact(A), Exact(B) ]` and `[ Exact(A), LeftPar, Exact(B), RightPar ]`
 //! keys into the trie and then get both of them using `[ Exact(A), * ]` key.

--- a/lib/src/common/multitrie.rs
+++ b/lib/src/common/multitrie.rs
@@ -373,12 +373,17 @@ mod test {
         trie.add(triekey!("A"), "exact_a");
         trie.add(triekey!(*), "wild");
         trie.add(triekey!(["A", "B"]), "expr_a_b");
+        trie.add(triekey!("A", "B"), "a_b");
 
         assert_eq!(trie.get(triekey!("A")).to_sorted(), vec!["exact_a", "wild"]);
         assert_eq!(trie.get(triekey!("B")).to_sorted(), vec!["wild"]);
         assert_eq!(trie.get(triekey!(*)).to_sorted(), vec!["exact_a", "expr_a_b", "wild"]);
         assert_eq!(trie.get(triekey!(["A", "B"])).to_sorted(), vec!["expr_a_b", "wild"]);
         assert_eq!(trie.get(triekey!(["A", "C"])).to_sorted(), vec!["wild"]);
+        assert_eq!(trie.get(triekey!(["A", *])).to_sorted(), vec!["expr_a_b", "wild"]);
+        assert_eq!(trie.get(triekey!("A", "B")).to_sorted(), vec!["a_b"]);
+        assert_eq!(trie.get(triekey!("A", "C")).to_sorted(), vec![] as Vec<&str>);
+        assert_eq!(trie.get(triekey!("A", *)).to_sorted(), vec!["a_b"]);
     }
 
     #[test]
@@ -419,14 +424,17 @@ mod test {
         trie.add(triekey!("A"), "exact_a");
         trie.add(triekey!(*), "wild");
         trie.add(triekey!(["A", "B"]), "expr_a_b");
+        trie.add(triekey!("A", "B"), "a_b");
 
         trie.remove(triekey!("A"), &"exact_a");
         trie.remove(triekey!(*), &"wild");
         trie.remove(triekey!(["A", "B"]), &"expr_a_b");
+        trie.remove(triekey!("A", "B"), &"a_b");
 
         assert!(trie.get(triekey!("A")).to_sorted().is_empty());
         assert!(trie.get(triekey!(*)).to_sorted().is_empty());
         assert!(trie.get(triekey!(["A", "B"])).to_sorted().is_empty());
+        assert!(trie.get(triekey!("A", "B")).to_sorted().is_empty());
     }
 
     #[test]

--- a/lib/src/common/multitrie.rs
+++ b/lib/src/common/multitrie.rs
@@ -150,7 +150,7 @@ struct TrieKeyIter<'a, T> {
     pos: usize,
 }
 
-impl<'a, T: Clone> TrieKeyIter<'a, T> {
+impl<'a, T> TrieKeyIter<'a, T> {
     // FIXME: can we remove it?
     fn is_empty(&self) -> bool {
         self.pos >= self.key.tokens.len()
@@ -193,8 +193,8 @@ pub struct MultiTrie<K, V>(MultiTrieNode<K, V>);
 
 impl<K, V> MultiTrie<K, V>
 where
-    K: Clone + Debug + Eq + Hash + ?Sized,
-    V: Clone + Debug + Eq + Hash + ?Sized,
+    K: Debug + Clone + Eq + Hash,
+    V: Debug + Eq + Hash,
 {
     /// Constructs new empty [MultiTrie] instance.
     pub fn new() -> Self {
@@ -302,8 +302,8 @@ struct MultiTrieNode<K, V> {
 
 impl<K, V> MultiTrieNode<K, V>
 where
-    K: Clone + Debug + Eq + Hash + ?Sized,
-    V: Clone + Debug + Eq + Hash + ?Sized,
+    K: Clone + Eq + Hash,
+    V: Eq + Hash,
 {
 
     fn new() -> Self {
@@ -454,8 +454,8 @@ struct MultiValueIter<'a, K, V> {
 
 impl<'a, K, V> MultiValueIter<'a, K, V>
 where
-    K: Clone + Debug + Eq + Hash + ?Sized,
-    V: Clone + Debug + Eq + Hash + ?Sized,
+    K: Clone + Eq + Hash,
+    V: Eq + Hash,
 {
     fn new(node: &'a MultiTrieNode<K, V>, key: TrieKeyIter<'a, K>) -> Self {
         let mut to_be_explored = Vec::new();
@@ -470,8 +470,8 @@ where
 
 impl<'a, K, V> Iterator for MultiValueIter<'a, K, V>
 where
-    K: Clone + Debug + Eq + Hash + ?Sized,
-    V: Clone + Debug + Eq + Hash + ?Sized,
+    K: Clone + Eq + Hash,
+    V: Eq + Hash,
 {
     type Item = &'a MultiTrieNode<K, V>;
 

--- a/lib/src/common/multitrie.rs
+++ b/lib/src/common/multitrie.rs
@@ -240,6 +240,11 @@ where
         ValueExplorer::new(self, key, MultiTrieNode::get_exploring_strategy)
             .flat_map(|node| node.values.iter())
     }
+
+    #[cfg(test)]
+    fn size(&self) -> usize {
+        self.children.values().fold(1, |size, node| { size + node.size() })
+    }
 }
 
 #[cfg(test)]
@@ -341,5 +346,27 @@ mod test {
         assert_eq!(format!("{:?}", exact_a), "TrieKey([Exact(\"A\")])");
         assert_eq!(format!("{:?}", wild), "TrieKey([Wildcard])");
         assert_eq!(format!("{:?}", expr_a_b), "TrieKey([Expression(3), Exact(\"A\"), Exact(\"B\"), ExpressionEnd])");
+    }
+
+    #[ignore]
+    #[test]
+    fn trie_add_key_with_many_subexpr() {
+        fn with_subexpr(nvars: usize) -> TrieKey<NodeKey<usize>> {
+            let mut keys = Vec::new();
+            keys.push(NodeKey::Expression(nvars * 2 + 1));
+            for _i in 0..nvars {
+                keys.push(NodeKey::Expression(1));
+                keys.push(NodeKey::ExpressionEnd);
+            }
+            keys.push(NodeKey::ExpressionEnd);
+            TrieKey::from_list(keys)
+        }
+        let mut index = MultiTrie::new();
+
+        index.add(with_subexpr(4), 0);
+        assert_eq!(index.size(), 4*2 + 4);
+
+        index.add(with_subexpr(8), 0);
+        assert_eq!(index.size(), 8*2 + 8);
     }
 }

--- a/lib/src/common/multitrie.rs
+++ b/lib/src/common/multitrie.rs
@@ -348,6 +348,18 @@ mod test {
         assert_eq!(format!("{:?}", expr_a_b), "TrieKey([Expression(3), Exact(\"A\"), Exact(\"B\"), ExpressionEnd])");
     }
 
+    #[test]
+    fn trie_clone() {
+        let mut trie = MultiTrie::new();
+        let key = TrieKey::from_list([NodeKey::Exact(0), NodeKey::Wildcard,
+            NodeKey::Expression(2), NodeKey::Wildcard, NodeKey::ExpressionEnd]);
+        trie.add(key.clone(), "test");
+
+        let copy = trie.clone();
+
+        assert_eq!(copy.get(key).to_sorted(), vec!["test"]);
+    }
+
     #[ignore]
     #[test]
     fn trie_add_key_with_many_subexpr() {

--- a/lib/src/common/shared.rs
+++ b/lib/src/common/shared.rs
@@ -114,6 +114,13 @@ impl<T> Shared<T> {
     pub fn as_ptr(&self) -> *mut T {
         self.0.as_ptr()
     }
+
+    pub fn unwrap_or_clone(self) -> T where T: Clone {
+        match Rc::try_unwrap(self.0) {
+            Err(rc) => RefCell::borrow(&rc).clone(),
+            Ok(ref_cell) => ref_cell.into_inner(),
+        }
+    }
 }
 
 impl<T> LockBorrow<T> for Shared<T> {

--- a/lib/src/common/shared.rs
+++ b/lib/src/common/shared.rs
@@ -110,6 +110,10 @@ impl<T> Shared<T> {
     pub fn cloned(&self) -> Self where T: Clone {
         Self::new(RefCell::borrow(&self.0).clone())
     }
+
+    pub fn as_ptr(&self) -> *mut T {
+        self.0.as_ptr()
+    }
 }
 
 impl<T> LockBorrow<T> for Shared<T> {

--- a/lib/src/space/grounding.rs
+++ b/lib/src/space/grounding.rs
@@ -104,7 +104,7 @@ impl GroundingSpace {
     pub fn from_vec(atoms: Vec<Atom>) -> Self {
         let mut index = MultiTrie::new();
         for (i, atom) in atoms.iter().enumerate() {
-            index.add(atom_to_trie_key(atom), i);
+            index.insert(atom_to_trie_key(atom), i);
         }
         Self{
             index,
@@ -163,12 +163,12 @@ impl GroundingSpace {
     fn add_internal(&mut self, atom: Atom) {
         if self.free.is_empty() {
             let pos = self.content.len();
-            self.index.add(atom_to_trie_key(&atom), pos);
+            self.index.insert(atom_to_trie_key(&atom), pos);
             self.content.push(atom);
         } else {
             let pos = *self.free.iter().next().unwrap();
             self.free.remove(&pos);
-            self.index.add(atom_to_trie_key(&atom), pos);
+            self.index.insert(atom_to_trie_key(&atom), pos);
             self.content[pos] = atom;
         }
     }

--- a/lib/src/space/grounding.rs
+++ b/lib/src/space/grounding.rs
@@ -55,12 +55,9 @@ fn atom_to_trie_key(atom: &Atom) -> TrieKey<SymbolAtom> {
         match atom {
             Atom::Symbol(sym) => keys.push(NodeKey::Exact(sym.clone())),
             Atom::Expression(expr) => {
-                let start = keys.len();
                 keys.push(NodeKey::ExpressionBegin);
                 expr.children().iter().for_each(|child| fill_key(child, keys));
                 keys.push(NodeKey::ExpressionEnd);
-                let expr_len = keys.len() - start - 1;
-                keys[start] = NodeKey::Expression(expr_len);
             },
             // TODO: At the moment all grounding symbols are matched as wildcards
             // because they potentially may have custom Grounded::match_()
@@ -706,7 +703,7 @@ mod test {
         assert_eq!(atom_to_trie_key(&Atom::value(1)), TrieKey::from_list([NodeKey::Wildcard]));
         assert_eq!(atom_to_trie_key(&Atom::var("a")), TrieKey::from_list([NodeKey::Wildcard]));
         assert_eq!(atom_to_trie_key(&expr!("A" "B")), TrieKey::from_list([
-                NodeKey::Expression(3),
+                NodeKey::ExpressionBegin,
                 NodeKey::Exact(SymbolAtom::new("A".into())),
                 NodeKey::Exact(SymbolAtom::new("B".into())),
                 NodeKey::ExpressionEnd

--- a/lib/src/space/grounding.rs
+++ b/lib/src/space/grounding.rs
@@ -198,13 +198,14 @@ impl GroundingSpace {
     }
 
     fn remove_internal(&mut self, atom: &Atom) -> bool {
-        let indexes: Vec<usize> = self.index.get(atom_to_trie_key(atom)).map(|i| *i).collect();
+        let index_key = atom_to_trie_key(atom);
+        let indexes: Vec<usize> = self.index.get(&index_key).map(|i| *i).collect();
         let mut indexes: Vec<usize> = indexes.into_iter()
             .filter(|i| self.content[*i] == *atom).collect();
         indexes.sort_by(|a, b| b.partial_cmp(a).unwrap());
         let is_removed = indexes.len() > 0;
         for i in indexes {
-            self.index.remove(atom_to_trie_key(atom), &i);
+            self.index.remove(&index_key, &i);
             self.free.insert(i);
         }
         is_removed
@@ -298,7 +299,7 @@ impl GroundingSpace {
         let mut result = Vec::new();
         let mut query_vars = HashSet::new();
         query.iter().filter_map(AtomIter::extract_var).for_each(|var| { query_vars.insert(var.clone()); });
-        for i in self.index.get(atom_to_trie_key(query)) {
+        for i in self.index.get(&atom_to_trie_key(query)) {
             let next = self.content.get(*i).expect(format!("Index contains absent atom: key: {:?}, position: {}", query, i).as_str());
             let next = make_variables_unique(next);
             log::trace!("single_query: match next: {}", next);

--- a/lib/src/space/grounding.rs
+++ b/lib/src/space/grounding.rs
@@ -55,9 +55,9 @@ fn atom_to_trie_key(atom: &Atom) -> TrieKey<SymbolAtom> {
         match atom {
             Atom::Symbol(sym) => keys.push(NodeKey::Exact(sym.clone())),
             Atom::Expression(expr) => {
-                keys.push(NodeKey::ExpressionBegin);
+                keys.push(NodeKey::LeftPar);
                 expr.children().iter().for_each(|child| fill_key(child, keys));
-                keys.push(NodeKey::ExpressionEnd);
+                keys.push(NodeKey::RightPar);
             },
             // TODO: At the moment all grounding symbols are matched as wildcards
             // because they potentially may have custom Grounded::match_()
@@ -703,10 +703,10 @@ mod test {
         assert_eq!(atom_to_trie_key(&Atom::value(1)), TrieKey::from_list([NodeKey::Wildcard]));
         assert_eq!(atom_to_trie_key(&Atom::var("a")), TrieKey::from_list([NodeKey::Wildcard]));
         assert_eq!(atom_to_trie_key(&expr!("A" "B")), TrieKey::from_list([
-                NodeKey::ExpressionBegin,
+                NodeKey::LeftPar,
                 NodeKey::Exact(SymbolAtom::new("A".into())),
                 NodeKey::Exact(SymbolAtom::new("B".into())),
-                NodeKey::ExpressionEnd
+                NodeKey::RightPar
         ]));
     }
 }


### PR DESCRIPTION
Fixes:
- memory issue for an atoms with large number of subexpressions;
- cleanup empty tree nodes after value is removed.

Documentation to the public API and overall index logic is added.

The idea is to have almost standard prefix tree with additional information about shortcuts to the ends of expressions. These shortcuts then can be used to continue search after matching the whole expression by wildcard key. `MultiTrieNode::add` function adds the key into the prefix tree, and setups shortcuts. `MultiTrieNode::remove` is rewritten via recursion to remove the child node when it becomes empty. `MultTrieNode::get` is only operation which requires an iterator through unexplored paths  so iterator is rewritten without macro.

