### PR TITLE
Add default Space::subst() implementation

### DIFF
--- a/c/src/space.rs
+++ b/c/src/space.rs
@@ -1,4 +1,5 @@
 use hyperon::space::grounding::*;
+use hyperon::space::Space;
 
 use crate::atom::*;
 use crate::util::*;

--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -1,7 +1,8 @@
 use crate::*;
 use crate::matcher::MatchResultIter;
+use crate::space::Space;
+use crate::space::grounding::GroundingSpace;
 use crate::metta::*;
-use crate::metta::space::grounding::GroundingSpace;
 use crate::metta::text::Tokenizer;
 use crate::metta::interpreter::interpret;
 use crate::metta::runner::Metta;

--- a/lib/src/space/grounding.rs
+++ b/lib/src/space/grounding.rs
@@ -315,28 +315,6 @@ impl GroundingSpace {
         result
     }
 
-    /// Executes `pattern` query on the space and for each result substitutes
-    /// variables in `template` by the values from `pattern`. Returns results
-    /// of the substitution.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use hyperon::{expr, assert_eq_no_order};
-    /// use hyperon::space::grounding::GroundingSpace;
-    ///
-    /// let space = GroundingSpace::from_vec(vec![expr!("A" "B"), expr!("A" "C")]);
-    ///
-    /// let result = space.subst(&expr!("A" x), &expr!("D" x));
-    ///
-    /// assert_eq_no_order!(result, vec![expr!("D" "B"), expr!("D" "C")]);
-    /// ```
-    pub fn subst(&self, pattern: &Atom, template: &Atom) -> Vec<Atom> {
-        self.query(pattern).drain(0..)
-            .map(| bindings | matcher::apply_bindings_to_atom(template, &bindings))
-            .collect()
-    }
-
     /// Returns the iterator over content of the space.
     pub fn iter(&self) -> SpaceIter {
         SpaceIter::new(GroundingSpaceIter::new(self))
@@ -349,9 +327,6 @@ impl Space for GroundingSpace {
     }
     fn query(&self, query: &Atom) -> Vec<Bindings> {
         GroundingSpace::query(self, query)
-    }
-    fn subst(&self, pattern: &Atom, template: &Atom) -> Vec<Atom> {
-        GroundingSpace::subst(self, pattern, template)
     }
 }
 

--- a/lib/src/space/mod.rs
+++ b/lib/src/space/mod.rs
@@ -7,7 +7,7 @@ use std::rc::Rc;
 use std::cell::RefCell;
 
 use crate::atom::Atom;
-use crate::atom::matcher::Bindings;
+use crate::atom::matcher::{Bindings, apply_bindings_to_atom};
 
 /// Contains information about space modification event.
 #[derive(Clone, Debug, PartialEq)]
@@ -112,6 +112,7 @@ pub trait Space {
     ///
     /// ```
     /// use hyperon::{expr, assert_eq_no_order};
+    /// use hyperon::space::Space;
     /// use hyperon::space::grounding::GroundingSpace;
     ///
     /// let space = GroundingSpace::from_vec(vec![expr!("A" "B"), expr!("A" "C")]);
@@ -120,7 +121,11 @@ pub trait Space {
     ///
     /// assert_eq_no_order!(result, vec![expr!("D" "B"), expr!("D" "C")]);
     /// ```
-    fn subst(&self, pattern: &Atom, template: &Atom) -> Vec<Atom>;
+    fn subst(&self, pattern: &Atom, template: &Atom) -> Vec<Atom> {
+        self.query(pattern).drain(0..)
+            .map(| bindings | apply_bindings_to_atom(template, &bindings))
+            .collect()
+    }
 }
 
 /// Mutable space trait.


### PR DESCRIPTION
Add default implementation for the Space::subst(), allowing to the implementers of the Space trait redefine it if it is needed. Remove GroundingSpace::subst() definition, reuse Space::subst().