### PR TITLE
Small cleanups

### DIFF
--- a/lib/src/metta/interpreter.rs
+++ b/lib/src/metta/interpreter.rs
@@ -846,7 +846,7 @@ mod tests {
             expr!("->" "&str" "Error")
         }
         fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-            Err(args[0].as_gnd::<&str>().unwrap().deref().into())
+            Err((*args[0].as_gnd::<&str>().unwrap()).into())
         }
         fn match_(&self, other: &Atom) -> matcher::MatchResultIter {
             match_by_equality(self, other)

--- a/python/hyperonpy.cpp
+++ b/python/hyperonpy.cpp
@@ -16,14 +16,12 @@ constexpr size_t lenghtof(T (&)[N]) { return N; }
 
 template <typename T>
 struct CPtr {
-    using type = T;
     CPtr(T* ptr) : ptr(ptr) {}
     T* ptr;
 };
 
 template <typename T>
 struct CStruct {
-    using type = T;
     CStruct(T obj) : obj(obj) {}
     T obj;
     T* ptr () { return &(this->obj); }


### PR DESCRIPTION
This addresses: https://github.com/trueagi-io/hyperon-experimental/pull/361#discussion_r1265670145

Removing superfluous `using type = T` in hyperonpy.cpp types
Also Fixing "suspicious deref" warning that started with new Rust tool chain