### PR TITLE
Properly apply and return var equalities from let, let* and case

### DIFF
--- a/c/tests/check_atom.c
+++ b/c/tests/check_atom.c
@@ -69,8 +69,8 @@ START_TEST (test_bindings_set)
 
     char str_buf[BUF_SIZE];
     bindings_set_iterate(set_1, &bindings_to_buf, &str_buf);
-    ck_assert(strlen(str_buf) == 45); //It's a pain to test every combinitory string, but they are all the same length
     //printf("%s\n\n", str_buf);
+    ck_assert(strlen(str_buf) == 49); //It's a pain to test every combinitory string, but they are all the same length
 
     //Don't need to free bindings_a, because ownership was consumed into set_1 by bindings_merge_v2
     bindings_free(bindings_b);

--- a/lib/src/atom/matcher.rs
+++ b/lib/src/atom/matcher.rs
@@ -612,7 +612,7 @@ impl Display for Bindings {
                 write!(f, "{}{}", prefix, var)?;
             }
             match self.value_by_id.get(id) {
-                Some(value) => write!(f, " = {}", value)?,
+                Some(value) => write!(f, " <- {}", value)?,
                 None => {},
             }
         }

--- a/lib/src/atom/matcher.rs
+++ b/lib/src/atom/matcher.rs
@@ -1386,6 +1386,19 @@ mod test {
     }
 
     #[test]
+    fn bindings_narrow_vars_keeps_vars_equality() -> Result<(), &'static str> {
+        let bindings = Bindings::new()
+            .add_var_equality(&VariableAtom::new("x"), &VariableAtom::new("y"))?
+            .add_var_equality(&VariableAtom::new("x"), &VariableAtom::new("z"))?;
+
+        let narrow = bindings.narrow_vars(&HashSet::from([VariableAtom::new("y"),
+            VariableAtom::new("z")]));
+
+        assert_eq!(narrow, bind!{ y: expr!(z) });
+        Ok(())
+    }
+
+    #[test]
     fn bindings_add_var_value_splits_bindings() {
         let pair = ReturnPairInX{};
 

--- a/lib/src/atom/matcher.rs
+++ b/lib/src/atom/matcher.rs
@@ -428,7 +428,9 @@ impl Bindings {
             });
 
         let results = results.into_iter().map(|(result, _)| result).collect();
-        log::trace!("Bindings::merge: {} ^ {} -> {:?}", trace_self.unwrap(), b, results);
+        if let Some(self_copy) = trace_self {
+            log::trace!("Bindings::merge: {} ^ {} -> {:?}", self_copy, b, results);
+        }
         results
     }
 

--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -394,7 +394,7 @@ impl CaseOp {
         let arg_error = || ExecError::from("case expects two arguments: atom and expression of cases");
         let cases = args.pop().ok_or_else(arg_error)?;
         let atom = args.pop().ok_or_else(arg_error)?;
-        let cases = CaseOp::cases_into_tuples(cases)?;
+        let cases = CaseOp::parse_cases(&atom, cases)?;
         log::debug!("CaseOp::execute: atom: {}, cases: {:?}", atom, cases);
 
         let result = interpret_no_error(self.space.clone(), &atom);
@@ -403,7 +403,7 @@ impl CaseOp {
         match result {
             Ok(result) if result.is_empty() => {
                 cases.into_iter()
-                    .find_map(|(pattern, template)| {
+                    .find_map(|(pattern, template, _external_vars)| {
                         if pattern == VOID_SYMBOL {
                             Some(template)
                         } else {
@@ -422,13 +422,16 @@ impl CaseOp {
         }
     }
 
-    fn cases_into_tuples(cases: Atom) -> Result<Vec<(Atom, Atom)>, ExecError> {
+    fn parse_cases(atom: &Atom, cases: Atom) -> Result<Vec<(Atom, Atom, HashSet<VariableAtom>)>, ExecError> {
         let cases = match cases {
             Atom::Expression(expr) => Ok(expr),
             _ => Err("case expects expression of cases as a second argument"),
         }?;
 
-        let mut pairs = Vec::new();
+        let mut atom_vars = HashSet::new();
+        collect_vars(&atom, &mut atom_vars);
+
+        let mut result = Vec::new();
         for next_case in cases.into_children() {
             let mut next_case = match next_case {
                 Atom::Expression(next_case) if next_case.children().len() == 2 => Ok(next_case.into_children()),
@@ -437,19 +440,20 @@ impl CaseOp {
             let mut template = next_case.pop().unwrap();
             let mut pattern = next_case.pop().unwrap();
 
-            let mut local_vars = HashMap::new();
-            introduce_local_vars(&mut pattern, &mut local_vars);
-            replace_vars(&mut template, &local_vars);
+            let mut external_vars = atom_vars.clone();
+            collect_vars(&template, &mut external_vars);
+            make_conflicting_vars_unique(&mut pattern, &mut template, &external_vars);
 
-            pairs.push((pattern, template));
+            result.push((pattern, template, external_vars));
         }
 
-        Ok(pairs)
+        Ok(result)
     }
 
-    fn return_first_matched(atom: &Atom, cases: &Vec<(Atom, Atom)>) -> Vec<Atom> {
-        for (pattern, template) in cases {
-            let bindings = matcher::match_atoms(atom, &pattern);
+    fn return_first_matched(atom: &Atom, cases: &Vec<(Atom, Atom, HashSet<VariableAtom>)>) -> Vec<Atom> {
+        for (pattern, template, external_vars) in cases {
+            let bindings = matcher::match_atoms(atom, &pattern)
+                .map(|b| b.convert_var_equalities_to_bindings(&external_vars));
             let result: Vec<Atom> = bindings.map(|b| matcher::apply_bindings_to_atom(&template, &b)).collect();
             if !result.is_empty() {
                 return result
@@ -842,6 +846,9 @@ impl Display for LetOp {
     }
 }
 
+use std::convert::TryFrom;
+use std::collections::HashSet;
+
 impl Grounded for LetOp {
     fn type_(&self) -> Atom {
         // TODO: Undefined for the argument is necessary to make argument reductable.
@@ -854,12 +861,11 @@ impl Grounded for LetOp {
         let atom = args.pop().ok_or_else(arg_error)?;
         let mut pattern = args.pop().ok_or_else(arg_error)?;
 
-        let mut local_vars = HashMap::new();
-        introduce_local_vars(&mut pattern, &mut local_vars);
-        replace_vars(&mut template, &local_vars);
+        let external_vars = resolve_var_conflicts(&atom, &mut pattern, &mut template);
 
-        let bindings = matcher::match_atoms(&pattern, &atom);
-        let result = bindings.map(|b| matcher::apply_bindings_to_atom(&template, &b)).collect();
+        let bindings = matcher::match_atoms(&pattern, &atom)
+            .map(|b| b.convert_var_equalities_to_bindings(&external_vars));
+        let result = bindings.map(|b| { matcher::apply_bindings_to_atom(&template, &b) }).collect();
         log::debug!("LetOp::execute: pattern: {}, atom: {}, template: {}, result: {:?}", pattern, atom, template, result);
         Ok(result)
     }
@@ -869,26 +875,46 @@ impl Grounded for LetOp {
     }
 }
 
-fn introduce_local_vars(atom: &mut Atom, vars: &mut HashMap<VariableAtom, VariableAtom>) {
-    atom.iter_mut().for_each(|sub| {
-        match sub {
-            Atom::Variable(var) => {
-                *var = vars.entry(var.clone()).or_insert(var.make_unique()).clone();
-            },
-            _ => {},
-        }
-    });
+fn resolve_var_conflicts(atom: &Atom, pattern: &mut Atom, template: &mut Atom) -> HashSet<VariableAtom> {
+    let mut external_vars = HashSet::new();
+    collect_vars(&atom, &mut external_vars);
+    collect_vars(&template, &mut external_vars);
+    make_conflicting_vars_unique(pattern, template, &external_vars);
+    external_vars
 }
 
-fn replace_vars(atom: &mut Atom, vars: &HashMap<VariableAtom, VariableAtom>) {
-    atom.iter_mut().for_each(|sub| {
-        match sub {
-            Atom::Variable(var) => {
-                vars.get(var).map(|v| *var = v.clone());
-            },
-            _ => {},
+fn atom_into_var_iter(atom: &Atom) -> impl Iterator<Item=&VariableAtom> {
+    atom.iter()
+        .map(<&VariableAtom>::try_from)
+        .filter(Result::is_ok)
+        .map(Result::unwrap)
+}
+
+fn atom_into_var_iter_mut(atom: &mut Atom) -> impl Iterator<Item=&mut VariableAtom> {
+    atom.iter_mut()
+        .map(<&mut VariableAtom>::try_from)
+        .filter(Result::is_ok)
+        .map(Result::unwrap)
+}
+
+fn collect_vars(atom: &Atom, vars: &mut HashSet<VariableAtom>) {
+    for var in atom_into_var_iter(atom) {
+        vars.insert(var.clone());
+    }
+}
+
+fn make_conflicting_vars_unique(pattern: &mut Atom, template: &mut Atom, external_vars: &HashSet<VariableAtom>) {
+    let mut local_vars = HashMap::new();
+
+    for var in atom_into_var_iter_mut(pattern) {
+        if external_vars.contains(var) {
+            *var = local_vars.entry(var.clone()).or_insert(var.make_unique()).clone();
         }
-    });
+    }
+
+    for var in atom_into_var_iter_mut(template) {
+        local_vars.get(var).map(|v| *var = v.clone());
+    }
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -1500,7 +1526,6 @@ mod tests {
             Ok(vec![expr!(x "A")]));
     }
 
-    #[ignore]
     #[test]
     fn let_op_keep_variables_equalities_issue290() {
         assert_eq_metta_results!(run_program("!(let* (($f f) ($f $x)) $x)"), Ok(vec![vec![expr!("f")]]));


### PR DESCRIPTION
Fixes #290. 

Get list of variables from atom and template and use them to replace variable equalities in `Bindings` by variable assignments. See https://github.com/trueagi-io/hyperon-experimental/issues/290#issuecomment-1546948623 for a description of logic behind the fix.

Also make displaying of `Bindings` more clear replacing `=` by `<-` to distinguish assignment and equalities. 
And fix the `panic!` in `matcher` when tracing is enabled for other modules only.