### PR TITLE
Low-impact changes to adopt new BindingsSet API

### DIFF
--- a/lib/benches/grounding_space.rs
+++ b/lib/benches/grounding_space.rs
@@ -5,6 +5,7 @@ extern crate test;
 use test::Bencher;
 
 use hyperon::*;
+use hyperon::matcher::BindingsSet;
 use hyperon::space::grounding::*;
 
 fn space(size: isize) -> GroundingSpace {
@@ -24,7 +25,7 @@ fn query_x10(bencher: &mut Bencher) {
     let space = space(10);
     bencher.iter(|| {
         let res = space.query(&expr!("=" ("func-9" "arg") X));
-        assert_eq!(res, vec![bind!{ X: Atom::sym("arg") }]);
+        assert_eq!(res, BindingsSet::from(bind!{ X: Atom::sym("arg") }));
     })
 }
 
@@ -33,6 +34,6 @@ fn query_x100(bencher: &mut Bencher) {
     let space = space(100);
     bencher.iter(|| {
         let res = space.query(&expr!("=" ("func-2A" "arg") X));
-        assert_eq!(res, vec![bind!{ X: Atom::sym("arg") }]);
+        assert_eq!(res, BindingsSet::from(bind!{ X: Atom::sym("arg") }));
     })
 }

--- a/lib/benches/grounding_space.rs
+++ b/lib/benches/grounding_space.rs
@@ -5,7 +5,6 @@ extern crate test;
 use test::Bencher;
 
 use hyperon::*;
-use hyperon::matcher::BindingsSet;
 use hyperon::space::grounding::*;
 
 fn space(size: isize) -> GroundingSpace {
@@ -25,7 +24,7 @@ fn query_x10(bencher: &mut Bencher) {
     let space = space(10);
     bencher.iter(|| {
         let res = space.query(&expr!("=" ("func-9" "arg") X));
-        assert_eq!(res, BindingsSet::from(bind!{ X: Atom::sym("arg") }));
+        assert_eq!(res, bind_set![{ X: Atom::sym("arg") }]);
     })
 }
 
@@ -34,6 +33,6 @@ fn query_x100(bencher: &mut Bencher) {
     let space = space(100);
     bencher.iter(|| {
         let res = space.query(&expr!("=" ("func-2A" "arg") X));
-        assert_eq!(res, BindingsSet::from(bind!{ X: Atom::sym("arg") }));
+        assert_eq!(res, bind_set![{ X: Atom::sym("arg") }]);
     })
 }

--- a/lib/src/atom/matcher.rs
+++ b/lib/src/atom/matcher.rs
@@ -981,7 +981,7 @@ pub fn apply_bindings_to_atom(atom: &Atom, bindings: &Bindings) -> Atom {
 pub fn apply_bindings_to_bindings(from: &Bindings, to: &Bindings) -> Result<Bindings, ()> {
     // TODO: apply_bindings_to_bindings can be replaced by Bindings::merge,
     // when Bindings::merge are modified to return Vec<Bindings>
-    //LP QUESTION: unclear whether behavior to filter out Bindings with loops continues to make this function relevant
+    //TODO: Delete of this function pending refactor of Interpreter
     from.clone().merge_v2(to).into_iter().filter(|bindings| !bindings.has_loops()).next().ok_or(())
 }
 

--- a/lib/src/space/grounding.rs
+++ b/lib/src/space/grounding.rs
@@ -253,7 +253,7 @@ impl GroundingSpace {
     /// # Examples
     ///
     /// ```
-    /// use hyperon::{expr, bind, sym};
+    /// use hyperon::{expr, bind_set, sym};
     /// use hyperon::matcher::BindingsSet;
     /// use hyperon::space::grounding::GroundingSpace;
     ///
@@ -262,7 +262,7 @@ impl GroundingSpace {
     ///
     /// let result = space.query(&query);
     ///
-    /// assert_eq!(result, BindingsSet::from(bind!{x: sym!("B")}));
+    /// assert_eq!(result, bind_set![{x: sym!("B")}]);
     /// ```
     pub fn query(&self, query: &Atom) -> BindingsSet {
         match split_expr(query) {
@@ -535,7 +535,7 @@ mod test {
     fn test_match_variable() {
         let mut space = GroundingSpace::new();
         space.add(expr!("foo"));
-        assert_eq!(space.query(&expr!(x)), BindingsSet::from(bind!{x: expr!("foo")}));
+        assert_eq!(space.query(&expr!(x)), bind_set![{x: expr!("foo")}]);
     }
 
     #[test]
@@ -550,7 +550,7 @@ mod test {
         let mut space = GroundingSpace::new();
         space.add(expr!("+" "A" ("*" "B" "C")));
         assert_eq!(space.query(&expr!("+" a ("*" b c))),
-        BindingsSet::from(bind!{a: expr!("A"), b: expr!("B"), c: expr!("C") }));
+        bind_set![{a: expr!("A"), b: expr!("B"), c: expr!("C") }]);
     }
 
     #[test]
@@ -566,14 +566,14 @@ mod test {
         space.add(expr!("equals" x x));
         
         let result = space.query(&expr!("equals" y z));
-        assert_eq!(result, BindingsSet::from(bind!{ y: expr!(z) }));
+        assert_eq!(result, bind_set![{ y: expr!(z) }]);
     }
 
     #[test]
     fn test_match_query_variable_via_data_variable() {
         let mut space = GroundingSpace::new();
         space.add(expr!(x x));
-        assert_eq!(space.query(&expr!(y (z))), BindingsSet::from(bind!{y: expr!((z))}));
+        assert_eq!(space.query(&expr!(y (z))), bind_set![{y: expr!((z))}]);
     }
 
     #[test]
@@ -581,7 +581,7 @@ mod test {
         let mut space = GroundingSpace::new();
         space.add(expr!("=" ("if" "True" then) then));
         assert_eq!(space.query(&expr!("=" ("if" "True" "42") X)),
-        BindingsSet::from(bind!{X: expr!("42")}));
+        bind_set![{X: expr!("42")}]);
     }
 
     #[test]
@@ -594,7 +594,7 @@ mod test {
         let result = space.query(&expr!("," ("posesses" "Sam" object)
         ("likes" "Sam" (color "stuff"))
         ("has-color" object color)));
-        assert_eq!(result, BindingsSet::from(bind!{object: expr!("baloon"), color: expr!("blue")}));
+        assert_eq!(result, bind_set![{object: expr!("baloon"), color: expr!("blue")}]);
     }
 
     #[test]
@@ -618,7 +618,7 @@ mod test {
         space.add(expr!("Cons" "Socrates" "Nil"));
 
         let result = space.query(&expr!("," (":" h "Human") ("Cons" h t)));
-        assert_eq!(result, BindingsSet::from(bind!{h: expr!("Socrates"), t: expr!("Nil")}));
+        assert_eq!(result, bind_set![{h: expr!("Socrates"), t: expr!("Nil")}]);
     }
 
     #[test]
@@ -658,7 +658,7 @@ mod test {
         space.add(expr!("A" "Sam"));
 
         let result = space.query(&expr!("," ("implies" ("B" x) z) ("implies" ("A" x) y) ("A" x)));
-        assert_eq!(result, BindingsSet::from(bind!{x: sym!("Sam"), y: expr!("B" x), z: expr!("C" x)}));
+        assert_eq!(result, bind_set![{x: sym!("Sam"), y: expr!("B" x), z: expr!("C" x)}]);
     }
 
     #[test]
@@ -669,7 +669,7 @@ mod test {
             expr!("A" {2} x "c"),
         ]);
         let result: BindingsSet = match_atoms(&Atom::gnd(space), &expr!("A" {1} x x)).collect();
-        assert_eq!(result, BindingsSet::from(bind!{x: sym!("a")}));
+        assert_eq!(result, bind_set![{x: sym!("a")}]);
     }
 
     #[test]

--- a/lib/src/space/grounding.rs
+++ b/lib/src/space/grounding.rs
@@ -4,9 +4,8 @@
 use crate::*;
 use super::*;
 use crate::atom::*;
-use crate::atom::matcher::{BindingsSet, match_atoms};
+use crate::atom::matcher::{BindingsSet, MatchResultIter, match_atoms};
 use crate::atom::subexpr::split_expr;
-use crate::matcher::MatchResultIter;
 use crate::common::multitrie::{MultiTrie, TrieKey, TrieToken};
 
 use std::fmt::{Display, Debug};
@@ -247,9 +246,9 @@ impl GroundingSpace {
     }
 
     /// Executes `query` on the space and returns variable bindings found.
-    /// Query may include sub-queries glued by [COMMA_SYMBOL] symbol. Number
-    /// of results is equal to the length of the `Vec<Bindings>` returned.
-    /// Each [Bindings] instance represents single result.
+    /// Query may include sub-queries glued by [COMMA_SYMBOL] symbol.
+    /// Each [Bindings](matcher::Bindings) instance in the returned [BindingsSet]
+    /// represents single result.
     ///
     /// # Examples
     ///

--- a/lib/src/space/grounding.rs
+++ b/lib/src/space/grounding.rs
@@ -279,8 +279,6 @@ impl GroundingSpace {
                                 let mut res = self.query(&query);
                                 res.drain(0..)
                                     .flat_map(|next| next.merge_v2(&prev))
-                                    .map(|next| matcher::apply_bindings_to_bindings(&next, &next)
-                                        .expect("Self consistent bindings are expected"))
                                     .collect()
                             }).collect()
                         };

--- a/lib/src/space/mod.rs
+++ b/lib/src/space/mod.rs
@@ -85,9 +85,9 @@ pub trait Space {
     fn register_observer(&self, observer: Rc<RefCell<dyn SpaceObserver>>);
 
     /// Executes `query` on the space and returns variable bindings found.
-    /// Query may include sub-queries glued by [grounding::COMMA_SYMBOL]
-    /// symbol. Number of results is equal to the length of the `Vec<Bindings>`
-    /// returned. Each [Bindings] instance represents single result.
+    /// Query may include sub-queries glued by [grounding::COMMA_SYMBOL] symbol. 
+    /// Each [Bindings](crate::atom::matcher::Bindings) instance in the returned [BindingsSet]
+    /// represents single result.
     ///
     /// # Examples
     ///

--- a/lib/src/space/mod.rs
+++ b/lib/src/space/mod.rs
@@ -92,7 +92,7 @@ pub trait Space {
     /// # Examples
     ///
     /// ```
-    /// use hyperon::{expr, bind, sym};
+    /// use hyperon::{expr, bind_set, sym};
     /// use hyperon::matcher::BindingsSet;
     /// use hyperon::space::grounding::GroundingSpace;
     ///
@@ -101,7 +101,7 @@ pub trait Space {
     ///
     /// let result = space.query(&query);
     ///
-    /// assert_eq!(result, BindingsSet::from(bind!{x: sym!("B")}));
+    /// assert_eq!(result, bind_set![{x: sym!("B")}]);
     /// ```
     fn query(&self, query: &Atom) -> BindingsSet;
 


### PR DESCRIPTION
Changing some tests & documentation to call newer "_v2" functions instead of compatibility shims
Changing GroundingSpace & Space trait `query` method to return BindingsSet instead of Vec<Bindings>

Still remaining to migrate are: FFI Exports & Interpreter