### PR TITLE
Add log! built-in

### DIFF
--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -708,6 +708,33 @@ impl Grounded for PrintlnOp {
 }
 
 #[derive(Clone, PartialEq, Debug)]
+pub struct LogOp {}
+
+impl Display for LogOp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "log!")
+    }
+}
+
+impl Grounded for LogOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_UNDEFINED, ATOM_TYPE_UNDEFINED, ATOM_TYPE_UNDEFINED])
+    }
+
+    fn execute(&self, args: &mut Vec<Atom>) -> Result<Vec<Atom>, ExecError> {
+        let arg_error = || ExecError::from("log! expects two atoms as arguments");
+        let msg = args.get(0).ok_or_else(arg_error)?;
+        let val = args.get(1).ok_or_else(arg_error)?.clone();
+        log::info!("{}", msg);
+        Ok(vec![val])
+    }
+
+    fn match_(&self, other: &Atom) -> MatchResultIter {
+        match_by_equality(self, other)
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
 pub struct NopOp {}
 
 impl Display for NopOp {
@@ -959,6 +986,8 @@ pub fn register_common_tokens(metta: &Metta) {
     tref.register_token(regex(r"superpose"), move |_| { superpose_op.clone() });
     let println_op = Atom::gnd(PrintlnOp{});
     tref.register_token(regex(r"println!"), move |_| { println_op.clone() });
+    let log_op = Atom::gnd(LogOp{});
+    tref.register_token(regex(r"log!"), move |_| { log_op.clone() });
     let nop_op = Atom::gnd(NopOp{});
     tref.register_token(regex(r"nop"), move |_| { nop_op.clone() });
     let let_op = Atom::gnd(LetOp{});


### PR DESCRIPTION
Takes two arguments, message and value, logs message at info level and returns value.

Example: assuming `RUST_LOG=hyperon=info` is in the environment

```
!(log! "Hello World" 42)
```

prints

```
[2023-03-15T08:12:19Z INFO  hyperon::metta::runner::stdlib] Hello World
[42]
```