### PR TITLE
Ensure GitHub actions are executed with minimal supported Python version 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,12 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: ["3.7"]
+
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
@@ -27,6 +32,11 @@ jobs:
           cargo check
           cargo build
           RUST_LOG=hyperon=debug cargo test
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - name: Install Conan
         uses: turtlebrowser/get-conan@v1.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,6 @@ jobs:
   tests:
 
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        python-version: ["3.7"]
 
     steps:
       - name: Check out repository code
@@ -33,10 +30,10 @@ jobs:
           cargo build
           RUST_LOG=hyperon=debug cargo test
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.7
 
       - name: Install Conan
         uses: turtlebrowser/get-conan@v1.1

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ to run.  If the docker image doesn't work, please raise an
 Install latest stable Rust (1.63 or later), see [Rust installation
 page](https://www.rust-lang.org/tools/install). Make sure your
 `PATH` variable includes `$HOME/.cargo/bin` directory after installing
-Rust (see the Notes at the installation page). Python 3 (3.6 or later),
+Rust (see the Notes at the installation page). Python 3 (3.7 or later),
 GCC (7.5 or later) and CMake (3.10 or later) are required to build C and
 Python API.
 


### PR DESCRIPTION
Python version 3.6 is not supported by the actual GitHub actions runners. The oldest runner is `ubuntu-20.04` and the oldest Python version is 3.7.

Makefiles still support 3.6 or later but this support is done on the best effort basis. Guarantees are given for the Python 3.7 and later.