### PR TITLE
API consistency changes around adding and traversing Bindings

### DIFF
--- a/c/tests/check_atom.c
+++ b/c/tests/check_atom.c
@@ -25,18 +25,15 @@ void clone_one_bindings(bindings_t* bindings, void *context) {
 START_TEST (test_bindings_set)
 {
     bindings_t* bindings_a = bindings_new();
-    var_atom_t var_atom_a = {.var = "a", .atom = atom_sym("A")};
-    bindings_add_var_binding(bindings_a, var_atom_a);
+    bindings_add_var_binding(bindings_a, atom_var("a"), atom_sym("A"));
 
     bindings_t* bindings_b = bindings_new();
-    var_atom_t var_atom_b = {.var = "b", .atom = atom_sym("B")};
-    bindings_add_var_binding(bindings_b, var_atom_b);
+    bindings_add_var_binding(bindings_b, atom_var("b"), atom_sym("B"));
 
     bindings_set_t set_1 = bindings_merge_v2(bindings_a, bindings_b);
 
     bindings_t* bindings_c = bindings_new();
-    var_atom_t var_atom_c = {.var = "c", .atom = atom_sym("C")};
-    bindings_add_var_binding(bindings_c, var_atom_c);
+    bindings_add_var_binding(bindings_c, atom_var("c"), atom_sym("C"));
 
     bindings_set_t set_2 = bindings_set_from_bindings(bindings_c);
     bindings_set_merge_into(&set_1, &set_2);
@@ -53,16 +50,11 @@ START_TEST (test_bindings_set)
     atom_free(d_sym);
 
     bindings_t* bindings_expected = bindings_new();
-    var_atom_t var_atom_a_expected = {.var = "a", .atom = atom_sym("A")};
-    var_atom_t var_atom_a_prime_expected = {.var = "a_prime", .atom = atom_sym("A")};
-    var_atom_t var_atom_b_expected = {.var = "b", .atom = atom_sym("B")};
-    var_atom_t var_atom_c_expected = {.var = "c", .atom = atom_sym("C")};
-    var_atom_t var_atom_d_expected = {.var = "d", .atom = atom_sym("D")};
-    bindings_add_var_binding(bindings_expected, var_atom_a_expected);
-    bindings_add_var_binding(bindings_expected, var_atom_a_prime_expected);
-    bindings_add_var_binding(bindings_expected, var_atom_b_expected);
-    bindings_add_var_binding(bindings_expected, var_atom_c_expected);
-    bindings_add_var_binding(bindings_expected, var_atom_d_expected);
+    bindings_add_var_binding(bindings_expected, atom_var("a"), atom_sym("A"));
+    bindings_add_var_binding(bindings_expected, atom_var("a_prime"), atom_sym("A"));
+    bindings_add_var_binding(bindings_expected, atom_var("b"), atom_sym("B"));
+    bindings_add_var_binding(bindings_expected, atom_var("c"), atom_sym("C"));
+    bindings_add_var_binding(bindings_expected, atom_var("d"), atom_sym("D"));
 
     bindings_t* result_bindings = NULL;
     bindings_set_iterate(&set_1, &clone_one_bindings, &result_bindings);

--- a/c/tests/check_space.c
+++ b/c/tests/check_space.c
@@ -29,12 +29,12 @@ void atom_string_callback(atom_ref_t atom, void* data)
     out->len += snprintf(out->str + out->len, 1024 - out->len, ", ");
 }
 
-void query_callback_single_atom(var_atom_t atom, void* data)
+void query_callback_single_atom(atom_ref_t var, atom_ref_t atom, void* data)
 {
     struct output_t* out = data;
-    out->len += snprintf(out->str + out->len, 1024 - out->len, "%s: ", atom.var);
-    atom_string_callback(atom_ref(&atom.atom), out);
-    atom_free(atom.atom);
+    out->len += atom_get_name(&var, out->str + out->len, 1024 - out->len);
+    out->len += snprintf(out->str + out->len, 1024 - out->len, ": ");
+    atom_string_callback(atom, out);
 }
 
 void query_callback(struct bindings_t* results, void* data)

--- a/python/hyperon/atoms.py
+++ b/python/hyperon/atoms.py
@@ -259,11 +259,11 @@ class Bindings:
     def merge_v2(left, right) -> 'BindingsSet':
         return BindingsSet(hp.bindings_merge_v2(left.cbindings, right.cbindings))
 
-    def add_var_bindings(self, var: Union[str, Atom], atom: Atom) -> bool:
+    def add_var_binding(self, var: Union[str, Atom], atom: Atom) -> bool:
         if isinstance(var, Atom):
-            return hp.bindings_add_var_bindings(self.cbindings, var.get_name(), atom.catom)
+            return hp.bindings_add_var_binding(self.cbindings, var.get_name(), atom.catom)
         else:
-            return hp.bindings_add_var_bindings(self.cbindings, var, atom.catom)
+            return hp.bindings_add_var_binding(self.cbindings, var, atom.catom)
 
     def is_empty(self) -> bool:
         return hp.bindings_is_empty(self.cbindings)
@@ -347,9 +347,12 @@ class BindingsSet:
         self.shadow_list = None
         hp.bindings_set_push(self.c_set, bindings.cbindings)
 
-    def add_var_binding(self, var: Atom, value: Atom) -> bool:
+    def add_var_binding(self, var: Union[str, Atom], value: Atom) -> bool:
         self.shadow_list = None
-        return hp.bindings_set_add_var_binding(self.c_set, var.catom, value.catom)
+        if isinstance(var, Atom):
+            return hp.bindings_set_add_var_binding(self.c_set, var.catom, value.catom)
+        else:
+            return hp.bindings_set_add_var_binding(self.c_set, V(var), value.catom)
 
     def add_var_equality(self, a: Atom, b: Atom) -> bool:
         self.shadow_list = None

--- a/python/tests/test_bindings.py
+++ b/python/tests/test_bindings.py
@@ -9,8 +9,8 @@ class BindingsTest(unittest.TestCase):
         self.emptyBindings = Bindings()
 
         self.bindings = Bindings()
-        self.bindings.add_var_bindings("a", S("b"))
-        self.bindings.add_var_bindings("x", S("y"))
+        self.bindings.add_var_binding("a", S("b"))
+        self.bindings.add_var_binding("x", S("y"))
 
 
     def tearDown(self) -> None:
@@ -24,8 +24,8 @@ class BindingsTest(unittest.TestCase):
 
         # uncomment this and assert on line 22 fails
         #self.assertEqual(hp.bindings_to_str(bindings), "{  }")
-        hp.bindings_add_var_bindings(bindings, "a", hp.atom_sym("b"))
-        hp.bindings_add_var_bindings(bindings, "x", hp.atom_sym("y"))
+        hp.bindings_add_var_binding(bindings, "a", hp.atom_sym("b"))
+        hp.bindings_add_var_binding(bindings, "x", hp.atom_sym("y"))
 
         bindings_as_str = hp.bindings_to_str(bindings)
 
@@ -109,7 +109,7 @@ class BindingsTest(unittest.TestCase):
         self.assertTrue(empty_set.is_empty())
 
         new_bindings = Bindings();
-        new_bindings.add_var_bindings(V("a"), S("A"))
+        new_bindings.add_var_binding(V("a"), S("A"))
         empty_set.push(new_bindings);
         no_longer_empty_set = empty_set;
 
@@ -123,7 +123,7 @@ class BindingsTest(unittest.TestCase):
         self.assertEqual(set, no_longer_empty_set);        
 
         new_bindings = Bindings();
-        new_bindings.add_var_bindings(V("a"), S("A"))
+        new_bindings.add_var_binding(V("a"), S("A"))
         set_2 = BindingsSet(new_bindings);
         self.assertEqual(set, set_2)
 
@@ -141,16 +141,16 @@ class BindingsTest(unittest.TestCase):
         self.assertEqual(1, bindings_counter)
 
         new_bindings = Bindings();
-        new_bindings.add_var_bindings(V("b"), S("B"))
+        new_bindings.add_var_binding(V("b"), S("B"))
         set.merge_into(new_bindings);
 
         new_bindings = Bindings();
-        new_bindings.add_var_bindings(V("c"), S("C"))
+        new_bindings.add_var_binding(V("c"), S("C"))
         new_set = BindingsSet(new_bindings);
         set.merge_into(new_set);
 
         new_bindings = Bindings();
-        new_bindings.add_var_bindings(V("d"), S("D"))
+        new_bindings.add_var_binding(V("d"), S("D"))
         for existing_bindings in set.iterator():
             new_set = new_bindings.merge_v2(existing_bindings);
         


### PR DESCRIPTION
Changes:

- Removing var_atom_t from the C API because it’s confusing
- Changing semantics of `c_var_binding_callback_t` (formerly `c_var_atom_callback_t`) so that the callback isn’t responsible for freeing atoms
- Renaming Python Bindings::add_var_bindings method to Bindings::add_var_binding, to be accurate and consistent with BindingsSet
- Adding convenience for BindingsSet::add_var_binding method to allow passing var atoms as strings

See https://github.com/trueagi-io/hyperon-experimental/issues/347