### PR TITLE
Add trace! built-in

### DIFF
--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -725,6 +725,20 @@ impl Grounded for PrintlnOp {
 // ```
 // [42]
 // ```
+//
+// Note that the first argument does not need to be a string, which
+// makes `trace!` actually quite capable on its own.  For instance
+// ```
+// !(trace! ("Hello world!" (if True A B) 1 2 3) 42)
+// ```
+// prints to stderr
+// ```
+// (Hello world! A 1 2 3)
+// ```
+// and returns
+// ```
+// [42]
+// ```
 
 #[derive(Clone, PartialEq, Debug)]
 pub struct TraceOp {}

--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -1288,6 +1288,12 @@ mod tests {
     }
 
     #[test]
+    fn trace_op() {
+        assert_eq!(TraceOp{}.execute(&mut vec![sym!("\"Here?\""), sym!("42")]),
+                   Ok(vec![sym!("42")]));
+    }
+
+    #[test]
     fn nop_op() {
         assert_eq!(NopOp{}.execute(&mut vec![]), Ok(vec![]));
     }

--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -756,8 +756,8 @@ impl Grounded for TraceOp {
 
     fn execute(&self, args: &mut Vec<Atom>) -> Result<Vec<Atom>, ExecError> {
         let arg_error = || ExecError::from("trace! expects two atoms as arguments");
-        let msg = args.get(0).ok_or_else(arg_error)?;
-        let val = args.get(1).ok_or_else(arg_error)?.clone();
+        let val = args.pop().ok_or_else(arg_error)?;
+        let msg = args.pop().ok_or_else(arg_error)?;
         eprintln!("{}", msg);
         Ok(vec![val])
     }

--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -708,37 +708,37 @@ impl Grounded for PrintlnOp {
     }
 }
 
-// Implement trace! built-in.
-//
-// It is equivalent to Idris or Haskell Trace, that is, it prints a
-// message to stderr and pass a value along.
-//
-// For instance
-// ```
-// !(trace! "Here?" 42)
-// ```
-// prints to stderr
-// ```
-// Here?
-// ```
-// and returns
-// ```
-// [42]
-// ```
-//
-// Note that the first argument does not need to be a string, which
-// makes `trace!` actually quite capable on its own.  For instance
-// ```
-// !(trace! ("Hello world!" (if True A B) 1 2 3) 42)
-// ```
-// prints to stderr
-// ```
-// (Hello world! A 1 2 3)
-// ```
-// and returns
-// ```
-// [42]
-// ```
+/// Implement trace! built-in.
+///
+/// It is equivalent to Idris or Haskell Trace, that is, it prints a
+/// message to stderr and pass a value along.
+///
+/// For instance
+/// ```metta
+/// !(trace! "Here?" 42)
+/// ```
+/// prints to stderr
+/// ```stderr
+/// Here?
+/// ```
+/// and returns
+/// ```metta
+/// [42]
+/// ```
+///
+/// Note that the first argument does not need to be a string, which
+/// makes `trace!` actually quite capable on its own.  For instance
+/// ```metta
+/// !(trace! ("Hello world!" (if True A B) 1 2 3) 42)
+/// ```
+/// prints to stderr
+/// ```stderr
+/// (Hello world! A 1 2 3)
+/// ```
+/// and returns
+/// ```metta
+/// [42]
+/// ```
 
 #[derive(Clone, PartialEq, Debug)]
 pub struct TraceOp {}

--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -709,6 +709,33 @@ impl Grounded for PrintlnOp {
 }
 
 #[derive(Clone, PartialEq, Debug)]
+pub struct TraceOp {}
+
+impl Display for TraceOp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "trace!")
+    }
+}
+
+impl Grounded for TraceOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_UNDEFINED, Atom::var("a"), Atom::var("a")])
+    }
+
+    fn execute(&self, args: &mut Vec<Atom>) -> Result<Vec<Atom>, ExecError> {
+        let arg_error = || ExecError::from("trace! expects two atoms as arguments");
+        let msg = args.get(0).ok_or_else(arg_error)?;
+        let val = args.get(1).ok_or_else(arg_error)?.clone();
+        eprintln!("{}", msg);
+        Ok(vec![val])
+    }
+
+    fn match_(&self, other: &Atom) -> MatchResultIter {
+        match_by_equality(self, other)
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
 pub struct NopOp {}
 
 impl Display for NopOp {
@@ -960,6 +987,8 @@ pub fn register_common_tokens(metta: &Metta) {
     tref.register_token(regex(r"superpose"), move |_| { superpose_op.clone() });
     let println_op = Atom::gnd(PrintlnOp{});
     tref.register_token(regex(r"println!"), move |_| { println_op.clone() });
+    let trace_op = Atom::gnd(TraceOp{});
+    tref.register_token(regex(r"trace!"), move |_| { trace_op.clone() });
     let nop_op = Atom::gnd(NopOp{});
     tref.register_token(regex(r"nop"), move |_| { nop_op.clone() });
     let let_op = Atom::gnd(LetOp{});

--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -708,6 +708,24 @@ impl Grounded for PrintlnOp {
     }
 }
 
+// Implement trace! built-in.
+//
+// It is equivalent to Idris or Haskell Trace, that is, it prints a
+// message to stderr and pass a value along.
+//
+// For instance
+// ```
+// !(trace! "Here?" 42)
+// ```
+// prints to stderr
+// ```
+// Here?
+// ```
+// and returns
+// ```
+// [42]
+// ```
+
 #[derive(Clone, PartialEq, Debug)]
 pub struct TraceOp {}
 


### PR DESCRIPTION
`trace!` is equivalent to Idris or Haskell Debug.Trace, that is, it prints a message to stderr and pass a value along.

For instance
```
!(trace! "Here?" 42)
```
prints to stderr
```
Here?
```
and returns
```
[42]
```

Note that the first argument does not need to be a string, which makes `trace!` actually quite capable on its own.  For instance
```
!(trace! ("Hello world!" (if True A B) 1 2 3) 42)
```
prints to stderr
```
(Hello world! A 1 2 3)
```
and returns
```
[42]
```

This does not completely remove the need for adding a `format` built-in and may be added later on if necessary.