### PR TITLE
Python API usability issues.  Changes:

### DIFF
--- a/c/src/space.rs
+++ b/c/src/space.rs
@@ -5,7 +5,6 @@ use hyperon::atom::*;
 use hyperon::matcher::*;
 
 use crate::atom::*;
-use crate::util::*;
 
 use std::os::raw::*;
 
@@ -524,14 +523,12 @@ pub unsafe extern "C" fn space_replace(space: *mut space_t, from: *const atom_t,
     (*space).0.borrow_mut().replace(&(*from).atom, ptr_into_atom(to))
 }
 
+/// NOTE: The returned BindingsSet needs to be freed with bindings_set_free
 #[no_mangle]
-pub extern "C" fn space_query(space: *const space_t,
-        pattern: *const atom_t, callback: lambda_t<* const bindings_t>, context: *mut c_void) {
+pub extern "C" fn space_query(space: *const space_t, pattern: *const atom_t) -> *mut bindings_set_t
+{
     let results = unsafe { (*space).0.borrow().query(&((*pattern).atom)) };
-    for result in results.into_iter() {
-        let b = (&result as *const Bindings).cast();
-        callback(b, context);
-    }
+    bindings_set_into_ptr(results)
 }
 
 #[no_mangle]

--- a/c/tests/check_space.c
+++ b/c/tests/check_space.c
@@ -37,7 +37,7 @@ void query_callback_single_atom(const struct var_atom_t* atom, void* data)
     atom_free(atom->atom);
 }
 
-void query_callback(struct bindings_t const* results, void* data)
+void query_callback(struct bindings_t* results, void* data)
 {
     struct output_t* out = data;
 
@@ -56,9 +56,11 @@ START_TEST (test_grounding_space_query)
     atom_t* query = expr(atom_sym("+"), atom_sym("A"), atom_var("b"), 0);
 
     struct output_t result = { "", 0 };
-    space_query(space, query, query_callback, &result);
+    bindings_set_t* bindings_set = space_query(space, query);
+    bindings_set_iterate(bindings_set, query_callback, &result);
     ck_assert_str_eq(result.str, "b: B, ");
 
+    bindings_set_free(bindings_set);
     space_free(space);
 }
 END_TEST
@@ -179,9 +181,12 @@ START_TEST (test_custom_c_space)
 
     space_add(space, expr(atom_sym("+"), atom_var("a"), atom_sym("B"), 0));
     atom_t* query = expr(atom_sym("+"), atom_sym("A"), atom_var("b"), 0);
+
     struct output_t result = { "", 0 };
-    space_query(space, query, query_callback, &result);
+    bindings_set_t* bindings_set = space_query(space, query);
+    bindings_set_iterate(bindings_set, query_callback, &result);
     ck_assert_str_eq(result.str, "b: B, ");
+    bindings_set_free(bindings_set);
 
     //Test that we can iterate the atoms in the space
     reset_output(&result);

--- a/python/hyperon/__init__.py
+++ b/python/hyperon/__init__.py
@@ -2,15 +2,6 @@ from .atoms import *
 from .base import *
 from .runner import MeTTa
 
-from .atoms import _priv_call_execute_on_grounded_atom
-from .atoms import _priv_call_match_on_grounded_atom
-from .base import _priv_call_query_on_python_space
-from .base import _priv_call_add_on_python_space
-from .base import _priv_call_remove_on_python_space
-from .base import _priv_call_replace_on_python_space
-from .base import _priv_call_atom_count_on_python_space
-from .base import _priv_call_new_iter_state_on_python_space
-
 def _version(dist_name):
     try:
         import sys

--- a/python/hyperon/__init__.py
+++ b/python/hyperon/__init__.py
@@ -2,6 +2,15 @@ from .atoms import *
 from .base import *
 from .runner import MeTTa
 
+from .atoms import _priv_call_execute_on_grounded_atom
+from .atoms import _priv_call_match_on_grounded_atom
+from .base import _priv_call_query_on_python_space
+from .base import _priv_call_add_on_python_space
+from .base import _priv_call_remove_on_python_space
+from .base import _priv_call_replace_on_python_space
+from .base import _priv_call_atom_count_on_python_space
+from .base import _priv_call_new_iter_state_on_python_space
+
 def _version(dist_name):
     try:
         import sys

--- a/python/hyperon/runner.py
+++ b/python/hyperon/runner.py
@@ -2,7 +2,7 @@ import os
 from importlib import import_module
 import hyperonpy as hp
 from .atoms import Atom, AtomType, OperationAtom
-from .base import GroundingSpace, Tokenizer, SExprParser
+from .base import GroundingSpaceRef, Tokenizer, SExprParser
 
 class MeTTa:
 
@@ -11,7 +11,7 @@ class MeTTa:
             self.cmetta = cmetta
         else:
             if space is None:
-                space = GroundingSpace()
+                space = GroundingSpaceRef()
             tokenizer = Tokenizer()
             self.cmetta = hp.metta_new(space.cspace, tokenizer.ctokenizer, cwd)
             self.load_py_module("hyperon.stdlib")
@@ -28,7 +28,7 @@ class MeTTa:
         return MeTTa(cmetta = hp.metta_clone(self.cmetta))
 
     def space(self):
-        return GroundingSpace._from_cspace(hp.metta_space(self.cmetta))
+        return GroundingSpaceRef._from_cspace(hp.metta_space(self.cmetta))
 
     def tokenizer(self):
         return Tokenizer._from_ctokenizer(hp.metta_tokenizer(self.cmetta))

--- a/python/hyperonpy.cpp
+++ b/python/hyperonpy.cpp
@@ -112,7 +112,7 @@ py::object inc_ref(py::object obj) {
 }
 
 exec_error_t *py_execute(const struct gnd_t* _cgnd, struct vec_atom_t* _args, struct vec_atom_t* ret) {
-    py::object hyperon = py::module_::import("hyperon");
+    py::object hyperon = py::module_::import("hyperon.atoms");
     py::function call_execute_on_grounded_atom = hyperon.attr("_priv_call_execute_on_grounded_atom");
     py::handle NoReduceError = hyperon.attr("NoReduceError");
     py::object pyobj = static_cast<GroundedObject const*>(_cgnd)->pyobj;
@@ -139,7 +139,7 @@ exec_error_t *py_execute(const struct gnd_t* _cgnd, struct vec_atom_t* _args, st
 }
 
 void py_match_(const struct gnd_t *_gnd, const struct atom_t *_atom, bindings_mut_callback_t callback, void *context) {
-    py::object hyperon = py::module_::import("hyperon");
+    py::object hyperon = py::module_::import("hyperon.atoms");
     py::function call_match_on_grounded_atom = hyperon.attr("_priv_call_match_on_grounded_atom");
 
     py::object pyobj = static_cast<GroundedObject const *>(_gnd)->pyobj;
@@ -222,7 +222,7 @@ struct PySpace {
 };
 
 bindings_set_t *py_space_query(const struct space_params_t *params, const struct atom_t *query_atom) {
-    py::object hyperon = py::module_::import("hyperon");
+    py::object hyperon = py::module_::import("hyperon.base");
     py::function call_query_on_python_space = hyperon.attr("_priv_call_query_on_python_space");
     py::object pyobj = static_cast<PySpace const *>(params->payload)->pyobj;
     CAtom catom = atom_clone(query_atom);
@@ -237,7 +237,7 @@ bindings_set_t *py_space_query(const struct space_params_t *params, const struct
 // }
 
 void py_space_add(const struct space_params_t *params, struct atom_t *atom) {
-    py::object hyperon = py::module_::import("hyperon");
+    py::object hyperon = py::module_::import("hyperon.base");
     py::function call_add_on_python_space = hyperon.attr("_priv_call_add_on_python_space");
     py::object pyobj = static_cast<PySpace const *>(params->payload)->pyobj;
     atom_t* notify_atom = atom_clone(atom);
@@ -252,7 +252,7 @@ void py_space_add(const struct space_params_t *params, struct atom_t *atom) {
 }
 
 bool py_space_remove(const struct space_params_t *params, const struct atom_t *atom) {
-    py::object hyperon = py::module_::import("hyperon");
+    py::object hyperon = py::module_::import("hyperon.base");
     py::function call_remove_on_python_space = hyperon.attr("_priv_call_remove_on_python_space");
     py::object pyobj = static_cast<PySpace const *>(params->payload)->pyobj;
     atom_t* notify_atom = atom_clone(atom);
@@ -271,7 +271,7 @@ bool py_space_remove(const struct space_params_t *params, const struct atom_t *a
 }
 
 bool py_space_replace(const struct space_params_t *params, const struct atom_t *from, struct atom_t *to) {
-    py::object hyperon = py::module_::import("hyperon");
+    py::object hyperon = py::module_::import("hyperon.base");
     py::function call_replace_on_python_space = hyperon.attr("_priv_call_replace_on_python_space");
     py::object pyobj = static_cast<PySpace const *>(params->payload)->pyobj;
     atom_t* notify_from = atom_clone(from);
@@ -293,7 +293,7 @@ bool py_space_replace(const struct space_params_t *params, const struct atom_t *
 }
 
 ssize_t py_space_atom_count(const struct space_params_t *params) {
-    py::object hyperon = py::module_::import("hyperon");
+    py::object hyperon = py::module_::import("hyperon.base");
     py::function call_atom_count_on_python_space = hyperon.attr("_priv_call_atom_count_on_python_space");
     py::object pyobj = static_cast<PySpace const *>(params->payload)->pyobj;
     py::int_ result = call_atom_count_on_python_space(pyobj);
@@ -301,7 +301,7 @@ ssize_t py_space_atom_count(const struct space_params_t *params) {
 }
 
 void *py_space_new_atom_iter_state(const struct space_params_t *params) {
-    py::object hyperon = py::module_::import("hyperon");
+    py::object hyperon = py::module_::import("hyperon.base");
     py::function call_new_iter_state_on_python_space = hyperon.attr("_priv_call_new_iter_state_on_python_space");
     py::object pyobj = static_cast<PySpace const *>(params->payload)->pyobj;
     py::object result = call_new_iter_state_on_python_space(pyobj);

--- a/python/hyperonpy.cpp
+++ b/python/hyperonpy.cpp
@@ -113,7 +113,7 @@ py::object inc_ref(py::object obj) {
 
 exec_error_t *py_execute(const struct gnd_t* _cgnd, struct vec_atom_t* _args, struct vec_atom_t* ret) {
     py::object hyperon = py::module_::import("hyperon");
-    py::function call_execute_on_grounded_atom = hyperon.attr("call_execute_on_grounded_atom");
+    py::function call_execute_on_grounded_atom = hyperon.attr("_priv_call_execute_on_grounded_atom");
     py::handle NoReduceError = hyperon.attr("NoReduceError");
     py::object pyobj = static_cast<GroundedObject const*>(_cgnd)->pyobj;
     CAtom pytyp = static_cast<GroundedObject const*>(_cgnd)->typ;
@@ -140,7 +140,7 @@ exec_error_t *py_execute(const struct gnd_t* _cgnd, struct vec_atom_t* _args, st
 
 void py_match_(const struct gnd_t *_gnd, const struct atom_t *_atom, bindings_mut_callback_t callback, void *context) {
     py::object hyperon = py::module_::import("hyperon");
-    py::function call_match_on_grounded_atom = hyperon.attr("call_match_on_grounded_atom");
+    py::function call_match_on_grounded_atom = hyperon.attr("_priv_call_match_on_grounded_atom");
 
     py::object pyobj = static_cast<GroundedObject const *>(_gnd)->pyobj;
     CAtom catom = atom_clone(_atom);
@@ -223,7 +223,7 @@ struct PySpace {
 
 bindings_set_t *py_space_query(const struct space_params_t *params, const struct atom_t *query_atom) {
     py::object hyperon = py::module_::import("hyperon");
-    py::function call_query_on_python_space = hyperon.attr("call_query_on_python_space");
+    py::function call_query_on_python_space = hyperon.attr("_priv_call_query_on_python_space");
     py::object pyobj = static_cast<PySpace const *>(params->payload)->pyobj;
     CAtom catom = atom_clone(query_atom);
     py::object result = call_query_on_python_space(pyobj, catom);
@@ -238,7 +238,7 @@ bindings_set_t *py_space_query(const struct space_params_t *params, const struct
 
 void py_space_add(const struct space_params_t *params, struct atom_t *atom) {
     py::object hyperon = py::module_::import("hyperon");
-    py::function call_add_on_python_space = hyperon.attr("call_add_on_python_space");
+    py::function call_add_on_python_space = hyperon.attr("_priv_call_add_on_python_space");
     py::object pyobj = static_cast<PySpace const *>(params->payload)->pyobj;
     atom_t* notify_atom = atom_clone(atom);
     CAtom catom = atom;
@@ -253,7 +253,7 @@ void py_space_add(const struct space_params_t *params, struct atom_t *atom) {
 
 bool py_space_remove(const struct space_params_t *params, const struct atom_t *atom) {
     py::object hyperon = py::module_::import("hyperon");
-    py::function call_remove_on_python_space = hyperon.attr("call_remove_on_python_space");
+    py::function call_remove_on_python_space = hyperon.attr("_priv_call_remove_on_python_space");
     py::object pyobj = static_cast<PySpace const *>(params->payload)->pyobj;
     atom_t* notify_atom = atom_clone(atom);
     CAtom catom = atom_clone(atom);
@@ -272,7 +272,7 @@ bool py_space_remove(const struct space_params_t *params, const struct atom_t *a
 
 bool py_space_replace(const struct space_params_t *params, const struct atom_t *from, struct atom_t *to) {
     py::object hyperon = py::module_::import("hyperon");
-    py::function call_replace_on_python_space = hyperon.attr("call_replace_on_python_space");
+    py::function call_replace_on_python_space = hyperon.attr("_priv_call_replace_on_python_space");
     py::object pyobj = static_cast<PySpace const *>(params->payload)->pyobj;
     atom_t* notify_from = atom_clone(from);
     atom_t* notify_to = atom_clone(to);
@@ -294,7 +294,7 @@ bool py_space_replace(const struct space_params_t *params, const struct atom_t *
 
 ssize_t py_space_atom_count(const struct space_params_t *params) {
     py::object hyperon = py::module_::import("hyperon");
-    py::function call_atom_count_on_python_space = hyperon.attr("call_atom_count_on_python_space");
+    py::function call_atom_count_on_python_space = hyperon.attr("_priv_call_atom_count_on_python_space");
     py::object pyobj = static_cast<PySpace const *>(params->payload)->pyobj;
     py::int_ result = call_atom_count_on_python_space(pyobj);
     return result.cast<ssize_t>();
@@ -302,7 +302,7 @@ ssize_t py_space_atom_count(const struct space_params_t *params) {
 
 void *py_space_new_atom_iter_state(const struct space_params_t *params) {
     py::object hyperon = py::module_::import("hyperon");
-    py::function call_new_iter_state_on_python_space = hyperon.attr("call_new_iter_state_on_python_space");
+    py::function call_new_iter_state_on_python_space = hyperon.attr("_priv_call_new_iter_state_on_python_space");
     py::object pyobj = static_cast<PySpace const *>(params->payload)->pyobj;
     py::object result = call_new_iter_state_on_python_space(pyobj);
     if (result.is_none()) {
@@ -559,9 +559,20 @@ PYBIND11_MODULE(hyperonpy, m) {
                 set.ptr,
                 bindings_copy_to_list_callback,
                 &bindings_list);
-
         return bindings_list;
     }, "Returns iterator to traverse Bindings within BindingsSet");
+    m.def("bindings_set_unpack", [](CBindingsSet set) -> pybind11::list {
+        py::list results;
+        bindings_set_iterate(
+            set.ptr,
+            [](bindings_t * cbindings, void* context) {
+                py::list& results = *(py::list*)context;
+                py::dict pybindings;
+                bindings_traverse(cbindings, copy_atom_to_dict, &pybindings );
+                results.append(pybindings);
+            }, &results);
+        return results;
+    }, "Unpacks a BindingsSet into a list of dicts");
 
     py::class_<CSpace>(m, "CSpace");
     m.def("space_new_grounding", []() { return CSpace(space_new_grounding_space()); }, "New grounding space instance");
@@ -587,15 +598,8 @@ PYBIND11_MODULE(hyperonpy, m) {
         }
     }, "Returns iterator to traverse atoms within a space");
     m.def("space_query", [](CSpace space, CAtom pattern) {
-            py::list results;
-            space_query(space.ptr, pattern.ptr,
-                    [](bindings_t const* cbindings, void* context) {
-                        py::list& results = *(py::list*)context;
-                        py::dict pybindings;
-                        bindings_traverse(cbindings, copy_atom_to_dict, &pybindings );
-                        results.append(pybindings);
-                    }, &results);
-            return results;
+            bindings_set_t* result_bindings_set = space_query(space.ptr, pattern.ptr);
+            return CBindingsSet(result_bindings_set);
         }, "Query atoms from space by pattern");
     m.def("space_subst", [](CSpace space, CAtom pattern, CAtom templ) {
             py::list atoms;

--- a/python/tests/test_atom.py
+++ b/python/tests/test_atom.py
@@ -81,9 +81,9 @@ class AtomTest(unittest.TestCase):
                 [x2Atom, ValueAtom(1.0)])
 
     def test_groundingspace_equals(self):
-        kb_a = GroundingSpace()
+        kb_a = GroundingSpaceRef()
         kb_a.add_atom(E(S("+"), S("1"), S("2")))
-        kb_b = GroundingSpace()
+        kb_b = GroundingSpaceRef()
         kb_b.add_atom(E(S("+"), S("1"), S("2")))
         kb_c = kb_a
         self.assertEqual(kb_a.get_atoms(), kb_b.get_atoms())
@@ -91,23 +91,23 @@ class AtomTest(unittest.TestCase):
         self.assertNotEqual(kb_a, kb_b)
 
     def test_interpret(self):
-        space = GroundingSpace()
+        space = GroundingSpaceRef()
         self.assertEqual(interpret(space, E(x2Atom, ValueAtom(1))),
                 [ValueAtom(2)])
 
     def test_plan(self):
-        space = GroundingSpace()
+        space = GroundingSpaceRef()
         interpreter = Interpreter(space, E(x2Atom, ValueAtom(1)))
         self.assertEqual(str(interpreter.get_step_result()),
                 "return [(-> int int)] then form alternative plans for expression (*2 1) using types")
 
     def test_no_reduce(self):
-        space = GroundingSpace()
+        space = GroundingSpaceRef()
         self.assertEqual(interpret(space, E(noReduceAtom, ValueAtom(1))),
                 [E(noReduceAtom, ValueAtom(1))])
 
     def test_match_(self):
-        space = GroundingSpace()
+        space = GroundingSpaceRef()
         match_atom = MatchableAtomTest(S("MatchableAtom"), type_name=None, atom_id=None)
         space.add_atom(match_atom)
         result = space.query(E(S('symbol_atom'), V('atom_type')))

--- a/python/tests/test_atom_type.py
+++ b/python/tests/test_atom_type.py
@@ -5,7 +5,7 @@ from hyperon import *
 class AtomTest(unittest.TestCase):
 
     def test_check_type(self):
-        space = GroundingSpace()
+        space = GroundingSpaceRef()
         space.add_atom(E(S(":"), S("a"), S("A")))
 
         self.assertTrue(check_type(space, S("a"), AtomType.UNDEFINED))
@@ -13,7 +13,7 @@ class AtomTest(unittest.TestCase):
         self.assertFalse(check_type(space, S("a"), S("B")))
 
     def test_validate_atom(self):
-        space = GroundingSpace()
+        space = GroundingSpaceRef()
         space.add_atom(E(S(":"), S("a"), S("A")))
         space.add_atom(E(S(":"), S("b"), S("B")))
         space.add_atom(E(S(":"), S("foo"), E(S("->"), S("A"), S("B"))))
@@ -21,7 +21,7 @@ class AtomTest(unittest.TestCase):
         self.assertTrue(validate_atom(space, E(S("foo"), S("a"))))
 
     def test_get_atom_types(self):
-        space = GroundingSpace()
+        space = GroundingSpaceRef()
         space.add_atom(E(S(":"), S("a"), S("A")))
         space.add_atom(E(S(":"), S("b"), S("B")))
         space.add_atom(E(S(":"), S("foo"), E(S("->"), S("A"), S("B"))))

--- a/python/tests/test_custom_space.py
+++ b/python/tests/test_custom_space.py
@@ -3,10 +3,10 @@ import unittest
 from hyperon import *
 from test_common import HyperonTestCase
 
-class TestSpace(PySpace):
+class TestSpace(AbstractSpace):
 
     def __init__(self, unwrap=True):
-        super().__init__((), "TestSpace")
+        super().__init__()
         self.atoms_list = []
         self.unwrap = unwrap
 
@@ -62,7 +62,7 @@ class CustomSpaceTest(HyperonTestCase):
         test_space = TestSpace()
         test_space.test_attrib = "Test Space Payload Attrib"
 
-        kb = Space(test_space)
+        kb = SpaceRef(test_space)
         kb.add_atom(S("a"))
         kb.add_atom(S("b"))
 
@@ -71,7 +71,7 @@ class CustomSpaceTest(HyperonTestCase):
         self.assertEqualNoOrder(kb.get_atoms(), [S("a"), S("b")])
 
     def test_remove(self):
-        kb = Space(TestSpace())
+        kb = SpaceRef(TestSpace())
         kb.add_atom(S("a"))
         kb.add_atom(S("b"))
         kb.add_atom(S("c"))
@@ -81,7 +81,7 @@ class CustomSpaceTest(HyperonTestCase):
         self.assertEqualNoOrder(kb.get_atoms(), [S("a"), S("c")])
 
     def test_replace(self):
-        kb = Space(TestSpace())
+        kb = SpaceRef(TestSpace())
         kb.add_atom(S("a"))
         kb.add_atom(S("b"))
         kb.add_atom(S("c"))
@@ -90,7 +90,7 @@ class CustomSpaceTest(HyperonTestCase):
         self.assertEqualNoOrder(kb.get_atoms(), [S("a"), S("d"), S("c")])
 
     def test_query(self):
-        kb = Space(TestSpace())
+        kb = SpaceRef(TestSpace())
         kb.add_atom(E(S("A"), S("B")))
         kb.add_atom(E(S("C"), S("D")))
 
@@ -101,7 +101,7 @@ class CustomSpaceTest(HyperonTestCase):
         m = MeTTa()
 
         #Make a little space and add it to the MeTTa interpreter's space
-        little_space = Space(TestSpace())
+        little_space = SpaceRef(TestSpace())
         little_space.add_atom(E(S("A"), S("B")))
         space_atom = G(little_space)
         m.space().add_atom(E(S("little-space"), space_atom))
@@ -118,7 +118,7 @@ class CustomSpaceTest(HyperonTestCase):
         little_space.add_atom(E(S("big-space"), G(m.space())))
 
     def test_match_nested_custom_space(self):
-        nested = Space(TestSpace())
+        nested = SpaceRef(TestSpace())
         nested.add_atom(E(S("A"), S("B")))
         space_atom = G(nested)
 

--- a/python/tests/test_grounding_space.py
+++ b/python/tests/test_grounding_space.py
@@ -73,6 +73,7 @@ class GroundingSpaceTest(HyperonTestCase):
         def query(self, query_atom):
             modified_query = E(S("blue"), query_atom)
             result = super().query(modified_query)
+            result.add_var_binding(V("color"), S("blue"))
             return result
 
     def test_python_extended_grounding_space(self):
@@ -82,4 +83,4 @@ class GroundingSpaceTest(HyperonTestCase):
         kb.add_atom(E(S("red"), E(S("A"), S("C"))))
 
         result = kb.query(E(S("A"), V("x")))
-        self.assertEqualNoOrder(result, [{"x": S("B")}])
+        self.assertEqualNoOrder(result, [{"x": S("B"), "color": S("blue")}])

--- a/python/tests/test_grounding_space.py
+++ b/python/tests/test_grounding_space.py
@@ -6,7 +6,7 @@ from test_common import HyperonTestCase
 class GroundingSpaceTest(HyperonTestCase):
 
     def test_add(self):
-        kb = GroundingSpace()
+        kb = GroundingSpaceRef()
         kb.add_atom(S("a"))
 
         kb.add_atom(S("b"))
@@ -14,7 +14,7 @@ class GroundingSpaceTest(HyperonTestCase):
         self.assertEqualNoOrder(kb.get_atoms(), [S("a"), S("b")])
 
     def test_remove(self):
-        kb = GroundingSpace()
+        kb = GroundingSpaceRef()
         kb.add_atom(S("a"))
         kb.add_atom(S("b"))
         kb.add_atom(S("c"))
@@ -24,7 +24,7 @@ class GroundingSpaceTest(HyperonTestCase):
         self.assertEqualNoOrder(kb.get_atoms(), [S("a"), S("c")])
 
     def test_replace(self):
-        kb = GroundingSpace()
+        kb = GroundingSpaceRef()
         kb.add_atom(S("a"))
         kb.add_atom(S("b"))
         kb.add_atom(S("c"))
@@ -34,7 +34,7 @@ class GroundingSpaceTest(HyperonTestCase):
         self.assertEqualNoOrder(kb.get_atoms(), [S("a"), S("d"), S("c")])
 
     def test_complex_query(self):
-        kb = GroundingSpace()
+        kb = GroundingSpaceRef()
         kb.add_atom(E(S("A"), S("B")))
         kb.add_atom(E(S("C"), S("B")))
 
@@ -42,7 +42,7 @@ class GroundingSpaceTest(HyperonTestCase):
         self.assertEqualNoOrder(result, [{"x": S("B")}])
 
     def test_match_nested_grounding_space(self):
-        nested = GroundingSpace()
+        nested = GroundingSpaceRef()
         nested.add_atom(E(S("A"), S("B")))
         space_atom = G(nested)
 
@@ -52,3 +52,19 @@ class GroundingSpaceTest(HyperonTestCase):
 
         result = runner.run("!(match nested (A $x) $x)")
         self.assertEqual([[S("B")]], result)
+
+    def test_python_wrapped_grounding_space(self):
+        kb = SpaceRef(GroundingSpace())
+
+        kb.add_atom(S("a"))
+        kb.add_atom(S("b"))
+        kb.add_atom(S("c"))
+
+        self.assertTrue(kb.remove_atom(S("b")))
+        self.assertEqualNoOrder(kb.get_atoms(), [S("a"), S("c")])
+
+        kb.add_atom(E(S("A"), S("B")))
+        kb.add_atom(E(S("C"), S("B")))
+
+        result = kb.query(E(S(","), E(S("A"), V("x")), E(S("C"), V("x"))))
+        self.assertEqualNoOrder(result, [{"x": S("B")}])

--- a/python/tests/test_grounding_space.py
+++ b/python/tests/test_grounding_space.py
@@ -68,3 +68,18 @@ class GroundingSpaceTest(HyperonTestCase):
 
         result = kb.query(E(S(","), E(S("A"), V("x")), E(S("C"), V("x"))))
         self.assertEqualNoOrder(result, [{"x": S("B")}])
+
+    class ExtendedGroundingSpace(GroundingSpace):
+        def query(self, query_atom):
+            modified_query = E(S("blue"), query_atom)
+            result = super().query(modified_query)
+            return result
+
+    def test_python_extended_grounding_space(self):
+        kb = SpaceRef(self.ExtendedGroundingSpace())
+
+        kb.add_atom(E(S("blue"), E(S("A"), S("B"))))
+        kb.add_atom(E(S("red"), E(S("A"), S("C"))))
+
+        result = kb.query(E(S("A"), V("x")))
+        self.assertEqualNoOrder(result, [{"x": S("B")}])


### PR DESCRIPTION
1. Changed names to be more clear how different objects should be used. 
 - PySpace -> Abstract
 - Space Space -> SpaceRef
 - GroundingSpace -> GroundingSpaceRef

2. Added API comments, briefly describing intended usage of objects and functions

3. Changed Space `query` return value to BindingsSet in both C and Python APIs

4. Added BindingsSet implementation for `__getitem__ ` Python BindingsSet, in order to be able to access the individual Bindings in the same list-of-dict format formerly returned by space.query()

5. Added `GroundingSpace` Python wrapper implementation, so basic GroundingSpace can be easily subclassed.

6. Rename hyperonpy trampoline functions to `_priv_` so users don’t get confused