### PR TITLE
Use repr() to display Python grounded atoms in logs

### DIFF
--- a/python/hyperon/atoms.py
+++ b/python/hyperon/atoms.py
@@ -115,7 +115,7 @@ class GroundedObject:
         self.id = id
 
     def __repr__(self):
-        return str(self.content) if self.id is None else self.id
+        return repr(self.content) if self.id is None else self.id
 
     def copy(self):
         return self

--- a/python/tests/test_atom.py
+++ b/python/tests/test_atom.py
@@ -39,6 +39,7 @@ class AtomTest(unittest.TestCase):
 
     def test_grounded_str(self):
         self.assertEqual(str(ValueAtom(1.0)), "1.0")
+        self.assertEqual(str(ValueAtom("1.0")), "'1.0'")
 
     def test_grounded_type(self):
         self.assertEqual(ValueAtom(1.0).get_type(), AtomKind.GROUNDED)


### PR DESCRIPTION
One liner fixes issue with displaying both number 42 and string "42" as 42.