### PR TITLE
Make vars unique for the type returned by grounded atom

### DIFF
--- a/lib/src/atom/mod.rs
+++ b/lib/src/atom/mod.rs
@@ -351,6 +351,8 @@ pub trait GroundedAtom : mopa::Any + Debug + Display {
     fn as_any_mut(&mut self) -> &mut dyn Any;
 
     // TODO: type_() should return Vec<Atom> because of type non-determinism
+    // TODO: type_() could return Vec<&Atom> as anyway each atom should be replaced
+    // by its alpha equivalent with unique variables
     fn type_(&self) -> Atom;
     fn execute(&self, args: &mut Vec<Atom>) -> Result<Vec<Atom>, ExecError>;
     fn match_(&self, other: &Atom) -> matcher::MatchResultIter;


### PR DESCRIPTION
If type from grounded atom is used as is its variables may clash with variables of another type.