### PR TITLE
Fix Python searching procedure for CMake less than 3.18

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -18,7 +18,12 @@ if (${CMAKE_VERSION} GREATER_EQUAL "3.12")
     if (NOT DEFINED Python3_FIND_VIRTUALENV)
         set(Python3_FIND_VIRTUALENV "ONLY")
     endif()
-    find_package(Python3 3.7 REQUIRED COMPONENTS Interpreter Development.Module)
+    if (${CMAKE_VERSION} GREATER_EQUAL "3.18")
+        # Development.Embed is not supported by cibuildwheel environment
+        find_package(Python3 3.7 REQUIRED COMPONENTS Interpreter Development.Module)
+    else()
+        find_package(Python3 3.7 REQUIRED COMPONENTS Interpreter Development)
+    endif()
 else() # support Ubuntu 18.04
     # pybind11 config looks for Python path again when deprecated PythonInterp
     # and PythonLibs packages are used. It should find the same version though


### PR DESCRIPTION
Select correct list of modules to search for CMake versions less than 3.18. `Development.Module` is supported from 3.18, on the other hand `Development` cannot be used for versions 3.18 and greater because it implies `Development.Embed` which in turn is absent in `cibuildwheel` environment.