### PR TITLE
Creating a pathway to wrap spaces in grounded atoms from C & Python

### DIFF
--- a/c/src/space.rs
+++ b/c/src/space.rs
@@ -463,6 +463,15 @@ pub extern "C" fn space_free(space: *mut space_t) {
     drop(space)
 }
 
+/// Clones a space_t reference.  The underlying space is still the same space.
+/// 
+/// The returned space_t must be freed with space_free
+#[no_mangle]
+pub extern "C" fn space_clone_ref(space: *const space_t) -> *mut space_t {
+    let space = unsafe { &(*space).0 };
+    Box::into_raw(Box::new(space_t(space.clone())))
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn space_eq(a: *const space_t, b: *const space_t) -> bool {
     *a == *b

--- a/lib/src/metta/types.rs
+++ b/lib/src/metta/types.rs
@@ -107,7 +107,7 @@ pub fn is_func(typ: &Atom) -> bool {
 fn query_types(space: &dyn Space, atom: &Atom) -> Vec<Atom> {
     let var_x = VariableAtom::new("X").make_unique();
     let mut types = query_has_type(space, atom, &Atom::Variable(var_x.clone()));
-    let mut types = types.drain(0..).map(|mut bindings| { bindings.resolve_and_remove(&var_x).unwrap() }).collect();
+    let mut types = types.drain(0..).filter_map(|mut bindings| { bindings.resolve_and_remove(&var_x) }).collect();
     add_super_types(space, &mut types, 0);
     types
 }

--- a/python/hyperon/atoms.py
+++ b/python/hyperon/atoms.py
@@ -90,13 +90,20 @@ class AtomType:
     EXPRESSION = Atom._from_catom(hp.CAtomType.EXPRESSION)
     GROUNDED = Atom._from_catom(hp.CAtomType.GROUNDED)
 
+class GroundedAtomType:
+    SPACE = Atom._from_catom(hp.CAtomType.GROUNDED_SPACE)
+
 class GroundedAtom(Atom):
 
     def __init__(self, catom):
         super().__init__(catom)
 
     def get_object(self):
-        return hp.atom_get_object(self.catom)
+        from .base import Space
+        if self.get_grounded_type() == GroundedAtomType.SPACE:
+            return Space._from_cspace(hp.atom_get_space(self.catom))
+        else:
+            return hp.atom_get_object(self.catom)
 
     def get_grounded_type(self):
         return Atom._from_catom(hp.atom_get_grounded_type(self.catom))

--- a/python/hyperon/base.py
+++ b/python/hyperon/base.py
@@ -43,13 +43,20 @@ def call_new_iter_state_on_python_space(space):
 class Space:
 
     def __init__(self, space_obj):
-        self.cspace = hp.space_new_custom(space_obj)
+        if type(space_obj) is hp.CSpace:
+            self.cspace = space_obj
+        else:
+            self.cspace = hp.space_new_custom(space_obj)
 
     def __del__(self):
         hp.space_free(self.cspace)
 
     def __eq__(self, other):
         return hp.space_eq(self.cspace, other.cspace)
+
+    @staticmethod
+    def _from_cspace(cspace):
+        return Space(cspace)
 
     def copy(self):
         return self

--- a/python/tests/test_custom_space.py
+++ b/python/tests/test_custom_space.py
@@ -103,7 +103,7 @@ class CustomSpaceTest(HyperonTestCase):
         #Make a little space and add it to the MeTTa interpreter's space
         little_space = Space(TestSpace())
         little_space.add_atom(E(S("A"), S("B")))
-        space_atom = G(little_space, S("Space"))
+        space_atom = G(little_space)
         m.space().add_atom(E(S("little-space"), space_atom))
 
         #Make sure we can get the little space back, and then query it
@@ -115,4 +115,16 @@ class CustomSpaceTest(HyperonTestCase):
         self.assertEqualNoOrder(result, [{"v": S("B")}])
 
         #Add the MeTTa space to the little space for some space recursion
-        space_atom.get_object().add_atom(E(S("big-space"), G(m.space(), S("Space"))))
+        little_space.add_atom(E(S("big-space"), G(m.space())))
+
+    def test_match_nested_custom_space(self):
+        nested = Space(TestSpace())
+        nested.add_atom(E(S("A"), S("B")))
+        space_atom = G(nested)
+
+        runner = MeTTa()
+        runner.space().add_atom(space_atom)
+        runner.tokenizer().register_token("nested", lambda token: space_atom)
+
+        result = runner.run("!(match nested (A $x) $x)")
+        self.assertEqual([[S("B")]], result)

--- a/python/tests/test_grounding_space.py
+++ b/python/tests/test_grounding_space.py
@@ -40,3 +40,15 @@ class GroundingSpaceTest(HyperonTestCase):
 
         result = kb.query(E(S(","), E(S("A"), V("x")), E(S("C"), V("x"))))
         self.assertEqualNoOrder(result, [{"x": S("B")}])
+
+    def test_match_nested_grounding_space(self):
+        nested = GroundingSpace()
+        nested.add_atom(E(S("A"), S("B")))
+        space_atom = G(nested)
+
+        runner = MeTTa()
+        runner.space().add_atom(space_atom)
+        runner.tokenizer().register_token("nested", lambda token: space_atom)
+
+        result = runner.run("!(match nested (A $x) $x)")
+        self.assertEqual([[S("B")]], result)


### PR DESCRIPTION
This should address https://github.com/trueagi-io/hyperon-experimental/issues/328

I went back and forth about which level to build the bridge, but fundamentally I decided that it made the most sense to create separate translator functions at the C level because C doesn't have any kind of runtime introspection.

So I added:
`fn atom_gnd_for_space(space: *mut space_t) -> *mut atom_t` and
`fn atom_get_space(atom: *const atom_t) -> *const space_t`

But at the Python level, runtime type introspection is back, so I kept the original interface of:
`G(space)` and
`GroundedAtom::get_object()`