### PR TITLE
Automatically update hyperonpy module when Python hyperon package is installed in editable mode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,7 @@ jobs:
         working-directory: ./python
         run: |
           python -m pip install build==0.10.0
-          python -m build
+          python -m build --wheel
           tar zcf dist-${{ inputs.os }}-py${{ inputs.python-version }}.tar.gz dist
 
       - name: Upload Python package to GitHub

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,14 +100,6 @@ jobs:
         run: |
           python -m pip install build==0.10.0
           python -m build --wheel
-          tar zcf dist-${{ inputs.os }}-py${{ inputs.python-version }}.tar.gz dist
-
-      - name: Upload Python package to GitHub
-        if: inputs.make-packages
-        uses: actions/upload-artifact@v3
-        with:
-          name: dist-${{ inputs.os }}-py${{ inputs.python-version }}.tar.gz
-          path: ./python/dist-${{ inputs.os }}-py${{ inputs.python-version }}.tar.gz
 
       - name: Publish artifacts on GitHub
         if: inputs.publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: ci
 
 on:
   push:
@@ -9,8 +9,8 @@ on:
       - main
 
 jobs:
-  tests:
-    uses: ./.github/workflows/build.yml
+  ci:
+    uses: ./.github/workflows/common.yml
     with:
       python-version: '3.7'
       os: ubuntu-20.04

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -5,7 +5,7 @@
 # provided by a third-party and are governed by separate terms of service,
 # privacy policy, and support documentation.
 
-name: Build, test, make packages, publish packages
+name: common
 
 on:
   workflow_call:
@@ -41,7 +41,7 @@ on:
         type: boolean
 
 jobs:
-  main:
+  run:
     runs-on: ${{ inputs.os }}
 
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish Packages
+name: publish
 
 on:
   workflow_dispatch:
@@ -16,7 +16,7 @@ jobs:
         os: [ubuntu-latest, macos-11]
       max-parallel: 3
 
-    uses: ./.github/workflows/build.yml
+    uses: ./.github/workflows/common.yml
     with:
       python-version: ${{ matrix.python-version }}
       os: ${{ matrix.os }}

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -65,8 +65,28 @@ add_dependencies(hyperonc-static build-hyperonc)
 
 add_subdirectory(tests)
 
-install(FILES ${HYPERONC_SHARED_LIB_PATH} DESTINATION lib)
-install(DIRECTORY ${HYPERONC_INCLUDE_DIR} DESTINATION include)
+set(BINARY_INSTALL_PATH "lib/hyperonc")
+set(INCLUDE_INSTALL_PATH "include/hyperonc")
+set(CONFIG_INSTALL_PATH "lib/cmake/hyperonc")
+set(SHARED_LIBRARY_INSTALL_PATH "${BINARY_INSTALL_PATH}/${HYPERONC_SHARED_LIB_FILE}")
+set(STATIC_LIBRARY_INSTALL_PATH "${BINARY_INSTALL_PATH}/${HYPERONC_STATIC_LIB_FILE}")
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file("hyperonc-config.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/hyperonc-config.cmake"
+    INSTALL_DESTINATION "${CONFIG_INSTALL_PATH}"
+    PATH_VARS INCLUDE_INSTALL_PATH SHARED_LIBRARY_INSTALL_PATH
+    STATIC_LIBRARY_INSTALL_PATH
+)
+
+install(FILES
+    "${HYPERONC_STATIC_LIB_PATH}"
+    "${HYPERONC_SHARED_LIB_PATH}"
+    DESTINATION "${BINARY_INSTALL_PATH}")
+install(DIRECTORY "${HYPERONC_INCLUDE_DIR}"
+    DESTINATION "${INCLUDE_INSTALL_PATH}")
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/hyperonc-config.cmake"
+    DESTINATION "${CONFIG_INSTALL_PATH}")
 
 add_test(NAME rust_c_api COMMAND cargo test --target-dir ${HYPERONC_TARGET_DIR}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/c/hyperonc-config.cmake.in
+++ b/c/hyperonc-config.cmake.in
@@ -1,0 +1,8 @@
+@PACKAGE_INIT@
+
+set_and_check(hyperonc_INCLUDE_DIRS "@PACKAGE_INCLUDE_INSTALL_PATH@")
+set_and_check(hyperonc_STATIC_LIBRARY "@PACKAGE_STATIC_LIBRARY_INSTALL_PATH@")
+set_and_check(hyperonc_SHARED_LIBRARY "@PACKAGE_SHARED_LIBRARY_INSTALL_PATH@")
+
+check_required_components(hyperonc)
+

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -4,4 +4,3 @@ __pycache__
 /build
 /*.so
 /*.dylib
-/setup.py

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -21,9 +21,6 @@ endif()
 message(STATUS "Python native modules installation path (Python3_SITEARCH): ${Python3_SITEARCH}")
 message(STATUS "Python modules installation path (Python3_SITELIB): ${Python3_SITELIB}")
 
-set(HYPERONPY_DIR ${CMAKE_CURRENT_BINARY_DIR})
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/setup.py.in ${CMAKE_CURRENT_SOURCE_DIR}/setup.py)
-
 execute_process(
     COMMAND conan install --build missing ${CMAKE_CURRENT_SOURCE_DIR}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
@@ -32,8 +29,10 @@ find_package(pybind11 REQUIRED)
 
 pybind11_add_module(hyperonpy SHARED hyperonpy.cpp)
 target_link_libraries(hyperonpy PRIVATE hyperonc-static)
+set_target_properties(hyperonpy PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
 
-set(PYTHONPATH "${CMAKE_CURRENT_BINARY_DIR}:${CMAKE_CURRENT_SOURCE_DIR}")
+set(PYTHONPATH "${CMAKE_CURRENT_SOURCE_DIR}")
 add_subdirectory(tests)
 
 INSTALL(TARGETS hyperonpy DESTINATION "${Python3_SITEARCH}")

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -34,6 +34,3 @@ set_target_properties(hyperonpy PROPERTIES
 
 set(PYTHONPATH "${CMAKE_CURRENT_SOURCE_DIR}")
 add_subdirectory(tests)
-
-INSTALL(TARGETS hyperonpy DESTINATION "${Python3_SITEARCH}")
-INSTALL(DIRECTORY hyperon DESTINATION "${Python3_SITELIB}")

--- a/python/hyperonpy.cpp
+++ b/python/hyperonpy.cpp
@@ -424,7 +424,7 @@ PYBIND11_MODULE(hyperonpy, m) {
     m.def("atom_gnd", [](py::object object, CAtom ctyp) {
             if (py::hasattr(object, "cspace")) {
                 //TODO: We should make static constant type atoms, so we don't need to allocate and then
-                // free them, just to test a constant 
+                // free them, just to test a constant
                 atom_t* undefined = ATOM_TYPE_UNDEFINED();
                 if (!atom_eq(ctyp.ptr, undefined)) {
                     throw std::runtime_error("Grounded Space Atoms can't have a custom type");

--- a/python/setup.py
+++ b/python/setup.py
@@ -20,6 +20,6 @@ class CopyBuild(build_ext):
             shutil.copyfile(source_path, target_path)
 
 setup(
-    ext_modules=[ CopyExtension('hyperonpy', source_dir='${HYPERONPY_DIR}') ],
+    ext_modules=[ CopyExtension('hyperonpy') ],
     cmdclass={ 'build_ext': CopyBuild },
 )


### PR DESCRIPTION
At the moment it is required to run `python3 -m pip install -e .[dev]` in order to update the `hyperonpy` module after some native code is changed. This PR changes the target directory for `hyperonpy` to `./python` which means that `hyperonpy` is automatically updated by `make` command.

Also this PR contains:
- add proper CMake package config for `hyperonc` library
- remove Python CMake installation because `pip` should be used instead
- stop uploading artifacts into GitHub internal storage as they are published to Release page
- rename GitHub Actions workflows and jobs to make them look better in GitHub UI

This PR is a step to `manylinux` package building.