### PR TITLE
Changing c_str api to follow the snprintf() pattern

### DIFF
--- a/c/src/atom.rs
+++ b/c/src/atom.rs
@@ -97,11 +97,14 @@ pub extern "C" fn bindings_clone(bindings: *const bindings_t) -> *mut bindings_t
     bindings_into_ptr(unsafe{ &(*bindings) }.bindings.clone())
 }
 
+/// Writes a text description of the bindings_t into the provided buffer and returns the number of bytes
+/// written, excluding the string terminator.
+///
+/// Returns 0 if the buffer is too small
 #[no_mangle]
-pub extern "C" fn bindings_to_str(bindings: *const bindings_t, callback: c_str_callback_t, context: *mut c_void) {
+pub extern "C" fn bindings_to_str(bindings: *const bindings_t, buf: *mut c_char, buf_len: usize) -> usize {
     let bindings = unsafe{ &(*bindings).bindings };
-    let s = str_as_cstr(bindings.to_string().as_str());
-    callback(s.as_ptr(), context);
+    write_into_buf(bindings, buf, buf_len)
 }
 
 #[no_mangle]
@@ -262,11 +265,14 @@ pub extern "C" fn bindings_set_eq(set: *const bindings_set_t, other: *const bind
     set == other
 }
 
+/// Writes a text description of the bindings_set_t into the provided buffer and returns the number of bytes
+/// written, excluding the string terminator.
+///
+/// Returns 0 if the buffer is too small
 #[no_mangle]
-pub extern "C" fn bindings_set_to_str(set: *const bindings_set_t, callback: c_str_callback_t, context: *mut c_void) {
+pub extern "C" fn bindings_set_to_str(set: *const bindings_set_t, buf: *mut c_char, buf_len: usize) -> usize {
     let set = unsafe{ &(*set).set };
-    let s = str_as_cstr(set.to_string().as_str());
-    callback(s.as_ptr(), context);
+    write_into_buf(set, buf, buf_len)
 }
 
 #[no_mangle]
@@ -364,19 +370,26 @@ pub unsafe extern "C" fn atom_get_type(atom: *const atom_t) -> atom_type_t {
     }
 }
 
+/// Writes a text description of the atom into the provided buffer and returns the number of bytes
+/// written, excluding the string terminator.
+///
+/// Returns 0 if the buffer is too small
 #[no_mangle]
-pub extern "C" fn atom_to_str(atom: *const atom_t, callback: c_str_callback_t, context: *mut c_void) {
+pub extern "C" fn atom_to_str(atom: *const atom_t, buf: *mut c_char, buf_len: usize) -> usize {
     let atom = unsafe{ &(*atom).atom };
-    callback(str_as_cstr(atom.to_string().as_str()).as_ptr(), context);
+    write_into_buf(atom, buf, buf_len)
 }
 
-
+/// Writes the name of the atom into the provided buffer and returns the number of bytes
+/// written, excluding the string terminator.
+///
+/// Returns 0 if the buffer is too small
 #[no_mangle]
-pub extern "C" fn atom_get_name(atom: *const atom_t, callback: c_str_callback_t, context: *mut c_void) {
+pub extern "C" fn atom_get_name(atom: *const atom_t, buf: *mut c_char, buf_len: usize) -> usize {
     let atom = unsafe{ &(*atom).atom };
     match atom {
-        Atom::Symbol(s) => callback(str_as_cstr(s.name()).as_ptr(), context),
-        Atom::Variable(v) => callback(string_as_cstr(v.name()).as_ptr(), context),
+        Atom::Symbol(s) => write_into_buf(s.name(), buf, buf_len),
+        Atom::Variable(v) => write_into_buf(v.name(), buf, buf_len),
         _ => panic!("Only Symbol and Variable has name attribute!"),
     }
 }

--- a/c/src/atom.rs
+++ b/c/src/atom.rs
@@ -98,9 +98,8 @@ pub extern "C" fn bindings_clone(bindings: *const bindings_t) -> *mut bindings_t
 }
 
 /// Writes a text description of the bindings_t into the provided buffer and returns the number of bytes
-/// written, excluding the string terminator.
-///
-/// Returns 0 if the buffer is too small
+/// written, or that would have been written had the buf_len been large enough, excluding the
+/// string terminator.
 #[no_mangle]
 pub extern "C" fn bindings_to_str(bindings: *const bindings_t, buf: *mut c_char, buf_len: usize) -> usize {
     let bindings = unsafe{ &(*bindings).bindings };
@@ -266,9 +265,8 @@ pub extern "C" fn bindings_set_eq(set: *const bindings_set_t, other: *const bind
 }
 
 /// Writes a text description of the bindings_set_t into the provided buffer and returns the number of bytes
-/// written, excluding the string terminator.
-///
-/// Returns 0 if the buffer is too small
+/// written, or that would have been written had the buf_len been large enough, excluding the
+/// string terminator.
 #[no_mangle]
 pub extern "C" fn bindings_set_to_str(set: *const bindings_set_t, buf: *mut c_char, buf_len: usize) -> usize {
     let set = unsafe{ &(*set).set };
@@ -371,9 +369,8 @@ pub unsafe extern "C" fn atom_get_type(atom: *const atom_t) -> atom_type_t {
 }
 
 /// Writes a text description of the atom into the provided buffer and returns the number of bytes
-/// written, excluding the string terminator.
-///
-/// Returns 0 if the buffer is too small
+/// written, or that would have been written had the buf_len been large enough, excluding the
+/// string terminator.
 #[no_mangle]
 pub extern "C" fn atom_to_str(atom: *const atom_t, buf: *mut c_char, buf_len: usize) -> usize {
     let atom = unsafe{ &(*atom).atom };
@@ -381,9 +378,8 @@ pub extern "C" fn atom_to_str(atom: *const atom_t, buf: *mut c_char, buf_len: us
 }
 
 /// Writes the name of the atom into the provided buffer and returns the number of bytes
-/// written, excluding the string terminator.
-///
-/// Returns 0 if the buffer is too small
+/// written, or that would have been written had the buf_len been large enough, excluding the
+/// string terminator.
 #[no_mangle]
 pub extern "C" fn atom_get_name(atom: *const atom_t, buf: *mut c_char, buf_len: usize) -> usize {
     let atom = unsafe{ &(*atom).atom };

--- a/c/src/metta.rs
+++ b/c/src/metta.rs
@@ -150,9 +150,8 @@ pub extern "C" fn step_get_result(step: *mut step_result_t,
 }
 
 /// Writes a text description of the step_result_t into the provided buffer and returns the number of bytes
-/// written, excluding the string terminator.
-///
-/// Returns 0 if the buffer is too small
+/// written, or that would have been written had the buf_len been large enough, excluding the
+/// string terminator.
 #[no_mangle]
 pub extern "C" fn step_to_str(step: *const step_result_t, buf: *mut c_char, buf_len: usize) -> usize {
     let result = unsafe{ &(*step).result };

--- a/c/src/metta.rs
+++ b/c/src/metta.rs
@@ -149,10 +149,14 @@ pub extern "C" fn step_get_result(step: *mut step_result_t,
     }
 }
 
+/// Writes a text description of the step_result_t into the provided buffer and returns the number of bytes
+/// written, excluding the string terminator.
+///
+/// Returns 0 if the buffer is too small
 #[no_mangle]
-pub extern "C" fn step_to_str(step: *const step_result_t, callback: c_str_callback_t, context: *mut c_void) {
+pub extern "C" fn step_to_str(step: *const step_result_t, buf: *mut c_char, buf_len: usize) -> usize {
     let result = unsafe{ &(*step).result };
-    callback(str_as_cstr(format!("{:?}", result).as_str()).as_ptr(), context);
+    write_debug_into_buf(result, buf, buf_len)
 }
 
 pub type metta_t = SharedApi<Metta>;

--- a/c/src/util.rs
+++ b/c/src/util.rs
@@ -38,25 +38,44 @@ pub fn string_as_cstr(s: String) -> CString {
 }
 
 pub(crate) fn write_into_buf<T: std::fmt::Display>(obj: T, buf: *mut c_char, buf_len: usize) -> usize {
-    let slice = unsafe{ slice::from_raw_parts_mut(buf as *mut u8, buf_len) };
-    let mut cursor = Cursor::new(slice);
-    let len = if let Err(_err) = write!(cursor, "{obj}") {
-        0 //The buffer was probably too short
-    } else {
-        let len = cursor.position() as usize;
 
-        //If we wrote right up to the end of the buffer, then fail, because we need room for the terminator
-        if len < buf_len-1 {
-            len
-        } else {
-            0
+    //If buf_len == 0, the caller is just interested in the size of buffer they will need
+    if buf_len == 0 {
+        struct LengthTracker(usize);
+        impl Write for LengthTracker {
+            fn write(&mut self, slice: &[u8]) -> Result<usize, std::io::Error> {
+                self.0 += slice.len();
+                Ok(slice.len())
+            }
+            fn flush(&mut self) -> Result<(), std::io::Error> { Ok (())}
         }
-    };
 
-    //Write the terminator
-    let slice = cursor.into_inner();
-    slice[len] = 0;
-    len
+        let mut length_tracker = LengthTracker(0);
+        write!(length_tracker, "{obj}").unwrap();
+        length_tracker.0
+    } else {
+        //We are goint to try and actually render the object into the buffer, saving room for the terminator
+        let slice = unsafe{ slice::from_raw_parts_mut(buf as *mut u8, buf_len) };
+        let mut cursor = Cursor::new(slice);
+        let len = if let Err(_err) = write!(cursor, "{obj}") {
+            //The buffer was probably too short, so figure out the buffer size we need
+            cursor.into_inner()[0] = 0;
+            return write_into_buf(obj, buf, 0);
+        } else {
+            let len = cursor.position() as usize;
+            //We still need room for the terminator
+            if len == buf_len {
+                cursor.into_inner()[0] = 0;
+                return write_into_buf(obj, buf, 0)
+            } else {
+                len
+            }
+        };
+
+        //Write the terminator
+        cursor.into_inner()[len] = 0;
+        len
+    }
 }
 
 pub(crate) fn write_debug_into_buf<T: std::fmt::Debug>(obj: T, buf: *mut c_char, buf_len: usize) -> usize {

--- a/c/tests/check_atom.c
+++ b/c/tests/check_atom.c
@@ -13,7 +13,8 @@ void teardown(void) {
 #include "stdio.h"
 
 void bindings_to_buf(bindings_t* bindings, void *context) {
-    bindings_to_str(bindings, &str_to_buf, context);
+    char* dst_buf = context;
+    bindings_to_str(bindings, dst_buf, BUF_SIZE);
 };
 
 void clone_one_bindings(bindings_t* bindings, void *context) {

--- a/c/tests/check_space.c
+++ b/c/tests/check_space.c
@@ -22,17 +22,19 @@ void reset_output(struct output_t* output) {
     output->len = 0;
 }
 
-void copy_to_output(char const* str, void* context) {
-    struct output_t *output = context;
-    output->len += snprintf(output->str + output->len, 1024 - output->len, "%s, ", str);
+void atom_string_callback(const atom_t* atom, void* data)
+{
+    struct output_t* out = data;
+    char atom_str_buf[1024];
+    atom_to_str(atom, atom_str_buf, 1024);
+    out->len += snprintf(out->str + out->len, 1024 - out->len, "%s, ", atom_str_buf);
 }
 
 void query_callback_single_atom(const struct var_atom_t* atom, void* data)
 {
     struct output_t* out = data;
-
     out->len += snprintf(out->str + out->len, 1024 - out->len, "%s: ", atom->var);
-    atom_to_str(atom->atom, copy_to_output, out);
+    atom_string_callback(atom->atom, out);
     atom_free(atom->atom);
 }
 
@@ -41,12 +43,6 @@ void query_callback(struct bindings_t const* results, void* data)
     struct output_t* out = data;
 
     bindings_traverse(results, query_callback_single_atom, out);
-}
-
-void atom_string_callback(const atom_t* atom, void* data)
-{
-    struct output_t* out = data;
-    atom_to_str(atom, copy_to_output, out);
 }
 
 void collect_atoms(const atom_t* atom, void* vec_ptr) {

--- a/c/tests/check_space.c
+++ b/c/tests/check_space.c
@@ -25,9 +25,8 @@ void reset_output(struct output_t* output) {
 void atom_string_callback(const atom_t* atom, void* data)
 {
     struct output_t* out = data;
-    char atom_str_buf[1024];
-    atom_to_str(atom, atom_str_buf, 1024);
-    out->len += snprintf(out->str + out->len, 1024 - out->len, "%s, ", atom_str_buf);
+    out->len += atom_to_str(atom, out->str + out->len, 1024 - out->len);
+    out->len += snprintf(out->str + out->len, 1024 - out->len, ", ");
 }
 
 void query_callback_single_atom(const struct var_atom_t* atom, void* data)

--- a/c/tests/util.c
+++ b/c/tests/util.c
@@ -3,21 +3,12 @@
 
 #include "util.h"
 
-void str_to_buf(const char *str, void *context) {
-    strncpy(context, str, BUF_SIZE);
-};
-
-void return_string(char const* value, void* context) {
-    char** buffer = context;
-    size_t length = strlen(value);
-    *buffer = malloc(length + 1);
-    strncpy(*buffer, value, length);
-    (*buffer)[length] = 0;
-}
-
 char* stratom(atom_t const* atom) {
-    char* buffer;
-    atom_to_str(atom, return_string, &buffer);
+    char temp_buffer[2048];
+    size_t len = atom_to_str(atom, temp_buffer, 2048);
+    char* buffer = malloc(len+1);
+    strncpy(buffer, temp_buffer, len+1);
+    buffer[len] = 0;
     return buffer;
 }
 

--- a/c/tests/util.c
+++ b/c/tests/util.c
@@ -4,11 +4,9 @@
 #include "util.h"
 
 char* stratom(atom_t const* atom) {
-    char temp_buffer[2048];
-    size_t len = atom_to_str(atom, temp_buffer, 2048);
+    size_t len = atom_to_str(atom, NULL, 0);
     char* buffer = malloc(len+1);
-    strncpy(buffer, temp_buffer, len+1);
-    buffer[len] = 0;
+    atom_to_str(atom, buffer, len+1);
     return buffer;
 }
 

--- a/python/hyperonpy.cpp
+++ b/python/hyperonpy.cpp
@@ -26,9 +26,10 @@ using CTokenizer = CPtr<tokenizer_t>;
 using CStepResult = CPtr<step_result_t>;
 using CMetta = CPtr<metta_t>;
 
-static void copy_to_string(char const* cstr, void* context) {
-    std::string* cppstr = static_cast<std::string*>(context);
-    cppstr->assign(cstr);
+std::string buf_to_string(char const* cstr) {
+    std::string new_str;
+    new_str.assign(cstr);
+    return new_str;
 }
 
 static void copy_atoms(atom_array_t atoms, void* context) {
@@ -266,15 +267,15 @@ PYBIND11_MODULE(hyperonpy, m) {
 
     m.def("atom_eq", [](CAtom a, CAtom b) -> bool { return atom_eq(a.ptr, b.ptr); }, "Test if two atoms are equal");
     m.def("atom_to_str", [](CAtom atom) {
-            std::string str;
-            atom_to_str(atom.ptr, copy_to_string, &str);
-            return str;
+            char dst_buf[2048];
+            atom_to_str(atom.ptr, dst_buf, 2048);
+            return buf_to_string(dst_buf);
         }, "Convert atom to human readable string");
     m.def("atom_get_type", [](CAtom atom) { return atom_get_type(atom.ptr); }, "Get type of the atom");
     m.def("atom_get_name", [](CAtom atom) {
-            std::string str;
-            atom_get_name(atom.ptr, copy_to_string, &str);
-            return str;
+            char dst_buf[2048];
+            atom_get_name(atom.ptr, dst_buf, 2048);
+            return buf_to_string(dst_buf);
         }, "Get name of the Symbol or Variable atom");
     m.def("atom_get_object", [](CAtom atom) {
             return static_cast<GroundedObject const*>(atom_get_object(atom.ptr))->pyobj;
@@ -326,9 +327,9 @@ PYBIND11_MODULE(hyperonpy, m) {
         }, "Resolve and remove" );
 
     m.def("bindings_to_str", [](CBindings bindings) {
-        std::string str;
-        bindings_to_str(bindings.ptr, copy_to_string, &str);
-        return str;
+        char dst_buf[2048];
+        bindings_to_str(bindings.ptr, dst_buf, 2048);
+        return buf_to_string(dst_buf);
     }, "Convert bindings to human readable string");
 
     m.def("bindings_list", [](CBindings bindings) -> pybind11::list {
@@ -355,9 +356,9 @@ PYBIND11_MODULE(hyperonpy, m) {
         return bindings_set_is_single(set.ptr);
     }, "Returns true if BindingsSet contains no variable bindings (unconstrained)");
     m.def("bindings_set_to_str", [](CBindingsSet set) {
-        std::string str;
-        bindings_set_to_str(set.ptr, copy_to_string, &str);
-        return str;
+        char dst_buf[2048];
+        bindings_set_to_str(set.ptr, dst_buf, 2048);
+        return buf_to_string(dst_buf);
     }, "Convert BindingsSet to human readable string");
     m.def("bindings_set_clone", [](CBindingsSet set) { return CBindingsSet(bindings_set_clone(set.ptr)); }, "Deep copy of BindingsSet");
     m.def("bindings_set_from_bindings", [](CBindings bindings) { bindings_t* cloned_bindings = bindings_clone(bindings.ptr); return CBindingsSet(bindings_set_from_bindings(cloned_bindings)); }, "New BindingsSet from existing Bindings");
@@ -429,9 +430,9 @@ PYBIND11_MODULE(hyperonpy, m) {
 
     py::class_<CStepResult>(m, "CStepResult")
         .def("__str__", [](CStepResult step) {
-            std::string str;
-            step_to_str(step.ptr, copy_to_string, &str);
-            return str;
+            char dst_buf[2048];
+            step_to_str(step.ptr, dst_buf, 2048);
+            return buf_to_string(dst_buf);
         }, "Convert step to human readable string");
     m.def("interpret_init", [](CSpace space, CAtom expr) {
             return CStepResult(interpret_init(space.ptr, expr.ptr));


### PR DESCRIPTION
Background:  @luketpeterson wrote:

>>  ## The `c_str_callback_t` pattern is less efficient than returning a malloced buffer.
>>
>> Regardless of the safer_ffi migration, I think we should eliminate the c_str_callback_t callback.
>>
>> My reasoning goes like this: The Rust &str & String types don’t include a trailing terminator character because the Rust types track a size.  The callback gets a non-owned read-only c_str argument, which the implementation created by allocating buffer and copying the string into the buffer, plus the terminator.  Then, the callback needs to do something with the string, and the most common thing is to allocate yet another buffer and copy the string again.
>>
>> We can save one of these copies by just returning an allocated buffer - not to mention making the API simpler to use.

To which @vsbogd replied:

> The only issue with returning the allocated string from Rust is that a C API user will be obliged to free it with the Rust specific function. Thus as far as I understand one cannot just get the `[u8]` buffer from Rust and use it as a usual `char*` (at least cannot free it by `free()`). Please correct me if I am wrong here. But I don't object, we can implement `string_t = *mut c_char` in C API and add `string_free` function.

Anyhow, it is possible to use the `libc` Rust crate, and get access to exactly the same allocator functions used by the code.  For example: https://docs.rs/libc/latest/libc/fn.malloc.html  So we could allocate a pointer in Rust that the C side could free with an ordinary `free()`.

However, I thought about it a little more, and returning an allocated buffer is an improvement over two allocations in every case.  But a bigger improvement would be to let the C side create the buffer (on the stack) and then have Rust write into it.  The `snprintf()` API pattern.  That's what this PR does.

It's not a big deal, performance-wise.  But it's also not a very big change and it simplifies the C API from the caller's perspective.