### PR TITLE
Consolidating MeTTa type definitions in one place for Atom Types and Grounded Atom Types

### DIFF
--- a/c/src/atom.rs
+++ b/c/src/atom.rs
@@ -49,8 +49,6 @@ pub struct bindings_set_t {
 pub type bindings_callback_t = lambda_t<*const bindings_t>;
 pub type bindings_mut_callback_t = lambda_t<*mut bindings_t>;
 
-#[no_mangle] pub extern "C" fn ATOM_TYPE_GROUNDED_SPACE() -> *mut atom_t { atom_into_ptr(rust_type_atom::<DynSpace>()) }
-
 #[repr(C)]
 pub struct gnd_api_t {
     // TODO: replace args by C array and ret by callback

--- a/c/src/metta.rs
+++ b/c/src/metta.rs
@@ -1,9 +1,11 @@
+use hyperon::space::DynSpace;
 use hyperon::Atom;
 use hyperon::metta::text::*;
 use hyperon::metta::interpreter;
 use hyperon::metta::interpreter::InterpretedAtom;
 use hyperon::common::plan::StepResult;
 use hyperon::metta::runner::Metta;
+use hyperon::rust_type_atom;
 
 use crate::util::*;
 use crate::atom::*;
@@ -89,6 +91,7 @@ pub unsafe extern "C" fn sexpr_parser_parse(parser: *mut sexpr_parser_t,
 #[no_mangle] pub extern "C" fn ATOM_TYPE_VARIABLE() -> *mut atom_t { atom_into_ptr(hyperon::metta::ATOM_TYPE_VARIABLE) }
 #[no_mangle] pub extern "C" fn ATOM_TYPE_EXPRESSION() -> *mut atom_t { atom_into_ptr(hyperon::metta::ATOM_TYPE_EXPRESSION) }
 #[no_mangle] pub extern "C" fn ATOM_TYPE_GROUNDED() -> *mut atom_t { atom_into_ptr(hyperon::metta::ATOM_TYPE_GROUNDED) }
+#[no_mangle] pub extern "C" fn ATOM_TYPE_GROUNDED_SPACE() -> *mut atom_t { atom_into_ptr(rust_type_atom::<DynSpace>()) }
 
 #[no_mangle]
 pub unsafe extern "C" fn check_type(space: *const space_t, atom: *const atom_t, typ: *const atom_t) -> bool {

--- a/python/hyperon/atoms.py
+++ b/python/hyperon/atoms.py
@@ -89,9 +89,7 @@ class AtomType:
     VARIABLE = Atom._from_catom(hp.CAtomType.VARIABLE)
     EXPRESSION = Atom._from_catom(hp.CAtomType.EXPRESSION)
     GROUNDED = Atom._from_catom(hp.CAtomType.GROUNDED)
-
-class GroundedAtomType:
-    SPACE = Atom._from_catom(hp.CAtomType.GROUNDED_SPACE)
+    GROUNDED_SPACE = Atom._from_catom(hp.CAtomType.GROUNDED_SPACE)
 
 class GroundedAtom(Atom):
 
@@ -100,7 +98,7 @@ class GroundedAtom(Atom):
 
     def get_object(self):
         from .base import Space
-        if self.get_grounded_type() == GroundedAtomType.SPACE:
+        if self.get_grounded_type() == AtomType.GROUNDED_SPACE:
             return Space._from_cspace(hp.atom_get_space(self.catom))
         else:
             return hp.atom_get_object(self.catom)


### PR DESCRIPTION
Originally, I had put the Python definition of ATOM_TYPE_GROUNDED_SPACE in atom.rs (precursor for the C API) and exported GroundedAtomType.SPACE to the Python API.

My thinking was to keep a separation from types returned by `atom_get_type()` and types returned by `atom_get_grounded_type()`.  However, it does make things a little more confusing.

Vitaly suggested putting the MeTTa types in the same place: https://github.com/trueagi-io/hyperon-experimental/pull/329#discussion_r1229642538

That is the purpose of this PR.