### PR TITLE
Init logger in a Python API library

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -9,7 +9,7 @@ mopa = "0.2.2"
 regex = "1.5.4"
 log = "0.4.0"
 env_logger = "0.8.4"
-ctor = "0.1.22"
+ctor = "0.2.0"
 smallvec = "1.10.0"
 
 [lib]

--- a/python/hyperonpy.cpp
+++ b/python/hyperonpy.cpp
@@ -236,9 +236,6 @@ struct CAtomType {};
 PYBIND11_MODULE(hyperonpy, m) {
     m.doc() = "Python API of the Hyperon library";
 
-    // TODO: integrate Rust logs with Python logger
-    m.def("init_logger", &init_logger, "Initialize Hyperon library logger");
-
     py::enum_<atom_type_t>(m, "AtomKind")
         .value("SYMBOL", atom_type_t::SYMBOL)
         .value("VARIABLE", atom_type_t::VARIABLE)
@@ -496,5 +493,11 @@ PYBIND11_MODULE(hyperonpy, m) {
         metta_load_module(metta.ptr, text.c_str());
     }, "Load MeTTa module");
 
+}
+
+__attribute__((constructor))
+static void init_library() {
+    // TODO: integrate Rust logs with Python logger
+    init_logger();
 }
 


### PR DESCRIPTION
PR fixes issue with logs absence in debug releases. The root cause is that `ctor` is not called when C API static library is built in debug configuration. I am calling `init_logger` manually from C library to fix it.

 I opened https://github.com/mmastrac/rust-ctor/issues/280 to ask `ctor` author for help in investigation.