### PR TITLE
Fix (let ...) pattern/template var mapping

### DIFF
--- a/lib/src/atom/matcher.rs
+++ b/lib/src/atom/matcher.rs
@@ -955,8 +955,8 @@ mod test {
     fn match_variable_with_unique_itself() {
         let x_uniq = Atom::Variable(VariableAtom::new_id("x", 1));
         assert_match(
-            make_variables_unique(&expr!(("A" x) ("B" x))),
-                                   expr!(("A" x)    z   ),
+            make_variables_unique(expr!(("A" x) ("B" x))),
+                                  expr!(("A" x)    z   ),
             vec![bind!{x: x_uniq.clone(), z: Atom::expr([sym!("B"), x_uniq])}]);
     }
 

--- a/lib/src/atom/matcher.rs
+++ b/lib/src/atom/matcher.rs
@@ -674,7 +674,14 @@ pub type MatchResultIter = Box<dyn Iterator<Item=matcher::Bindings>>;
 /// ```
 pub fn match_atoms<'a>(left: &'a Atom, right: &'a Atom) -> MatchResultIter {
     Box::new(match_atoms_recursively(left, right)
-        .filter(|binding| !binding.has_loops()))
+        .filter(|binding| {
+            if binding.has_loops() {
+                log::trace!("match_atoms: remove bindings which contains a variable loop: {}", binding);
+                false
+            } else {
+                true
+            }
+        }))
 }
 
 fn match_atoms_recursively(left: &Atom, right: &Atom) -> MatchResultIter {

--- a/lib/src/atom/mod.rs
+++ b/lib/src/atom/mod.rs
@@ -267,26 +267,20 @@ impl Display for VariableAtom {
 }
 
 /// Returns a copy of `atom` with all variables replaced by unique instances.
-pub fn make_variables_unique(atom: &Atom) -> Atom {
-    fn recursion(atom: &Atom, vars: &mut HashMap<VariableAtom, Atom>) -> Atom {
-        match atom {
+pub fn make_variables_unique(mut atom: Atom) -> Atom {
+    let mut vars = HashMap::new();
+    atom.iter_mut().for_each(|sub| {
+        match sub {
             Atom::Variable(var) => {
                 if !vars.contains_key(var) {
                     vars.insert(var.clone(), Atom::Variable(var.make_unique()));
                 }
-                vars[var].clone()
-            },
-            Atom::Expression(expr) => {
-                let children: Vec<Atom> = expr.children().iter()
-                    .map(|atom| recursion(&atom, vars))
-                    .collect();
-                Atom::expr(children)
+                *sub = vars[var].clone();
             }
-            _ => atom.clone(),
+            _ => {},
         }
-    }
-
-    recursion(atom, &mut HashMap::new())
+    });
+    atom
 }
 
 // Grounded atom

--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -1318,6 +1318,22 @@ mod tests {
             Ok(vec![expr!("B" "A")]));
     }
 
+    #[ignore = "Not fixed yet"]
+    #[test]
+    fn let_op_external_vars_at_right_are_kept_untouched() {
+        assert_eq!(LetOp{}.execute(&mut vec![expr!(t), expr!(ext), expr!(t)]),
+            Ok(vec![expr!(ext)]));
+        assert_eq!(LetOp{}.execute(&mut vec![expr!(t), expr!(ext "A"), expr!(t)]),
+            Ok(vec![expr!(ext "A")]));
+    }
+
+    #[ignore = "Not fixed yet"]
+    #[test]
+    fn let_op_internal_variables_has_priority_in_template() {
+        assert_eq!(LetOp{}.execute(&mut vec![expr!(x), expr!(x "A"), expr!(x)]),
+            Ok(vec![expr!(x "A")]));
+    }
+
     #[test]
     fn let_var_op() {
         assert_eq!(LetVarOp{}.execute(&mut vec![expr!(), sym!("B")]),

--- a/lib/src/metta/types.rs
+++ b/lib/src/metta/types.rs
@@ -320,7 +320,7 @@ fn get_matched_types(space: &dyn Space, atom: &Atom, typ: &Atom) -> Vec<(Atom, B
     types.drain(0..).filter_map(|t| {
         let mut bindings = Bindings::new();
         // TODO: write a unit test
-        let t = make_variables_unique(&t);
+        let t = make_variables_unique(t);
         if match_reducted_types(&t, typ, &mut bindings) {
             Some((t, bindings))
         } else {

--- a/lib/src/space/grounding.rs
+++ b/lib/src/space/grounding.rs
@@ -301,7 +301,7 @@ impl GroundingSpace {
         query.iter().filter_map(AtomIter::extract_var).for_each(|var| { query_vars.insert(var.clone()); });
         for i in self.index.get(&atom_to_trie_key(query)) {
             let next = self.content.get(*i).expect(format!("Index contains absent atom: key: {:?}, position: {}", query, i).as_str());
-            let next = make_variables_unique(next);
+            let next = make_variables_unique(next.clone());
             log::trace!("single_query: match next: {}", next);
             for bindings in match_atoms(&next, query) {
                 let bindings = bindings.narrow_vars(&query_vars);


### PR DESCRIPTION
The variables in pattern part of `let` expressions are unique and visible only inside `let` expression. Variables from the matched part vice versa can be visible outside of `let` expression and thus should be moved into the template untouched.
Another part of the issue is the possible variable loop between internal variable in pattern and external variable in the matched atom. Current code doesn't match such patterns.

As a side change logging logic is improved to spot the loops inside bindings. Also `make_variables_unique()` function is rewritten using `Atom` iterator. It allows removing cloning in one usage at least.

This PR fixes the behavior and introduces Rust unit tests for the behavior.

It makes the following original example work correctly:
```
;; Knowledge
(→ P Q)
(→ Q R)

;; Rule
(= (rule (→ $p $q) (→ $q $r)) (→ $p $r))

;; Query (does not work as expected)
(= (query $kb)
   (let* (($pq (→ $p $q))
          ($qr (→ $q $r)))
     (match $kb
       ;; Premises
       (, $pq $qr)
       ;; Conclusion
       (rule $pq $qr))))

;; Call
!(query &self)
;; [(→ P R)]
```