### PR TITLE
Canonicalize path before loading module to make sure it is unique

### DIFF
--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -66,6 +66,7 @@ impl Grounded for ImportOp {
         // TODO: replace Symbol by grounded String?
         if let Atom::Symbol(file) = file {
             path.push(file.name());
+            path = path.canonicalize().unwrap();
             log::debug!("import! load file, full path: {}", path.display());
         } else {
             return Err("import! expects a file path as a second argument".into())


### PR DESCRIPTION
Two syntactically different paths pointing to the same destination will not be wrongly qualified as different after being canonicalized.