### PR TITLE
Add filter_type() function into AtomIter to filter sub-atoms by types

### DIFF
--- a/c/src/atom.rs
+++ b/c/src/atom.rs
@@ -201,7 +201,7 @@ pub extern "C" fn bindings_narrow_vars(bindings: *mut bindings_t, vars: *const v
     let bindings = unsafe{&mut (*bindings).bindings};
     let vars = unsafe{&(*vars).0};
     let vars_iter = vars.into_iter().map(|atom| {
-        TryInto::<VariableAtom>::try_into(atom.clone())
+        TryInto::<&VariableAtom>::try_into(atom)
             .expect("Only variable atoms allowed for bindings_narrow_vars")
     });
     let vars_set = HashSet::from_iter(vars_iter);

--- a/lib/src/atom/iter.rs
+++ b/lib/src/atom/iter.rs
@@ -31,6 +31,10 @@ impl<'a> AtomIter<'a> {
             },
         }
     }
+
+    pub fn filter_type<T: TryFrom<&'a Atom>>(self) -> impl Iterator<Item=T> + 'a {
+        self.filter_map(|a| <T>::try_from(a).ok())
+    }
 }
 
 impl<'a> Iterator for AtomIter<'a> {
@@ -76,6 +80,9 @@ impl<'a> AtomIterMut<'a> {
         }
     }
 
+    pub fn filter_type<T: TryFrom<&'a mut Atom>>(self) -> impl Iterator<Item=T> + 'a {
+        self.filter_map(|a| <T>::try_from(a).ok())
+    }
 }
 
 impl<'a> Iterator for AtomIterMut<'a> {

--- a/lib/src/atom/matcher.rs
+++ b/lib/src/atom/matcher.rs
@@ -81,7 +81,6 @@ macro_rules! bind_set {
 
 use std::collections::{HashMap, HashSet};
 use core::iter::FromIterator;
-use std::convert::TryFrom;
 use std::cmp::max;
 
 use super::*;
@@ -480,7 +479,7 @@ impl Bindings {
         }
     }
 
-    fn build_var_mapping<'a>(&'a self, required_names: &HashSet<VariableAtom>, required_ids: &HashSet<u32>) -> HashMap<&'a VariableAtom, &'a VariableAtom> {
+    fn build_var_mapping<'a>(&'a self, required_names: &HashSet<&VariableAtom>, required_ids: &HashSet<u32>) -> HashMap<&'a VariableAtom, &'a VariableAtom> {
         let mut id_names: HashSet<VariableAtom> = HashSet::new();
         let mut mapping = HashMap::new();
         for (var, &id) in &self.id_by_var {
@@ -523,12 +522,12 @@ impl Bindings {
     ///
     /// let bindings = bind!{ leftA: expr!("A"), leftA: expr!(rightB),
     ///     leftC: expr!("C"), leftD: expr!(rightE), rightF: expr!("F") };
-    /// let right = bindings.narrow_vars(&HashSet::from([VariableAtom::new("rightB"),
-    ///     VariableAtom::new("rightE"), VariableAtom::new("rightF")]));
+    /// let right = bindings.narrow_vars(&HashSet::from([&VariableAtom::new("rightB"),
+    ///     &VariableAtom::new("rightE"), &VariableAtom::new("rightF")]));
     ///
     /// assert_eq!(right, bind!{ rightB: expr!("A"), rightF: expr!("F"), rightE: expr!(rightE) });
     /// ```
-    pub fn narrow_vars(&self, vars: &HashSet<VariableAtom>) -> Bindings {
+    pub fn narrow_vars(&self, vars: &HashSet<&VariableAtom>) -> Bindings {
         let mut deps: HashSet<VariableAtom> = HashSet::new();
         for var in vars {
             self.find_deps(var, &mut deps);
@@ -1433,8 +1432,8 @@ mod test {
             .add_var_equality(&VariableAtom::new("leftD"), &VariableAtom::new("rightE"))?
             .add_var_binding_v2(VariableAtom::new("rightF"), expr!("F"))?;
 
-        let narrow = bindings.narrow_vars(&HashSet::from([VariableAtom::new("rightB"),
-            VariableAtom::new("rightE"), VariableAtom::new("rightF")]));
+        let narrow = bindings.narrow_vars(&HashSet::from([&VariableAtom::new("rightB"),
+            &VariableAtom::new("rightE"), &VariableAtom::new("rightF")]));
 
         assert_eq!(narrow, bind!{ rightB: expr!("A"), rightF: expr!("F"), rightE: expr!(rightE) });
         Ok(())
@@ -1446,8 +1445,8 @@ mod test {
             .add_var_equality(&VariableAtom::new("x"), &VariableAtom::new("y"))?
             .add_var_equality(&VariableAtom::new("x"), &VariableAtom::new("z"))?;
 
-        let narrow = bindings.narrow_vars(&HashSet::from([VariableAtom::new("y"),
-            VariableAtom::new("z")]));
+        let narrow = bindings.narrow_vars(&HashSet::from([&VariableAtom::new("y"),
+            &VariableAtom::new("z")]));
 
         assert_eq!(narrow, bind!{ y: expr!(z) });
         Ok(())

--- a/lib/src/atom/mod.rs
+++ b/lib/src/atom/mod.rs
@@ -269,16 +269,15 @@ impl Display for VariableAtom {
 
 /// Returns a copy of `atom` with all variables replaced by unique instances.
 pub fn make_variables_unique(mut atom: Atom) -> Atom {
-    let mut vars = HashMap::new();
-    atom.iter_mut().for_each(|sub| {
-        match sub {
-            Atom::Variable(var) => {
-                if !vars.contains_key(var) {
-                    vars.insert(var.clone(), Atom::Variable(var.make_unique()));
-                }
-                *sub = vars[var].clone();
+    let mut vars: HashMap<VariableAtom, VariableAtom> = HashMap::new();
+    atom.iter_mut().filter_type::<&mut VariableAtom>().for_each(|var| {
+        match vars.get(var) {
+            Some(new_var) => *var = new_var.clone(),
+            None => {
+                let mut key = var.make_unique();
+                std::mem::swap(&mut key, var);
+                vars.insert(key, var.clone());
             }
-            _ => {},
         }
     });
     atom

--- a/lib/src/space/grounding.rs
+++ b/lib/src/space/grounding.rs
@@ -12,8 +12,6 @@ use std::fmt::{Display, Debug};
 use std::rc::{Rc, Weak};
 use std::cell::RefCell;
 use std::collections::BTreeSet;
-use std::collections::HashSet;
-use std::convert::TryFrom;
 
 // Grounding space
 
@@ -295,9 +293,7 @@ impl GroundingSpace {
     fn single_query(&self, query: &Atom) -> BindingsSet {
         log::debug!("single_query: query: {}", query);
         let mut result = BindingsSet::empty();
-        let mut query_vars = HashSet::new();
-        query.iter().filter_map(|atom| <&VariableAtom>::try_from(atom).ok())
-            .for_each(|var| { query_vars.insert(var.clone()); });
+        let query_vars = query.iter().filter_type::<&VariableAtom>().collect();
         for i in self.index.get(&atom_to_trie_key(query)) {
             let next = self.content.get(*i).expect(format!("Index contains absent atom: key: {:?}, position: {}", query, i).as_str());
             let next = make_variables_unique(next.clone());


### PR DESCRIPTION
This removes a code duplication and adds a standard way of filtering vars as it is a frequent operation.
Addresses https://github.com/trueagi-io/hyperon-experimental/pull/298#discussion_r1197338902