### PR TITLE
Add ReplacingMapper utility to reuse variable mapping code

### DIFF
--- a/lib/src/atom/mod.rs
+++ b/lib/src/atom/mod.rs
@@ -268,7 +268,7 @@ impl Display for VariableAtom {
     }
 }
 
-/// Returns a copy of `atom` with all variables replaced by unique instances.
+/// Returns `atom` with all variables replaced by unique instances.
 pub fn make_variables_unique(mut atom: Atom) -> Atom {
     let mut mapper = ReplacingMapper::new(VariableAtom::make_unique);
     atom.iter_mut().filter_type::<&mut VariableAtom>().for_each(|var| mapper.replace(var));

--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -9,6 +9,7 @@ use crate::metta::runner::Metta;
 use crate::metta::types::get_atom_types;
 use crate::common::shared::Shared;
 use crate::common::assert::vec_eq_no_order;
+use crate::common::ReplacingMapper;
 
 use std::rc::Rc;
 use std::cell::RefCell;
@@ -887,17 +888,17 @@ fn collect_vars(atom: &Atom, vars: &mut HashSet<VariableAtom>) {
 }
 
 fn make_conflicting_vars_unique(pattern: &mut Atom, template: &mut Atom, external_vars: &HashSet<VariableAtom>) {
-    let mut local_vars = HashMap::new();
+    let mut local_var_mapper = ReplacingMapper::new(VariableAtom::make_unique);
 
-    for var in pattern.iter_mut().filter_type::<&mut VariableAtom>() {
-        if external_vars.contains(var) {
-            *var = local_vars.entry(var.clone()).or_insert(var.make_unique()).clone();
-        }
-    }
+    pattern.iter_mut().filter_type::<&mut VariableAtom>()
+        .filter(|var| external_vars.contains(var))
+        .for_each(|var| local_var_mapper.replace(var));
 
-    for var in template.iter_mut().filter_type::<&mut VariableAtom>() {
-        local_vars.get(var).map(|v| *var = v.clone());
-    }
+    template.iter_mut().filter_type::<&mut VariableAtom>()
+        .for_each(|var| match local_var_mapper.get_mapping().get(var) {
+            Some(v) => *var = v.clone(),
+            None => {},
+        });
 }
 
 #[derive(Clone, PartialEq, Debug)]


### PR DESCRIPTION
Kind of experimental refactoring to reuse the variable mapping code which was written in three different places.

After writing this I think that may be the better way is to allow collecting `AtomIter` back into the atom, then one can use traditional `Iterator::map` instead of `Iterator::for_each(...)`. But it requires keeping the structure of the expression inside the iterated items, so I think we can do it in the future if we want.