### PR TITLE
Correctly handle variables in results of the interpreter cache

### DIFF
--- a/lib/src/metta/interpreter.rs
+++ b/lib/src/metta/interpreter.rs
@@ -93,7 +93,7 @@ impl InterpretedAtom {
     fn bindings(&self) -> &Bindings {
         &self.1
     }
-    
+
     /// Convert the instance into tuple of [Atom] and [Bindings]
     pub fn into_tuple(self) -> (Atom, Bindings) {
         (self.0, self.1)
@@ -259,7 +259,7 @@ impl<'a, T: SpaceRef<'a>> Clone for InterpreterContextRef<'a, T> {
 }
 
 fn is_grounded_op(expr: &ExpressionAtom) -> bool {
-    match expr.children().get(0) { 
+    match expr.children().get(0) {
         Some(Atom::Grounded(op)) if is_func(&op.type_())
             || op.type_() == ATOM_TYPE_UNDEFINED => true,
         _ => false,
@@ -564,7 +564,7 @@ fn match_op<'a, T: SpaceRef<'a>>(context: InterpreterContextRef<'a, T>, input: I
     let results: Vec<InterpretedAtom> = query_bindings
         .drain(0..)
         .map(|mut query_binding| {
-            let result = query_binding.resolve_and_remove(&var_x).unwrap(); 
+            let result = query_binding.resolve_and_remove(&var_x).unwrap();
             let result = apply_bindings_to_atom(&result, &query_binding);
             // TODO: sometimes we apply bindings twice: first time here,
             // second time when inserting matched argument into nesting
@@ -608,7 +608,7 @@ use std::collections::VecDeque;
 
 /// Plan which interprets in parallel alternatives of the expression.
 /// Each successful result is appended to the overall result of the plan.
-/// If no alternatives returned successful result the plan returns error. 
+/// If no alternatives returned successful result the plan returns error.
 pub struct AlternativeInterpretationsPlan<'a, T> {
     atom: Atom,
     plans: VecDeque<Box<dyn Plan<'a, (), Vec<T>, InterpreterError> + 'a>>,
@@ -617,7 +617,7 @@ pub struct AlternativeInterpretationsPlan<'a, T> {
 }
 
 impl<'a, T> AlternativeInterpretationsPlan<'a, T> {
-    /// Create new instance of [AlternativeInterpretationsPlan]. 
+    /// Create new instance of [AlternativeInterpretationsPlan].
     ///
     /// # Arguments
     /// `atom` - atom to be printed as root of the alternative interpretations
@@ -860,7 +860,7 @@ mod tests {
         let space = GroundingSpace::new();
         let expr = Atom::expr([Atom::gnd(ThrowError()), Atom::value("Runtime test error")]);
 
-        assert_eq!(interpret(&space, &expr), 
+        assert_eq!(interpret(&space, &expr),
             Ok(vec![Atom::expr([ERROR_SYMBOL, expr, Atom::sym("Runtime test error")])]));
     }
 


### PR DESCRIPTION
This PR fixes the following example:
```
(= (get-ptrn) (-> (-> $a $b) (-> $a $c)))
!(let* (((-> $y $z) (get-ptrn))
        ((-> $u $v) (get-ptrn))
        ($z (-> $in Bool))
        ($u (-> Number String))
        ($y (-> Bool Number)))
   $in)
```
which returns `[]` while it is expected to return `[Bool]`.

The root cause is that results of the `(get-ptrn)` call are cached. Thus in both calls inside `let*` the cache returns exactly same atom `(-> (-> $a $b) (-> $a $c))` and matching fails.

The fix applies the following rules for cached results. When atom is transformed from <input> to <result>:
- values of the variables which are present in input are kept with result;
- values of the variables which are present in <result> but not present in <input> are applied to the <result>;
- all other variables are cleaned up.

When <result> atom is extracted using <input> all variables in result becomes unique.

Thus each call of `(get-ptrn)` above return the unique atom with variables replaced.