### PR TITLE
Uniformly replace variables in bindings when returning cached result

### DIFF
--- a/lib/src/atom/matcher.rs
+++ b/lib/src/atom/matcher.rs
@@ -652,11 +652,6 @@ impl Bindings {
         BindingsIter { bindings: self, delegate: self.id_by_var.iter() }
     }
 
-    /// Converts [Bindings] into an iterator of pairs `(VariableAtom, Atom)`.
-    pub fn into_iter(self) -> impl Iterator<Item=(VariableAtom, Atom)> {
-        self.into_vec_of_pairs().into_iter()
-    }
-
     fn into_vec_of_pairs(mut self) -> Vec<(VariableAtom, Atom)> {
         let mut result = Vec::new();
         let mut core_vars: HashMap<u32, Atom> = HashMap::new();
@@ -771,6 +766,16 @@ impl From<&[(VariableAtom, Atom)]> for Bindings {
             }.unwrap_or_else(|e| panic!("Error creating Bindings from Atoms: {}", e));
         }
         bindings
+    }
+}
+
+impl IntoIterator for Bindings {
+    type Item = (VariableAtom, Atom);
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    /// Converts [Bindings] into an iterator of pairs `(VariableAtom, Atom)`.
+    fn into_iter(self) -> Self::IntoIter {
+        self.into_vec_of_pairs().into_iter()
     }
 }
 

--- a/lib/src/atom/matcher.rs
+++ b/lib/src/atom/matcher.rs
@@ -651,6 +651,46 @@ impl Bindings {
     pub fn iter(&self) -> BindingsIter {
         BindingsIter { bindings: self, delegate: self.id_by_var.iter() }
     }
+
+    /// Converts [Bindings] into an iterator of pairs `(VariableAtom, Atom)`.
+    pub fn into_iter(self) -> impl Iterator<Item=(VariableAtom, Atom)> {
+        self.into_vec_of_pairs().into_iter()
+    }
+
+    fn into_vec_of_pairs(mut self) -> Vec<(VariableAtom, Atom)> {
+        let mut result = Vec::new();
+        let mut core_vars: HashMap<u32, Atom> = HashMap::new();
+
+        for (var, id) in self.id_by_var {
+            match self.value_by_id.remove(&id) {
+                Some(value) => {
+                    core_vars.insert(id, Atom::Variable(var.clone()));
+                    result.push((var, value));
+                },
+                None => {
+                    match core_vars.get(&id) {
+                        Some(core_var) => { result.push((var, core_var.clone())); }
+                        None => { core_vars.insert(id, Atom::Variable(var)); }
+                    }
+                },
+            }
+        }
+
+        result
+    }
+
+    /// Rename variables inside bindings using `rename`.
+    pub fn rename_vars<F>(self, mut rename: F) -> Self where F: FnMut(VariableAtom) -> VariableAtom {
+        self.into_iter()
+            .map(|(mut v, mut a)| {
+                v = rename(v);
+                a.iter_mut().filter_type::<&mut VariableAtom>()
+                    .for_each(|var| *var = rename(var.clone()));
+                (v, a)
+            })
+            .collect::<Vec<(VariableAtom, Atom)>>()
+            .into()
+    }
 }
 
 impl Display for Bindings {
@@ -1576,4 +1616,50 @@ mod test {
         Ok(())
     }
 
+    #[ignore = "Unstable because HashMap doesn't guarantee the order of entries"]
+    #[test]
+    fn bindings_into_entries() -> Result<(), &'static str> {
+        let bindings = Bindings::new()
+            .add_var_equality(&VariableAtom::new("x"), &VariableAtom::new("y"))?
+            .add_var_binding_v2(VariableAtom::new("x"), Atom::sym("Z"))?
+            .add_var_binding_v2(VariableAtom::new("a"), Atom::expr([Atom::sym("A"), Atom::var("x")]))?
+            .add_var_binding_v2(VariableAtom::new("b"), Atom::expr([Atom::sym("B"), Atom::var("x")]))?;
+
+        let entries: Vec<(VariableAtom, Atom)> = bindings.into_iter().collect();
+
+        assert_eq_no_order!(entries, vec![
+            (VariableAtom::new("x"), Atom::var("y")),
+            (VariableAtom::new("y"), Atom::sym("Z")),
+            (VariableAtom::new("a"), Atom::expr([ Atom::sym("A"), Atom::var("x") ])),
+            (VariableAtom::new("b"), Atom::expr([ Atom::sym("B"), Atom::var("x") ])),
+        ]);
+        Ok(())
+    }
+
+    #[test]
+    fn bindings_rename_vars() -> Result<(), &'static str> {
+        let bindings = Bindings::new()
+            .add_var_equality(&VariableAtom::new("x"), &VariableAtom::new("y"))?
+            .add_var_binding_v2(VariableAtom::new("x"), Atom::sym("Z"))?
+            .add_var_binding_v2(VariableAtom::new("a"), Atom::expr([Atom::sym("A"), Atom::var("x")]))?
+            .add_var_binding_v2(VariableAtom::new("b"), Atom::expr([Atom::sym("B"), Atom::var("x")]))?;
+
+        let map: HashMap<VariableAtom, VariableAtom> = vec![
+            (VariableAtom::new("x"), VariableAtom::new("z"))
+        ].into_iter().collect();
+        let renamed = bindings.rename_vars(|v| {
+            match map.get(&v) {
+                Some(v) => v.clone(),
+                None => v,
+            }
+        });
+
+        let expected = Bindings::new()
+            .add_var_equality(&VariableAtom::new("z"), &VariableAtom::new("y"))?
+            .add_var_binding_v2(VariableAtom::new("z"), Atom::sym("Z"))?
+            .add_var_binding_v2(VariableAtom::new("a"), Atom::expr([Atom::sym("A"), Atom::var("z")]))?
+            .add_var_binding_v2(VariableAtom::new("b"), Atom::expr([Atom::sym("B"), Atom::var("z")]))?;
+        assert_eq!(renamed, expected);
+        Ok(())
+    }
 }

--- a/lib/src/common/mod.rs
+++ b/lib/src/common/mod.rs
@@ -98,6 +98,7 @@ impl<T> Display for GndRefCell<T> {
     }
 }
 
+#[derive(Clone)]
 pub struct ReplacingMapper<T: Clone + std::hash::Hash + Eq + ?Sized, F: Fn(T) -> T> {
     mapper: F,
     mapping: HashMap<T, T>,
@@ -119,8 +120,12 @@ impl<T: Clone + std::hash::Hash + Eq + ?Sized, F: Fn(T) -> T> ReplacingMapper<T,
         }
     }
 
-    pub fn get_mapping(&self) -> &HashMap<T, T> {
-        &self.mapping
+    pub fn mapping_mut(&mut self) -> &mut HashMap<T, T> {
+        &mut self.mapping
+    }
+
+    pub fn as_fn_mut<'a>(&'a mut self) -> impl 'a + FnMut(T) -> T {
+        move |mut t| { self.replace(&mut t); t }
     }
 }
 

--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -898,7 +898,7 @@ fn make_conflicting_vars_unique(pattern: &mut Atom, template: &mut Atom, externa
         .for_each(|var| local_var_mapper.replace(var));
 
     template.iter_mut().filter_type::<&mut VariableAtom>()
-        .for_each(|var| match local_var_mapper.get_mapping().get(var) {
+        .for_each(|var| match local_var_mapper.mapping_mut().get(var) {
             Some(v) => *var = v.clone(),
             None => {},
         });


### PR DESCRIPTION
Fix #323. When resulting atom contains variables which are absent in original atom they are replaced by unique instances. In such case variables in bindings should also be replaced.

What is not done:
This PR adds one more method into `Bindings` API. It is not published as a part of C API or Python API. Also I would like to minimize the number of such methods in `Bindings`. I am raising it because it is blocker and @ngeiswei asked doing it asap. Will add an issue on `Bindings` code polishing.