### PR TITLE
Fix superpose to interpret arguments independently

### DIFF
--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -1160,6 +1160,7 @@ pub fn metta_code() -> &'static str {
     (: if (-> Bool Atom Atom $t))
     (= (if True $then $else) $then)
     (= (if False $then $else) $else)
+    (: Error (-> Atom Atom ErrorType))
     "
 }
 

--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -629,9 +629,12 @@ impl Grounded for SuperposeOp {
         let arg_error = || ExecError::from("superpose expects single expression as an argument");
         // `superpose` receives one atom (expression) in order to make composition
         // `(superpose (collapse ...))` possible
-        let expr = atom_as_expr(args.get(0).ok_or_else(arg_error)?).ok_or(arg_error())?;
+        let expr = match args.pop().ok_or_else(arg_error)? {
+            Atom::Expression(expr) => Ok(expr),
+            _ => Err(arg_error()),
+        }?;
 
-        Ok(expr.children().clone())
+        Ok(expr.into_children())
     }
 
     fn match_(&self, other: &Atom) -> MatchResultIter {

--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -1163,6 +1163,7 @@ pub fn metta_code() -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::metta::runner::*;
     use crate::metta::types::validate_atom;
 
     #[test]
@@ -1363,6 +1364,23 @@ mod tests {
         assert!(validate_atom(&space, &expr!({SumOp{}}
             ({SuperposeOp{}} ({Number::Integer(1)} {Number::Integer(2)} {Number::Integer(3)}))
             {Number::Integer(1)})));
+    }
+
+    #[test]
+    fn superpose_op_multiple_interpretations() {
+        let metta = new_metta_rust();
+        let mut parser = SExprParser::new("
+            (= (f) A)
+            (= (f) B)
+            (= (g) C)
+            (= (g) D)
+
+            !(superpose ((f) (g)))
+        ");
+
+        assert_eq_metta_results!(metta.run(&mut parser),
+            Ok(vec![vec![expr!("A"), expr!("B"), expr!("C"), expr!("D"),
+                         expr!("A"), expr!("B"), expr!("C"), expr!("D")]]));
     }
 
     #[test]

--- a/python/tests/scripts/b4_nondeterm.metta
+++ b/python/tests/scripts/b4_nondeterm.metta
@@ -27,7 +27,7 @@
 ; `superpose` reverts `collapse`
 !(assertEqual
   (color)
-  (superpose (collapse (color))))
+  (let $x (collapse (color)) (superpose $x)))
 
 ; In contrast to `match`, if the equality query returns an empty result
 ; the interpreter doesn't reduce a symbolic expression


### PR DESCRIPTION
This PR is to fix the following MeTTa script:
```
(: f (-> Number String))
!(superpose ((get-type (f 42)) (get-type (f "42"))))
```
which returns
```
[(Error ((get-type (f 42)) (get-type (f '42'))) NoValidAlternatives)]
```
This result shows interpreter cannot interpret the whole `superpose` expression because second argument `(get-type (f "42"))` returns empty result.

The PR adds unit tests to fix current behavior. `SuperposeOp` implementation is changed to interpret each sub-expression of expression independently and return combined result. In addition type for the `Error` is added into `stdlib` in order to prevent interpretation of the `Error` expression returned by `superpose`.