### PR TITLE
Add initial minimal MeTTa implementation

### DIFF
--- a/doc/minimal-metta.md
+++ b/doc/minimal-metta.md
@@ -1,0 +1,289 @@
+This document describes the minimal set of embedded MeTTa instructions which is
+enough to write the complete MeTTa interpreter in MeTTa. Current version of the
+document includes improvements which were added after experimenting with the
+first version of such an interpreter. It is not a final version and some
+directions of the future work is explained at the end of the document.
+
+# Minimal instruction set
+
+## Interpreter state
+
+The MeTTa interpreter interprets an atom passed as an input. It interprets it
+step by step on each step executing the single instruction. In order to do that
+the interpreter needs a context which is wider than the atom itself. The
+context also includes (see Explicit atomspace variable bindings):
+- an atomspace which contains the knowledge which drives the evaluation of the
+  expressions;
+- bindings of the variables which are used to evaluate expressions; the
+  bindings are empty at the beginning.
+
+Each step of interpretation inputs and outputs a list of pairs (`<atom>`,
+`<bindings>`) which is called an interpretation plan. Each pair in the plan
+represents one possible way of interpreting the original atom or possible
+branch of the evaluation. Interpreter doesn't select one of them for further
+processing. It continues interpreting all of the branches in parallel. This is
+what is called non-deterministic evaluation.
+
+One step of the interpretation is an execution of a single instruction from a
+plan. An interpreter removes the atom from the plan, executes it and adds the
+results back to the plan. Here we suppose that on the top level the plan
+contains only the instructions from the minimal set. It is not necessary but it
+allowed developing the first stable version with less effort (see `eval` and
+`Return`). If an instruction returns the atom which is not from the minimal set
+it is not interpreted further and returned as a part of the final result.
+
+## Error/Empty
+
+There are atoms which can be returned to designate a special situation in a code:
+- `(Error <atom> <message>)` means the interpretation is finished with error;
+- `Empty` means the corresponding branch of the evaluation returned no results,
+  such result is not returned among other results when interpreting is
+  finished.
+
+Both these atoms are not interpreted further as they are not a part of the
+minimal set of instructions.
+
+## eval
+
+`(eval <atom>)` is a first instruction which evaluates an atom passed as an
+argument. Evaluation is different for the grounded function calls (the
+expression with a grounded atom on a first position) and pure MeTTa
+expressions. For the pure MeTTa expression the interpreter searches the `(=
+<atom> <var>)` expression in the atomspace. The found values of the `<var>` are
+the result of evaluation. Execution of the grounded atom leads to the call of
+the foreign function passing the tail of the expression as arguments. For
+example `(+ 1 2)` calls the implementation of addition with `1` and `2` as
+arguments.  The list of atoms returned by the grounded function is a result of
+the evaluation in this case. A grounded function can have side effects as well.
+In both cases bindings of the `eval`'s argument are merged to the bindings of
+the result.
+
+Atomspace search can bring the list of results which can be empty. When search
+returns no results then `Empty` atom is a result of the instruction. Grounded
+function can return a list of atoms, empty result, `Error(<message>)` or
+`NoReduce` result. The result of the instruction for a special values are the
+following:
+- empty result returns `Empty` atom;
+- `Error(<message>)` returns `(Error <original-atom> <message>)` atom;
+- `NoReduce` returns `<original-atom>` atom which is not evaluated further
+  because it is not an operation from the minimal set.
+
+## chain
+
+A function call with a sub-expression as an argument can be interpreted using
+two different orders. The interpreter can evaluate the whole expression or
+evaluate the argument first and then insert the result into the original
+expression. The proper order of interpretation can depend on the type of the
+function.
+
+`chain` instruction allows a programmer to control the order of the evaluation
+and interpret the subexpression first. It has a form `(chain <atom> <var>
+<template>)` and executed differently depending on what kind of `<atom>` is passed
+as a first argument:
+- if `<atom>` is an instruction from the minimal set then chain executes it and
+  returns `(chain <execution-result> <var> <template>)`; bindings of the <atom>
+  are merged to the bindings of the result;
+- it substitutes all occurrences of `<var>` in `<template>` by the `<atom>`
+  otherwise.  When execution of the `<atom>` brings more than a single result
+  `chain` returns one `(chain ...)` expression for each result. `chain` can be
+  nested in such a case only the most nested `chain` instruction is executed
+  during the interpretation step.
+
+## match
+
+Conditioning on the results can be done using `match` operation `(match <atom>
+<pattern> <then> <else>)`. This operation matches `<atom>` with a `<pattern>`. If
+match is successful then it returns `<then>` atom and merges bindings of the
+original `<atom>` to resulting variable bindings. If matching is not successful
+then it returns the `<else>` branch with the original variable bindings.
+
+## cons/decons
+
+Last pair of operations are `cons` and `decons` to construct and deconstruct
+the expression atom from/to head and tail. `(decons <expr>)` returns:
+- `()` when `<expr>` is empty;
+- `(<head> <tail>)` when `<expr>` is not empty.
+
+`(cons <head> <tail>)` returns an expression where the first sub-atom is
+`<head>` and others are copied from `<tail>`.
+
+# Examples
+
+Examples of the programs written using minimal MeTTa interpreter:
+
+Switch implementation:
+
+```metta
+(= (switch $atom $cases)
+  (chain (decons $cases) $list (eval (switch-internal $atom $list))))
+(= (switch-internal $atom (($pattern $template) $tail))
+  (match $atom $pattern $template (eval (switch $atom $tail))))
+```
+
+Reduce in loop until result is calculated:
+
+```metta
+(= (subst $atom $var $templ)
+  (match $atom $var $templ
+    (Error (subst $atom $var $templ)
+      \"subst expects a variable as a second argument\") ))
+
+(= (reduce $atom $var $templ)
+  (chain (eval $atom) $res
+    (match $res (Error $a $m)
+      (Error $a $m)
+      (match $res Empty
+        (eval (subst $atom $var $templ))
+        (eval (reduce $res $var $templ)) ))))
+```
+
+[Link](https://github.com/vsbogd/hyperon-experimental/blob/f64bf92edf632a538aa6277b6048dbd418924435/lib/src/metta/runner/stdlib.rs#L1199-L1263)
+to the full code of the interpreter in MeTTa (not finished yet).
+
+# Properties
+
+## Turing completeness
+
+The following program implements a Turing machine using the minimal MeTTa
+instruction set (the full code of the example can be found
+[here](https://github.com/vsbogd/hyperon-experimental/blob/f64bf92edf632a538aa6277b6048dbd418924435/lib/src/metta/interpreter2.rs#L526-L566)):
+
+```metta
+           (= (tm $rule $state $tape)
+              (match $state HALT
+                $tape
+                (chain (eval (read $tape)) $char
+                  (chain (eval ($rule $state $char)) $res
+                    (match $res ($next-state $next-char $dir)
+                      (chain (eval (move $tape $next-char $dir)) $next-tape
+                        (eval (tm $rule $next-state $next-tape)) )
+                      (Error (tm $rule $state $tape) \"Incorrect state\") )))))
+
+            (= (read ($head $hole $tail)) $hole)
+
+            (= (move ($head $hole $tail) $char N) ($head $char $tail))
+            (= (move ($head $hole $tail) $char L)
+              (chain (cons $char $head) $next-head
+                (chain (decons $tail) $list
+                  (match $list ($next-hole $next-tail)
+                    ($next-head $next-hole $next-tail)
+                    ($next-head 0 ()) ))))
+            (= (move ($head $hole $tail) $char R)
+              (chain (cons $char $tail) $next-tail
+                (chain (decons $head) $list
+                  (match $list ($next-hole $next-head)
+                    ($next-head $next-hole $next-tail)
+                    (() 0 $next-tail) ))))
+```
+
+## Comparison with MeTTa Operational Semantics
+
+One difference from MOPS [1] is that the minimal instruction set allows
+relatively easy write deterministic programs and non-determinism is injected
+only via matching and evaluation. `Query` and `Chain` from MOPS are very
+similar to `eval`. `Transform` is very similar to `match`. `chain` has no
+analogue in MOPS, it is used to make deterministic computations.
+`cons`/`decons` to some extent are analogues of `AtomAdd`/`AtomRemove` in a
+sense that they can be used to change the state.
+
+## eval or return
+
+Using `eval` to designate evaluation of the atom seems too verbose. But we need
+to give a programmer some way to designate whether the atom should be evaluated
+or not. `eval` marks atoms which should be evaluated. As an alternative to this
+solution we could mark atoms which should not be evaluated.
+
+For example we could use a special instruction `(return <atom>)` which
+basically does nothing. When `return` is on the top level of the interpretation
+plan then the interpreter puts `<atom>` into the list of the final results. Other
+atoms on the top of the plan are evaluated. `chain` should be changed to have
+the same semantics: evaluate any atom except `(return ...)` and insert the `(return
+...)` into the template.
+
+The version of the `reduce` written using `return` will look like the following:
+```metta
+(= (reduce $atom $var $templ)
+  (chain $atom $res
+    (match $res (return (Error $a $m))
+      (return (Error $a $m))
+      (match $res (return Empty)
+        (subst $atom $var $templ)
+        (match $res (return $val)
+          (subst $val $var $templ)
+          (reduce $res $var $templ) )))))
+```
+
+This version has one more interesting property: a programmer can use `(return
+<atom>)` to designate that the process of reducing should be finished. Otherwise
+the reduction stops only when an atom cannot be evaluated further. Thus the
+`return` idea can also be used in the MeTTa interpreter to control an execution
+and improve performance.
+
+We could also implement `chain` which removes `return` and inserts `<atom>`
+into the template. It can make program even more compact:
+```metta
+(= (reduce $atom $var $templ)
+  (chain $atom $res
+    (match $res (Error $a $m)
+      (Error $a $m)
+      (match $res Empty
+        (subst $atom $var $templ)
+        (reduce $res $var $templ) ))))
+```
+
+But in such a case there is a risk of getting `(chain (return <atom>) $x $x)`
+which continues evaluation of the `<atom>` further while it is not expected.
+
+The final convention can be chosen from a usability perspective. Although it
+may seem that eliminating `eval` is the most convenient solution, it is not
+obvious. `eval` is a kind of `call` in assembly language and writing it
+explicitly makes the author think about whether the atom can be called.
+
+## Partial and complete functions
+
+Each instruction in a minimal instruction set is a complete function.
+Nevertheless `Empty` allows defining partial functions in MeTTa. For example
+partial `if` can be defined as follows:
+```metta
+(= (if $condition $then) (match $condition True $then Empty))
+```
+
+# Future work
+
+## Explicit atomspace variable bindings
+
+Current implementation implicitly keeps and applies variable bindings during
+the process of the interpretation. It can be easily made explicit but the value
+of explicit bindings is not obvious see [discussion in issue
+#290](https://github.com/trueagi-io/hyperon-experimental/issues/290#issuecomment-1541314289).
+
+Making atomspace out of implicit context could make import semantics more
+straightforward. In the current implementation of the minimal instruction set
+it was needed to explicitly pass the atomspace to the interpreter because
+otherwise grounded `get-type` function didn't work properly.It also could allow
+defining `eval` via `match` which minimizes the number of instructions and
+allows defining `eval` in a MeTTa program itself. Which in turn allows defining
+different versions of `eval` to program different kinds of chaining.
+Nevertheless defining `eval` through `match` requires rework of the grounded
+functions interface to allow calling them by executing `match` instructions.
+Which is an interesting direction to follow.
+
+## Scope of variables
+
+Scope of the variable inside instructions is not described in this
+specification. It is a clear gap and one of the todo items.
+
+## Collapse
+
+The described language allows transforming the atom into a non-deterministic
+result using `eval`, but there is no reversed instruction. As a consequence one
+cannot implement `collapse` using the instruction set above. In order to add
+such possibility the additional instruction is needed. It could mark a set of
+results as joined and when their evaluation is finished would assemble them
+into an expression.
+
+# Links
+
+1. Lucius Gregory Meredith, Ben Goertzel, Jonathan Warrell, and Adam
+   Vandervorst. Meta-MeTTa: an operational semantics for MeTTa.
+   [https://raw.githubusercontent.com/leithaus/rho4u/main/ai/mops/mops.pdf](https://raw.githubusercontent.com/leithaus/rho4u/main/ai/mops/mops.pdf)

--- a/lib/src/metta/interpreter2.rs
+++ b/lib/src/metta/interpreter2.rs
@@ -680,7 +680,7 @@ mod tests {
             expr!("->" "&str" "Error")
         }
         fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-            Err(args[0].as_gnd::<&str>().unwrap().deref().into())
+            Err((*args[0].as_gnd::<&str>().unwrap()).into())
         }
         fn match_(&self, other: &Atom) -> matcher::MatchResultIter {
             match_by_equality(self, other)

--- a/lib/src/metta/interpreter2.rs
+++ b/lib/src/metta/interpreter2.rs
@@ -294,6 +294,9 @@ fn eval<'a, T: SpaceRef<'a>>(space: T, atom: Atom, bindings: Bindings) -> Vec<In
                 },
                 Err(ExecError::Runtime(err)) =>
                     vec![InterpretedAtom(error_atom(atom, err), bindings)],
+                // TODO: NoReduce should also be available for processing
+                // on MeTTa code level, to allow override code behavior in
+                // case when grounded expression cannot be reduced.
                 Err(ExecError::NoReduce) =>
                     vec![InterpretedAtom(return_atom(atom), bindings)],
             }

--- a/lib/src/metta/interpreter2.rs
+++ b/lib/src/metta/interpreter2.rs
@@ -350,6 +350,11 @@ fn chain<'a, T: SpaceRef<'a>>(space: T, bindings: Bindings, nested: &Atom, var: 
 }
 
 fn match_(bindings: Bindings, atom: &Atom, pattern: &Atom, then: &Atom, else_: &Atom) -> Vec<InterpretedAtom> {
+    // TODO: Should match_() be symmetrical or not. While it is symmetrical then
+    // if variable is matched by variable then both variables have the same
+    // priority. Thus interpreter can use any of them further. This sometimes
+    // looks unexpected. For example see `metta_car` unit test where variable
+    // from car's argument is replaced.
     let matches: Vec<Bindings> = match_atoms(atom, pattern).collect();
     if matches.is_empty() {
         let result = apply_bindings_to_atom(else_, &bindings);

--- a/lib/src/metta/interpreter2.rs
+++ b/lib/src/metta/interpreter2.rs
@@ -228,7 +228,7 @@ fn interpret_atom_root<'a, T: SpaceRef<'a>>(space: T, interpreted_atom: Interpre
         },
         Some([op, args @ ..]) if *op == DECONS_SYMBOL => {
             match args {
-                [Atom::Expression(_tail)] => {
+                [Atom::Expression(tail)] if tail.children().len() > 0 => {
                     match atom_into_array(atom) {
                         Some([_, Atom::Expression(expr)]) => decons(bindings, expr),
                         _ => panic!("Unexpected state"),
@@ -581,7 +581,7 @@ mod tests {
     #[test]
     fn interpret_atom_decons_empty() {
         let result = interpret_atom(&space(""), atom("(decons ())", bind!{}));
-        assert_eq!(result, vec![atom("()", bind!{})]);
+        assert_eq!(result, vec![InterpretedAtom(expr!("Error" ("decons" ()) "expected: (decons (: <expr> Expression)), found: (decons ())"), bind!{})]);
     }
 
     #[test]

--- a/lib/src/metta/interpreter2.rs
+++ b/lib/src/metta/interpreter2.rs
@@ -1,0 +1,606 @@
+//! MeTTa assembly language implementation.
+//!
+//! # Algorithm
+//!
+//! FIXME: explain an algorithm
+
+use crate::*;
+use crate::atom::matcher::*;
+use crate::space::*;
+use crate::space::grounding::*;
+use crate::metta::*;
+
+use std::ops::Deref;
+use std::rc::Rc;
+use std::fmt::{Debug, Display, Formatter};
+use std::convert::TryFrom;
+
+/// Result of atom interpretation plus variable bindings found
+#[derive(Clone, PartialEq)]
+pub struct InterpretedAtom(Atom, Bindings);
+
+impl Display for InterpretedAtom {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        if self.1.is_empty() {
+            write!(f, "{}", self.0)
+        } else {
+            // TODO: it is possible to cleanup all bindings for nested
+            // expressions which were introduced by matching when all
+            // sub-expressions are interpreted. This will simplify
+            // textual representation. For example in test_air_humidity_regulator
+            // (make air wet) leads to (start kettle), {$y: kettle}) result
+            // but $y is not present in the expression after interpreting
+            // (make air wet) and can be removed.
+            write!(f, "{}|{}", self.0, self.1)
+        }
+    }
+}
+
+impl Debug for InterpretedAtom {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+use std::marker::PhantomData;
+
+pub trait SpaceRef<'a> : Space + 'a {}
+impl<'a, T: Space + 'a> SpaceRef<'a> for T {}
+
+struct InterpreterContext<'a, T: SpaceRef<'a>> {
+    space: T,
+    phantom: PhantomData<&'a GroundingSpace>,
+}
+
+struct InterpreterContextRef<'a, T: SpaceRef<'a>>(Rc<InterpreterContext<'a, T>>);
+
+impl<'a, T: SpaceRef<'a>> InterpreterContextRef<'a, T> {
+    fn new(space: T) -> Self {
+        Self(Rc::new(InterpreterContext{ space, phantom: PhantomData }))
+    }
+}
+
+impl<'a, T: SpaceRef<'a>> Deref for InterpreterContextRef<'a, T> {
+    type Target = InterpreterContext<'a, T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'a, T: SpaceRef<'a>> Clone for InterpreterContextRef<'a, T> {
+    fn clone(&self) -> Self {
+        Self(Rc::clone(&self.0))
+    }
+}
+
+pub struct InterpreterState<'a, T: SpaceRef<'a>> {
+    plan: Vec<InterpretedAtom>,
+    finished: Vec<Atom>,
+    context: InterpreterContextRef<'a, T>,
+}
+
+fn atom_as_slice(atom: &Atom) -> Option<&[Atom]> {
+    <&[Atom]>::try_from(atom).ok()
+}
+
+// FIXME: return incorrect length as error_atom() from caller
+fn atom_into_array<const N: usize>(atom: Atom) -> Option<[Atom; N]> {
+    <[Atom; N]>::try_from(atom).ok()
+}
+
+impl<'a, T: SpaceRef<'a>> InterpreterState<'a, T> {
+
+    fn has_next(&self) -> bool {
+        !self.plan.is_empty()
+    }
+
+    fn into_result(self) -> Result<Vec<Atom>, String> {
+        if self.has_next() {
+            Err("Evaluation is not finished".into())
+        } else {
+            Ok(self.finished)
+        }
+    }
+
+    fn pop(&mut self) -> Option<InterpretedAtom> {
+        self.plan.pop()
+    }
+
+    fn push(&mut self, atom: InterpretedAtom) {
+        if is_embedded_op(&atom.0) {
+            self.plan.push(atom);
+        } else {
+            let InterpretedAtom(atom, _bindings) = atom;
+            if atom != EMPTY_SYMBOL {
+                self.finished.push(atom);
+            }
+        }
+    }
+}
+
+impl<'a, T: SpaceRef<'a>> std::fmt::Display for InterpreterState<'a, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:?}\n", self.plan)
+    }
+}
+
+
+/// Initialize interpreter and returns the result of the zero step.
+/// It can be error, immediate result or interpretation plan to be executed.
+/// See [crate::metta::interpreter] for algorithm explanation.
+///
+/// # Arguments
+/// * `space` - atomspace to query for interpretation
+/// * `expr` - atom to interpret
+pub fn interpret_init<'a, T: Space + 'a>(space: T, expr: &Atom) -> InterpreterState<'a, T> {
+    let context = InterpreterContextRef::new(space);
+    InterpreterState {
+        plan: vec![InterpretedAtom(expr.clone(), Bindings::new())],
+        finished: vec![],
+        context
+    }
+}
+
+/// Perform next step of the interpretation plan and return the result. Panics
+/// when [StepResult::Return] or [StepResult::Error] are passed as input.
+/// See [crate::metta::interpreter] for algorithm explanation.
+///
+/// # Arguments
+/// * `step` - [StepResult::Execute] result from the previous step.
+pub fn interpret_step<'a, T: Space + 'a>(mut state: InterpreterState<'a, T>) -> InterpreterState<'a, T> {
+    let interpreted_atom = state.pop().unwrap();
+    log::debug!("interpret_step: {:?}", interpreted_atom);
+    for result in interpret_atom(&state.context.space, interpreted_atom) {
+        state.push(result);
+    }
+    state
+}
+
+/// Interpret passed atom and return a new plan, result or error. This function
+/// blocks until result is calculated. For step by step interpretation one
+/// should use [interpret_init] and [interpret_step] functions.
+/// # Arguments
+/// * `space` - atomspace to query for interpretation
+/// * `expr` - atom to interpret
+pub fn interpret<T: Space>(space: T, expr: &Atom) -> Result<Vec<Atom>, String> {
+    let mut state = interpret_init(space, expr);
+    while state.has_next() {
+        state = interpret_step(state);
+    }
+    state.into_result()
+}
+
+fn is_embedded_op(atom: &Atom) -> bool {
+    let expr = atom_as_slice(&atom);
+    match expr {
+        Some([op, ..]) => *op == EVAL_SYMBOL
+            || *op == CHAIN_SYMBOL
+            || *op == MATCH_SYMBOL
+            || *op == CONS_SYMBOL
+            || *op == DECONS_SYMBOL,
+        _ => false,
+    }
+}
+
+fn interpret_atom<'a, T: SpaceRef<'a>>(space: T, interpreted_atom: InterpretedAtom) -> Vec<InterpretedAtom> {
+    let InterpretedAtom(atom, bindings) = interpreted_atom;
+    let expr = atom_as_slice(&atom);
+    match expr {
+        Some([op, ..]) if *op == EVAL_SYMBOL => {
+            let [_, atom]: [Atom; 2] = atom_into_array(atom.clone()).unwrap();
+            evaluate_atom(space, atom, bindings)
+        },
+        Some([op, ..]) if *op == CHAIN_SYMBOL => {
+            let [_, nested, var, templ]: [Atom; 4] = atom_into_array(atom.clone()).unwrap();
+            if is_embedded_op(&nested) {
+                let result = interpret_atom(space, InterpretedAtom(nested, bindings.clone()));
+                result.into_iter()
+                    .flat_map(|InterpretedAtom(r, b)| {
+                        let var = var.clone();
+                        let templ = templ.clone();
+                        b.merge_v2(&bindings)
+                            .into_iter()
+                            .map(move |bindings| {
+                                // TODO: we could eliminate bindings application here
+                                // and below after pretty print for debug is ready,
+                                // before that it is difficult to look at the plans
+                                // with the variables and bindings separated.
+                                let result = apply_bindings_to_atom(&r, &bindings);
+                                InterpretedAtom(Atom::expr([CHAIN_SYMBOL, result, var.clone(), templ.clone()]), bindings)
+                            })
+                    })
+                .collect()
+            } else {
+                let var = VariableAtom::try_from(var).unwrap();
+                let b = Bindings::new().add_var_binding_v2(&var, nested).unwrap();
+                let result = apply_bindings_to_atom(&templ, &b);
+                vec![InterpretedAtom(result, bindings)]
+            }
+        },
+        Some([op, ..]) if *op == MATCH_SYMBOL => {
+            let [_, atom, pattern, then, else_]: [Atom; 5] = atom_into_array(atom).unwrap();
+            let matches: Vec<Bindings> = match_atoms(&atom, &pattern).collect();
+            if matches.is_empty() {
+                let result = apply_bindings_to_atom(&else_, &bindings);
+                vec![InterpretedAtom(result, bindings)]
+            } else {
+                matches.into_iter()
+                    .flat_map(|b| {
+                        b.merge_v2(&bindings).into_iter()
+                            .map(|b| {
+                                let then = apply_bindings_to_atom(&then, &b);
+                                InterpretedAtom(then.clone(), b)
+                            })
+                    })
+                .collect()
+            }
+        },
+        Some([op, ..]) if *op == DECONS_SYMBOL => {
+            // FIXME: add a macros to check the types of the arguments and return array of args.
+            // If check is performed before deconstruction then cloning should not be needed.
+            let [_, expr]: [Atom; 2] = atom_into_array(atom.clone()).unwrap();
+            let result = match atom_as_slice(&expr) {
+                Some([]) => InterpretedAtom(Atom::expr([]), bindings),
+                Some([_, ..]) => {
+                    let mut children = ExpressionAtom::try_from(expr).unwrap().into_children();
+                    let head = children.remove(0);
+                    let tail = children;
+                    InterpretedAtom(Atom::expr([head, Atom::expr(tail)]), bindings)
+                },
+                None => {
+                    InterpretedAtom(error_atom(atom, "decons expects an ExpressionAtom as an argument".into()), bindings)
+                },
+            };
+            vec![result]
+        },
+        Some([op, ..]) if *op == CONS_SYMBOL => {
+            let [_, head, tail]: [Atom; 3] = atom_into_array(atom.clone()).unwrap();
+            let mut children = vec![head];
+            children.extend(ExpressionAtom::try_from(tail).unwrap().into_children());
+            vec![InterpretedAtom(Atom::expr(children), bindings)]
+        },
+        _ => {
+            vec![InterpretedAtom(return_atom(atom), bindings)]
+        },
+    }
+}
+
+fn return_empty() -> Atom {
+    EMPTY_SYMBOL
+}
+
+fn error_atom(atom: Atom, err: String) -> Atom {
+    Atom::expr([Atom::sym("Error"), atom, Atom::sym(err)])
+}
+
+fn return_atom(atom: Atom) -> Atom {
+    atom
+}
+
+fn evaluate_atom<'a, T: SpaceRef<'a>>(space: T, atom: Atom, bindings: Bindings) -> Vec<InterpretedAtom> {
+    match atom_as_slice(&atom) {
+        Some([Atom::Grounded(op), args @ ..]) => {
+            match op.execute(args) {
+                Ok(results) => {
+                    if results.is_empty() {
+                        vec![InterpretedAtom(return_empty(), bindings)]
+                    } else {
+                        results.into_iter()
+                            .map(|atom| InterpretedAtom(atom, bindings.clone()))
+                            .collect()
+                    }
+                },
+                Err(ExecError::Runtime(err)) =>
+                    vec![InterpretedAtom(error_atom(atom, err), bindings)],
+                Err(ExecError::NoReduce) =>
+                    vec![InterpretedAtom(return_atom(atom), bindings)],
+            }
+        },
+        _ => query_atom(space, atom, bindings),
+    }
+}
+
+fn query_atom<'a, T: SpaceRef<'a>>(space: T, atom: Atom, bindings: Bindings) -> Vec<InterpretedAtom> {
+    let var = VariableAtom::new("X").make_unique();
+    let query = Atom::expr([EQUAL_SYMBOL, atom, Atom::Variable(var.clone())]);
+    let results = space.query(&query);
+    if results.is_empty() {
+        vec![InterpretedAtom(return_empty(), bindings)]
+    } else {
+        results.into_iter()
+            .flat_map(|mut b| {
+                let atom = b.resolve_and_remove(&var).unwrap();
+                let bindings = b.merge_v2(&bindings);
+                bindings.into_iter().map(move |b| (atom.clone(), b))
+            })
+        .map(|(atom, bindings)| {
+            let atom = apply_bindings_to_atom(&atom, &bindings);
+            InterpretedAtom(atom, bindings)
+        })
+        .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn interpret_atom_evaluate_atom() {
+        let result = interpret_atom(&space("(= a b)"), atom("(eval a)", bind!{}));
+        assert_eq!(result, vec![atom("b", bind!{})]);
+    }
+
+    #[test]
+    fn interpret_atom_evaluate_atom_no_definition() {
+        let result = interpret_atom(&space(""), atom("(eval a)", bind!{}));
+        assert_eq!(result, vec![atom("Empty", bind!{})]);
+    }
+
+    #[test]
+    fn interpret_atom_evaluate_empty_expression() {
+        let result = interpret_atom(&space(""), atom("(eval ())", bind!{}));
+        assert_eq!(result, vec![atom("Empty", bind!{})]);
+    }
+
+    #[test]
+    fn interpret_atom_evaluate_grounded_value() {
+        let result = interpret_atom(&space(""), InterpretedAtom(expr!("eval" {6}), bind!{}));
+        assert_eq!(result, vec![atom("Empty", bind!{})]);
+    }
+
+
+    #[test]
+    fn interpret_atom_evaluate_pure_expression() {
+        let space = space("(= (foo $a B) $a)");
+        let result = interpret_atom(&space, atom("(eval (foo A $b))", bind!{}));
+        assert_eq!(result, vec![atom("A", bind!{b: expr!("B")})]);
+    }
+
+    #[test]
+    fn interpret_atom_evaluate_pure_expression_non_determinism() {
+        let space = space("
+            (= color red)
+            (= color green)
+            (= color blue)
+        ");
+        let result = interpret_atom(&space, atom("(eval color)", bind!{}));
+        assert_eq_no_order!(result, vec![
+            atom("red", bind!{}),
+            atom("green", bind!{}),
+            atom("blue", bind!{})
+        ]);
+    }
+
+    #[test]
+    fn interpret_atom_evaluate_pure_expression_no_definition() {
+        let result = interpret_atom(&space(""), atom("(eval (foo A))", bind!{}));
+        assert_eq!(result, vec![atom("Empty", bind!{})]);
+    }
+
+    #[test]
+    fn interpret_atom_evaluate_pure_expression_variable_name_conflict() {
+        let space = space("(= (foo ($W)) True)");
+        let result = interpret_atom(&space, atom("(eval (foo $W))", bind!{}));
+        assert_eq!(result[0].0, sym!("True"));
+    }
+
+
+    #[test]
+    fn interpret_atom_evaluate_grounded_expression() {
+        let result = interpret_atom(&space(""), InterpretedAtom(expr!("eval" ({MulXUndefinedType(7)} {6})), bind!{}));
+        assert_eq!(result, vec![InterpretedAtom(expr!({42}), bind!{})]);
+    }
+
+    #[test]
+    fn interpret_atom_evaluate_grounded_expression_empty() {
+        let result = interpret_atom(&space(""), InterpretedAtom(expr!("eval" ({ReturnNothing()} {6})), bind!{}));
+        assert_eq!(result, vec![atom("Empty", bind!{})]);
+    }
+
+    #[test]
+    fn interpret_atom_evaluate_grounded_expression_noreduce() {
+        let result = interpret_atom(&space(""), InterpretedAtom(expr!({NonReducible()} {6}), bind!{}));
+        assert_eq!(result, vec![InterpretedAtom(expr!({NonReducible()} {6}), bind!{})]);
+    }
+
+    #[test]
+    fn interpret_atom_evaluate_grounded_expression_error() {
+        let result = interpret_atom(&space(""), InterpretedAtom(expr!("eval" ({ThrowError()} {"Test error"})), bind!{}));
+        assert_eq!(result, vec![InterpretedAtom(expr!("Error" ({ThrowError()} {"Test error"}) "Test error"), bind!{})]);
+    }
+
+
+    #[test]
+    fn interpret_atom_chain_atom() {
+        let result = interpret_atom(&space(""), InterpretedAtom(expr!("chain" ("A" () {6} y) x ("bar" x)), bind!{}));
+        assert_eq!(result, vec![InterpretedAtom(expr!("bar" ("A" () {6} y)), bind!{})]);
+    }
+
+
+    #[test]
+    fn interpret_atom_chain_evaluation() {
+        let space = space("(= (foo $a B) $a)");
+        let result = interpret_atom(&space, atom("(chain (eval (foo A $b)) $x (bar $x))", bind!{}));
+        assert_eq!(result, vec![atom("(chain A $x (bar $x))", bind!{b: expr!("B")})]);
+    }
+
+    #[test]
+    fn interpret_atom_chain_nested_evaluation() {
+        let space = space("(= (foo $a B) $a)");
+        let result = interpret_atom(&space, atom("(chain (chain (eval (foo A $b)) $x (bar $x)) $y (baz $y))", bind!{}));
+        assert_eq!(result, vec![atom("(chain (chain A $x (bar $x)) $y (baz $y))", bind!{b: expr!("B")})]);
+    }
+
+    #[test]
+    fn interpret_atom_chain_nested_value() {
+        let result = interpret_atom(&space(""), atom("(chain (chain A $x (bar $x)) $y (baz $y))", bind!{}));
+        assert_eq!(result, vec![atom("(chain (bar A) $y (baz $y))", bind!{})]);
+    }
+
+    #[test]
+    fn interpret_atom_chain_expression_non_determinism() {
+        let space = space("
+            (= (color) red)
+            (= (color) green)
+            (= (color) blue)
+        ");
+        let result = interpret_atom(&space, atom("(chain (eval (color)) $x (bar $x))", bind!{}));
+        assert_eq_no_order!(result, vec![
+            atom("(chain red $x (bar $x))", bind!{}),
+            atom("(chain green $x (bar $x))", bind!{}),
+            atom("(chain blue $x (bar $x))", bind!{})
+        ]);
+    }
+
+    #[test]
+    fn interpret_atom_chain_return() {
+        let result = interpret_atom(&space(""), atom("(chain Empty $x (bar $x))", bind!{}));
+        assert_eq!(result, vec![atom("(bar Empty)", bind!{})]);
+    }
+
+
+    #[test]
+    fn interpret_atom_match_then() {
+        let result = interpret_atom(&space(""), atom("(match (A $b) ($a B) ($a $b) Empty)", bind!{}));
+        assert_eq!(result, vec![atom("(A B)", bind!{a: expr!("A"), b: expr!("B")})]);
+    }
+
+    #[test]
+    fn interpret_atom_match_else() {
+        let result = interpret_atom(&space(""), atom("(match (A $b C) ($a B D) ($a $b) Empty)", bind!{}));
+        assert_eq!(result, vec![atom("Empty", bind!{})]);
+    }
+
+
+    #[test]
+    fn interpret_atom_decons_empty() {
+        let result = interpret_atom(&space(""), atom("(decons ())", bind!{}));
+        assert_eq!(result, vec![atom("()", bind!{})]);
+    }
+
+    #[test]
+    fn interpret_atom_decons_single() {
+        let result = interpret_atom(&space(""), atom("(decons (a))", bind!{}));
+        assert_eq!(result, vec![atom("(a ())", bind!{})]);
+    }
+
+    #[test]
+    fn interpret_atom_decons_list() {
+        let result = interpret_atom(&space(""), atom("(decons (a b c))", bind!{}));
+        assert_eq!(result, vec![atom("(a (b c))", bind!{})]);
+    }
+
+
+    #[test]
+    fn interpret_atom_cons_empty() {
+        let result = interpret_atom(&space(""), atom("(cons a ())", bind!{}));
+        assert_eq!(result, vec![atom("(a)", bind!{})]);
+    }
+
+    #[test]
+    fn interpret_atom_cons_single() {
+        let result = interpret_atom(&space(""), atom("(cons a (b))", bind!{}));
+        assert_eq!(result, vec![atom("(a b)", bind!{})]);
+    }
+
+    #[test]
+    fn interpret_atom_cons_list() {
+        let result = interpret_atom(&space(""), atom("(cons a (b c))", bind!{}));
+        assert_eq!(result, vec![atom("(a b c)", bind!{})]);
+    }
+
+
+    fn atom(text: &str, bindings: Bindings) -> InterpretedAtom {
+        InterpretedAtom(metta_atom(text), bindings)
+    }
+
+    fn space(text: &str) -> GroundingSpace {
+        metta_space(text)
+    }
+
+    #[derive(PartialEq, Clone, Debug)]
+    struct ThrowError();
+
+    impl Grounded for ThrowError {
+        fn type_(&self) -> Atom {
+            expr!("->" "&str" "Error")
+        }
+        fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+            Err(args[0].as_gnd::<&str>().unwrap().deref().into())
+        }
+        fn match_(&self, other: &Atom) -> matcher::MatchResultIter {
+            match_by_equality(self, other)
+        }
+    }
+
+    impl Display for ThrowError {
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(f, "throw-error")
+        }
+    }
+
+    #[derive(PartialEq, Clone, Debug)]
+    struct NonReducible();
+
+    impl Grounded for NonReducible {
+        fn type_(&self) -> Atom {
+            expr!("->" "u32" "u32")
+        }
+        fn execute(&self, _args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+            Err(ExecError::NoReduce)
+        }
+        fn match_(&self, other: &Atom) -> matcher::MatchResultIter {
+            match_by_equality(self, other)
+        }
+    }
+
+    impl Display for NonReducible {
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(f, "non-reducible")
+        }
+    }
+
+    #[derive(PartialEq, Clone, Debug)]
+    struct MulXUndefinedType(i32);
+
+    impl Grounded for MulXUndefinedType {
+        fn type_(&self) -> Atom {
+            ATOM_TYPE_UNDEFINED
+        }
+        fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+            Ok(vec![Atom::value(self.0 * args.get(0).unwrap().as_gnd::<i32>().unwrap())])
+        }
+        fn match_(&self, other: &Atom) -> matcher::MatchResultIter {
+            match_by_equality(self, other)
+        }
+    }
+
+    impl Display for MulXUndefinedType {
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(f, "x{}", self.0)
+        }
+    }
+
+    #[derive(PartialEq, Clone, Debug)]
+    struct ReturnNothing();
+
+    impl Grounded for ReturnNothing {
+        fn type_(&self) -> Atom {
+            ATOM_TYPE_UNDEFINED
+        }
+        fn execute(&self, _args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+            Ok(vec![])
+        }
+        fn match_(&self, other: &Atom) -> matcher::MatchResultIter {
+            match_by_equality(self, other)
+        }
+    }
+
+    impl Display for ReturnNothing {
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(f, "return-nothing")
+        }
+    }
+}

--- a/lib/src/metta/mod.rs
+++ b/lib/src/metta/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod text;
 pub mod interpreter;
+pub mod interpreter2;
 pub mod types;
 pub mod runner;
 
@@ -29,6 +30,13 @@ pub const BAD_TYPE_SYMBOL : Atom = sym!("BadType");
 pub const INCORRECT_NUMBER_OF_ARGUMENTS_SYMBOL : Atom = sym!("IncorrectNumberOfArguments");
 pub const NOT_REDUCIBLE_SYMBOL : Atom = sym!("NotReducible");
 pub const NO_VALID_ALTERNATIVES : Atom = sym!("NoValidAlternatives");
+
+pub const EMPTY_SYMBOL : Atom = sym!("Empty");
+pub const EVAL_SYMBOL : Atom = sym!("eval");
+pub const CHAIN_SYMBOL : Atom = sym!("chain");
+pub const MATCH_SYMBOL : Atom = sym!("match");
+pub const DECONS_SYMBOL : Atom = sym!("decons");
+pub const CONS_SYMBOL : Atom = sym!("cons");
 
 // TODO: use stdlib to parse input text
 pub fn metta_space(text: &str) -> GroundingSpace {

--- a/lib/src/metta/runner/arithmetics.rs
+++ b/lib/src/metta/runner/arithmetics.rs
@@ -10,7 +10,7 @@ pub const ATOM_TYPE_BOOL : Atom = sym!("Bool");
 #[derive(Clone, PartialEq, Debug)]
 pub enum Number {
     Integer(i64),
-    Float(f64), 
+    Float(f64),
 }
 
 impl Number {
@@ -49,7 +49,7 @@ impl Grounded for Number {
 }
 
 #[derive(Clone, PartialEq, Debug)]
-pub struct Bool(bool);
+pub struct Bool(pub bool);
 
 impl Bool {
     pub fn from_str(b: &str) -> Self {

--- a/lib/src/metta/runner/mod.rs
+++ b/lib/src/metta/runner/mod.rs
@@ -345,25 +345,6 @@ mod tests {
     }
 
     #[test]
-    fn test_frog_reasoning() {
-        let program = "
-            (= (and True True) True)
-
-            (= (Fritz croaks) True)
-            (= (Fritz eats-flies) True)
-
-            (= (Tweety chirps) True)
-            (= (Tweety yello) True)
-            (= (Tweety eats-flies) True)
-
-            !(if (and ($x croaks) ($x eats-flies)) (= ($x frog) True) Empty)
-        ";
-
-        //let result = run_program(program);
-        //assert_eq!(result, Ok(vec![vec![expr!("=" ("Fritz" "frog") "True")]]));
-    }
-
-    #[test]
     fn operation_is_expression() {
         let mut space = GroundingSpace::new();
         space.add(expr!(":" "foo" ("->" ("->" "A" "A"))));

--- a/lib/src/metta/runner/mod.rs
+++ b/lib/src/metta/runner/mod.rs
@@ -205,8 +205,6 @@ pub fn new_metta_rust() -> Metta {
 mod tests {
     use super::*;
 
-    use crate::atom::matcher::*;
-
     #[test]
     fn test_space() {
         let program = "
@@ -341,92 +339,6 @@ mod tests {
         let result = metta.run(&mut SExprParser::new(program));
 
         assert_eq!(result, Ok(vec![vec![expr!()]]));
-    }
-
-    #[test]
-    fn operation_is_expression() {
-        let mut space = GroundingSpace::new();
-        space.add(expr!(":" "foo" ("->" ("->" "A" "A"))));
-        space.add(expr!(":" "a" "A"));
-        space.add(expr!("=" ("foo") "bar"));
-        space.add(expr!("=" ("bar" x) x));
-
-        assert_eq!(interpret(&space, &expr!(("foo") "a")), Ok(vec![expr!("a")]));
-    }
-
-    static ID_NUM: &Operation = &Operation{
-        name: "id_num",
-        execute: |_, args| {
-            let arg_error = || ExecError::from("id_num expects one argument: number");
-            let num = args.get(0).ok_or_else(arg_error)?;
-            Ok(vec![num.clone()])
-        },
-        typ: "(-> Number Number)",
-    };
-
-    #[test]
-    fn return_bad_type_error() {
-        let mut space = GroundingSpace::new();
-        space.add(expr!(":" "myAtom" "myType"));
-        space.add(expr!(":" "id_a" ("->" "A" "A")));
-        space.add(expr!("=" ("id_a" a) a));
-
-        assert_eq!(interpret(&space, &expr!({ID_NUM} "myAtom")),
-            Ok(vec![Atom::expr([ERROR_SYMBOL, sym!("myAtom"), BAD_TYPE_SYMBOL])]));
-        assert_eq!(interpret(&space, &expr!("id_a" "myAtom")),
-            Ok(vec![Atom::expr([ERROR_SYMBOL, sym!("myAtom"), BAD_TYPE_SYMBOL])]));
-    }
-
-    #[test]
-    fn test_variable_defined_via_variable() {
-        let mut space = GroundingSpace::new();
-        space.add(expr!("=" ("if" "True" y) y));
-        space.add(expr!("=" ("not" "False") "True"));
-        space.add(expr!("=" ("a" z) ("not" ("b" z))));
-        space.add(expr!("=" ("b" "d") "False"));
-        let expr = expr!("if" ("a" x) x);
-
-        assert_eq!(interpret(&space, &expr), Ok(vec![expr!("d")]));
-    }
-
-    #[test]
-    fn test_variable_keeps_value_in_different_sub_expressions() {
-        let mut space = GroundingSpace::new();
-        space.add(expr!("=" ("eq" x x) "True"));
-        space.add(expr!("=" ("plus" "Z" y) y));
-        space.add(expr!("=" ("plus" ("S" k) y) ("S" ("plus" k y))));
-
-        assert_eq!(interpret(&space, &expr!("eq" ("plus" "Z" n) n)),
-            Ok(vec![expr!("True")]));
-        let actual = interpret(&space, &expr!("eq" ("plus" ("S" "Z") n) n));
-        let expected = Ok(vec![expr!("eq" ("S" y) y)]);
-        assert!(results_are_equivalent(&actual, &expected),
-            "actual: {:?} and expected: {:?} are not equivalent", actual, expected);
-    }
-
-    #[test]
-    fn test_variable_name_conflict_renaming() {
-        let space = metta_space("
-            (= (b ($x $y)) (c $x $y))
-        ");
-        let expr = metta_atom("(a (b $a) $x $y)");
-
-        let result = interpret(&space, &expr);
-
-        assert!(results_are_equivalent(&result,
-            &Ok(vec![metta_atom("(a (c $a $b) $c $d)")])));
-    }
-
-    fn results_are_equivalent(actual: &Result<Vec<Atom>, String>,
-            expected: &Result<Vec<Atom>, String>) -> bool {
-        match (actual, expected) {
-            (Ok(actual), Ok(expected)) =>
-                actual.len() == expected.len() &&
-                actual.iter().zip(expected.iter()).all(|(actual, expected)| {
-                    atoms_are_equivalent(actual, expected) }),
-            (Err(actual), Err(expected)) => actual == expected,
-            _ => false,
-        }
     }
 
 }

--- a/lib/src/metta/runner/mod.rs
+++ b/lib/src/metta/runner/mod.rs
@@ -206,7 +206,6 @@ mod tests {
     use super::*;
 
     use crate::atom::matcher::*;
-    use arithmetics::*;
 
     #[test]
     fn test_space() {

--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -1181,21 +1181,19 @@ pub fn register_rust_tokens(metta: &Metta) {
     metta.tokenizer.borrow_mut().move_front(&mut rust_tokens);
 }
 
-pub fn metta_code() -> &'static str {
-    // `$then`, `$else` should be of `Atom` type to avoid evaluation
-    // and infinite cycle in inference
-    "
+pub static METTA_CODE: &'static str = "
+    ; `$then`, `$else` should be of `Atom` type to avoid evaluation
+    ; and infinite cycle in inference
     (: if (-> Bool Atom Atom $t))
     (= (if True $then $else) $then)
     (= (if False $then $else) $else)
     (: Error (-> Atom Atom ErrorType))
-    "
-}
+";
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::metta::runner::*;
+    use crate::metta::runner::new_metta_rust;
     use crate::metta::types::validate_atom;
 
     fn run_program(program: &str) -> Result<Vec<Vec<Atom>>, String> {

--- a/lib/src/metta/runner/stdlib2.rs
+++ b/lib/src/metta/runner/stdlib2.rs
@@ -216,8 +216,9 @@ pub static METTA_CODE: &'static str = "
       (chain (eval (get-type $op $space)) $op-type
         (chain (eval (is-function $op-type)) $is-func
           (match $is-func True
-            (Error $atom \"Functions processing is not implemented yet\")
-            (chain (eval (interpret-children $atom $space)) $tuple (eval (call $tuple $type $space))) )))
+            (chain (eval (interpret-children $args $space)) $reduced_args
+              (chain (cons $op $reduced_args) $reduced_atom (eval (call $reduced_atom %Undefined% $space))) )
+            (chain (eval (interpret-children $atom $space)) $reduced_atom (eval (call $reduced_atom $type $space))) )))
       (eval (type-cast $atom $type $space)) )))
 
 (= (interpret-children $atom $space)
@@ -392,21 +393,21 @@ mod tests {
     }
 
     #[test]
-    fn test_frog_reasoning() {
+    fn metta_frog_reasoning() {
         let program = "
             (= (and True True) True)
 
-            (= (Fritz croaks) True)
-            (= (Fritz eats-flies) True)
+            (= (is Fritz croaks) True)
+            (= (is Fritz eats-flies) True)
 
-            (= (Tweety chirps) True)
-            (= (Tweety yello) True)
-            (= (Tweety eats-flies) True)
+            (= (is Tweety chirps) True)
+            (= (is Tweety yellow) True)
+            (= (is Tweety eats-flies) True)
 
-            !(eval (interpret (if (and ($x croaks) ($x eats-flies)) (= ($x frog) True) Empty) %Undefined% &self))
+            !(eval (interpret (if (and (is $x croaks) (is $x eats-flies)) (= (is $x frog) True) Empty) %Undefined% &self))
         ";
 
-        //let result = run_program(program);
-        //assert_eq!(result, Ok(vec![vec![expr!("=" ("Fritz" "frog") "True")]]));
+        let result = run_program(program);
+        assert_eq!(result, Ok(vec![vec![expr!("=" ("is" "Fritz" "frog") {Bool(true)})]]));
     }
 }

--- a/lib/src/metta/runner/stdlib2.rs
+++ b/lib/src/metta/runner/stdlib2.rs
@@ -1,0 +1,370 @@
+use crate::*;
+use crate::matcher::MatchResultIter;
+use crate::space::*;
+use crate::metta::*;
+use crate::metta::text::Tokenizer;
+use crate::metta::runner::Metta;
+use crate::metta::types::{get_atom_types, get_meta_type};
+
+use std::fmt::Display;
+use std::path::PathBuf;
+use regex::Regex;
+use std::convert::TryInto;
+
+use super::arithmetics::*;
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct CarAtomOp {}
+
+impl Display for CarAtomOp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "car-atom")
+    }
+}
+
+impl Grounded for CarAtomOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_EXPRESSION, ATOM_TYPE_ATOM])
+    }
+
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        let arg_error = || ExecError::from("car-atom expects one argument: expression");
+        let expr = args.get(0).ok_or_else(arg_error)?;
+        let expr: &ExpressionAtom = expr.try_into().map_err(|_| arg_error())?;
+        let chld = expr.children();
+        let car = chld.get(0).ok_or("car-atom expects non-empty expression")?;
+        Ok(vec![car.clone()])
+    }
+
+    fn match_(&self, other: &Atom) -> MatchResultIter {
+        match_by_equality(self, other)
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct GetTypeOp {}
+
+impl Display for GetTypeOp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "get-type")
+    }
+}
+
+impl Grounded for GetTypeOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_ATOM, ATOM_TYPE_ATOM, ATOM_TYPE_ATOM])
+    }
+
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        let arg_error = || ExecError::from("get-type expects single atom as an argument");
+        let atom = args.get(0).ok_or_else(arg_error)?;
+        let space = args.get(1).ok_or_else(arg_error)?;
+        let space = Atom::as_gnd::<DynSpace>(space).ok_or("match expects a space as the first argument")?;
+        Ok(get_atom_types(space, atom))
+    }
+
+    fn match_(&self, other: &Atom) -> MatchResultIter {
+        match_by_equality(self, other)
+    }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct GetMetaTypeOp { }
+
+impl Display for GetMetaTypeOp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "get-metatype")
+    }
+}
+
+impl Grounded for GetMetaTypeOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_ATOM, ATOM_TYPE_ATOM])
+    }
+
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        let arg_error = || ExecError::from("get-metatype expects single atom as an argument");
+        let atom = args.get(0).ok_or_else(arg_error)?;
+
+        Ok(vec![get_meta_type(&atom)])
+    }
+
+    fn match_(&self, other: &Atom) -> MatchResultIter {
+        match_by_equality(self, other)
+    }
+}
+
+
+fn regex(regex: &str) -> Regex {
+    Regex::new(regex).unwrap()
+}
+
+pub fn register_common_tokens(metta: &Metta) {
+    let tokenizer = &metta.tokenizer;
+    let mut tref = tokenizer.borrow_mut();
+
+    let car_atom_op = Atom::gnd(CarAtomOp{});
+    tref.register_token(regex(r"car-atom"), move |_| { car_atom_op.clone() });
+    let get_type_op = Atom::gnd(GetTypeOp{});
+    tref.register_token(regex(r"get-type"), move |_| { get_type_op.clone() });
+    let get_meta_type_op = Atom::gnd(GetMetaTypeOp{});
+    tref.register_token(regex(r"get-metatype"), move |_| { get_meta_type_op.clone() });
+}
+
+pub fn register_runner_tokens(metta: &Metta, _cwd: PathBuf) {
+    let _space = &metta.space;
+    let tokenizer = &metta.tokenizer;
+
+    let mut tref = tokenizer.borrow_mut();
+
+    // &self should be updated
+    // TODO: adding &self might be done not by stdlib, but by MeTTa itself.
+    // TODO: adding &self introduces self referencing and thus prevents space
+    // from being freed. There are two options to eliminate this. (1) use weak
+    // pointer and somehow use the same type to represent weak and strong
+    // pointers to the atomspace. (2) resolve &self in GroundingSpace::query
+    // method without adding it into container.
+    let self_atom = Atom::gnd(metta.space.clone());
+    tref.register_token(regex(r"&self"), move |_| { self_atom.clone() });
+}
+
+pub fn register_rust_tokens(metta: &Metta) {
+    let mut rust_tokens = Tokenizer::new();
+    let tref = &mut rust_tokens;
+
+    tref.register_token(regex(r"\d+"),
+        |token| { Atom::gnd(Number::from_int_str(token)) });
+    tref.register_token(regex(r"\d+(.\d+)([eE][\-\+]?\d+)?"),
+        |token| { Atom::gnd(Number::from_float_str(token)) });
+    tref.register_token(regex(r"True|False"),
+        |token| { Atom::gnd(Bool::from_str(token)) });
+    let sum_op = Atom::gnd(SumOp{});
+    tref.register_token(regex(r"\+"), move |_| { sum_op.clone() });
+    let sub_op = Atom::gnd(SubOp{});
+    tref.register_token(regex(r"\-"), move |_| { sub_op.clone() });
+    let mul_op = Atom::gnd(MulOp{});
+    tref.register_token(regex(r"\*"), move |_| { mul_op.clone() });
+    let div_op = Atom::gnd(DivOp{});
+    tref.register_token(regex(r"/"), move |_| { div_op.clone() });
+    let mod_op = Atom::gnd(ModOp{});
+    tref.register_token(regex(r"%"), move |_| { mod_op.clone() });
+
+    metta.tokenizer.borrow_mut().move_front(&mut rust_tokens);
+}
+
+pub static METTA_CODE: &'static str = "
+
+;`$then`, `$else` should be of `Atom` type to avoid evaluation
+; and infinite cycle in inference
+(: if (-> Bool Atom Atom $t))
+(= (if True $then $else) $then)
+(= (if False $then $else) $else)
+
+(: Error (-> Atom Atom ErrorType))
+
+(= (switch $atom $cases)
+  (chain (decons $cases) $list (eval (switch-internal $atom $list))))
+(= (switch-internal $atom (($pattern $template) $tail))
+  (match $atom $pattern $template (eval (switch $atom $tail))))
+
+(= (subst $atom $var $templ)
+  (match $atom $var $templ
+    (Error (subst $atom $var $templ)
+      \"subst expects a variable as a second argument\") ))
+
+(= (eval-or-default $atom $default)
+  (chain (eval $atom) $result
+    (match $result Empty $default $result) ))
+
+(= (reduce $atom $var $templ)
+  (chain (eval $atom) $res
+    (match $res (Error $a $m)
+      (Error $a $m)
+      (match $res Empty
+        (eval (subst $atom $var $templ))
+        (eval (reduce $res $var $templ)) ))))
+
+(= (type-cast $atom $type $space)
+  (eval (reduce (get-type $atom $space) $actual-type
+    (eval (switch ($actual-type $type)
+      (
+        ((%Undefined% $_) $atom)
+        (($_ %Undefined%) $atom)
+        (($type $_) $atom)
+        ($_ Empty) ))))))
+
+(= (is-function $type)
+  (eval (reduce (car $type) $head
+    (match $head -> True False) )))
+
+(= (interpret $atom $type $space)
+  (eval (reduce (get-metatype $atom) $meta
+    (eval (switch ($type $meta)
+      (
+        ((Atom $_meta) $atom)
+        (($meta $meta) $atom)
+        (($_type Variable) $atom)
+
+        (($_type Symbol) (eval (type-cast $atom $type $space)))
+        (($_type Grounded) (eval (type-cast $atom $type $space)))
+        (($_type Expression) (eval (interpret-expression $atom $type $space))) ))))))
+
+(= (interpret-expression $atom $type $space)
+  (chain (decons $atom) $list
+    (match ($op $args) $list
+      (eval (reduce (get-type $op $space) $op-type
+        (eval (reduce (is-function $op-type) $is-func
+          (match $is-func True
+            (Error $atom \"Functions processing is not implemented yet\")
+            (eval (reduce (interpret-children $atom $space) $tuple (eval (eval-or-default $tuple $tuple))))
+          )))))
+      (eval (type-cast $atom $type $space)) )))
+
+(= (interpret-children $atom $space)
+  (chain (decons $atom) $list
+    (match ($head $tail) $list
+      (eval (reduce (interpret $head %Undefined% $space) $rhead
+        (eval (reduce (interpret-children $tail $space) $rtail
+          (chain (cons $rhead $rtail) $cons $cons)))))
+      $atom )))
+";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metta::runner::new_metta_rust;
+
+    fn run_program(program: &str) -> Result<Vec<Vec<Atom>>, String> {
+        let metta = new_metta_rust();
+        metta.run(&mut SExprParser::new(program))
+    }
+
+    #[test]
+    fn car_atom_op() {
+        let res = CarAtomOp{}.execute(&mut vec![expr!(("A" "C") "B")]).expect("No result returned");
+        assert_eq!(res, vec![expr!("A" "C")]);
+    }
+
+    #[test]
+    fn get_type_op() {
+        let space = DynSpace::new(metta_space("
+            (: B Type)
+            (: C Type)
+            (: A B)
+            (: A C)
+        "));
+
+        let get_type_op = GetTypeOp{};
+        assert_eq_no_order!(get_type_op.execute(&mut vec![sym!("A"), expr!({space.clone()})]).unwrap(),
+            vec![sym!("B"), sym!("C")]);
+    }
+
+    #[test]
+    fn get_type_op_non_valid_atom() {
+        let space = DynSpace::new(metta_space("
+            (: f (-> Number String))
+            (: 42 Number)
+            (: \"test\" String)
+        "));
+
+        let get_type_op = GetTypeOp{};
+        assert_eq_no_order!(get_type_op.execute(&mut vec![expr!("f" "42"), expr!({space.clone()})]).unwrap(),
+            vec![sym!("String")]);
+        assert_eq_no_order!(get_type_op.execute(&mut vec![expr!("f" "\"test\""), expr!({space.clone()})]).unwrap(),
+            Vec::<Atom>::new());
+    }
+
+
+    #[test]
+    fn metta_switch() {
+        let result = run_program("!(eval (switch (A $b) ( (($a B) ($b $a)) ((B C) (C B)) )))");
+        assert_eq!(result, Ok(vec![vec![expr!("B" "A")]]));
+        let result = run_program("!(eval (switch (A $b) ( ((B C) (C B)) (($a B) ($b $a)) )))");
+        assert_eq!(result, Ok(vec![vec![expr!("B" "A")]]));
+        let result = run_program("!(eval (switch (A $b) ( ((B C) (C B)) ((D E) (E B)) )))");
+        assert_eq!(result, Ok(vec![vec![]]));
+    }
+
+    #[test]
+    fn metta_reduce_chain() {
+        assert_eq!(run_program("
+            (= (foo $x) (bar $x))
+            (= (bar $x) (baz $x))
+            (= (baz $x) $x)
+            !(eval (reduce (foo A) $x (reduced $x)))
+        "), Ok(vec![vec![expr!("reduced" "A")]]));
+        assert_eq!(run_program("
+            !(eval (reduce (foo A) $x (reduced $x)))
+        "), Ok(vec![vec![expr!("reduced" ("foo" "A"))]]));
+        assert_eq!(run_program("
+            (= (foo A) (Error (foo A) \"Test error\"))
+            !(eval (reduce (foo A) $x (reduced $x)))
+        "), Ok(vec![vec![expr!("Error" ("foo" "A") "\"Test error\"")]]));
+    }
+
+    #[test]
+    fn metta_reduce_reduce() {
+        assert_eq!(run_program("
+            (= (foo $x) (reduce (bar $x) $t $t))
+            (= (bar $x) $x)
+            !(eval (reduce (foo A) $x $x))
+        "), Ok(vec![vec![expr!("A")]]));
+    }
+
+    #[test]
+    fn metta_type_cast() {
+        assert_eq!(run_program("(: a A) !(eval (type-cast a A &self))"), Ok(vec![vec![expr!("a")]]));
+        assert_eq!(run_program("(: a A) !(eval (type-cast a B &self))"), Ok(vec![vec![]]));
+        assert_eq!(run_program("(: a A) !(eval (type-cast a %Undefined% &self))"), Ok(vec![vec![expr!("a")]]));
+        assert_eq!(run_program("!(eval (type-cast a B &self))"), Ok(vec![vec![expr!("a")]]));
+        assert_eq!(run_program("!(eval (type-cast 42 Number &self))"), Ok(vec![vec![expr!({Number::Integer(42)})]]));
+        assert_eq!(run_program("!(eval (type-cast 42 %Undefined% &self))"), Ok(vec![vec![expr!({Number::Integer(42)})]]));
+    }
+
+    #[test]
+    fn metta_interpret_single_atom_as_atom() {
+        let result = run_program("!(eval (interpret A Atom &self))");
+        assert_eq!(result, Ok(vec![vec![expr!("A")]]));
+    }
+
+    #[test]
+    fn metta_interpret_single_atom_as_meta_type() {
+        assert_eq!(run_program("!(eval (interpret A Symbol &self))"), Ok(vec![vec![expr!("A")]]));
+        assert_eq!(run_program("!(eval (interpret $x Variable &self))"), Ok(vec![vec![expr!(x)]]));
+        assert_eq!(run_program("!(eval (interpret (A B) Expression &self))"), Ok(vec![vec![expr!("A" "B")]]));
+        assert_eq!(run_program("!(eval (interpret 42 Grounded &self))"), Ok(vec![vec![expr!({Number::Integer(42)})]]));
+    }
+
+    #[test]
+    fn metta_interpret_symbol_or_grounded_value_as_type() {
+        assert_eq!(run_program("(: a A) !(eval (interpret a A &self))"), Ok(vec![vec![expr!("a")]]));
+        assert_eq!(run_program("(: a A) !(eval (interpret a B &self))"), Ok(vec![vec![]]));
+        assert_eq!(run_program("!(eval (interpret 42 Number &self))"), Ok(vec![vec![expr!({Number::Integer(42)})]]));
+    }
+
+    #[test]
+    fn metta_interpret_variable_as_type() {
+        assert_eq!(run_program("!(eval (interpret $x %Undefined% &self))"), Ok(vec![vec![expr!(x)]]));
+        assert_eq!(run_program("!(eval (interpret $x SomeType &self))"), Ok(vec![vec![expr!(x)]]));
+    }
+
+    #[test]
+    fn metta_interpret_empty_expression_as_type() {
+        assert_eq!(run_program("!(eval (interpret () %Undefined% &self))"), Ok(vec![vec![expr!(())]]));
+        assert_eq!(run_program("!(eval (interpret () SomeType &self))"), Ok(vec![vec![expr!(())]]));
+    }
+
+    #[test]
+    fn metta_interpret_children() {
+        assert_eq!(run_program("!(eval (interpret-children () &self))"), Ok(vec![vec![expr!(())]]));
+        assert_eq!(run_program("!(eval (interpret-children (a) &self))"), Ok(vec![vec![expr!(("a"))]]));
+        assert_eq!(run_program("!(eval (interpret-children (a b) &self))"), Ok(vec![vec![expr!(("a" "b"))]]));
+    }
+
+    #[test]
+    fn metta_interpret_expression_as_type() {
+        assert_eq!(run_program("(= (foo $x) $x) !(eval (interpret (foo a) %Undefined% &self))"), Ok(vec![vec![expr!("a")]]));
+        assert_eq!(run_program("!(eval (interpret (foo a) %Undefined% &self))"), Ok(vec![vec![expr!("foo" "a")]]));
+        assert_eq!(run_program("!(eval (interpret () SomeType &self))"), Ok(vec![vec![expr!(())]]));
+    }
+}

--- a/lib/src/metta/runner/stdlib2.rs
+++ b/lib/src/metta/runner/stdlib2.rs
@@ -261,8 +261,8 @@ pub static METTA_CODE: &'static str = "
       (chain (eval (get-type $op $space)) $op-type
         (chain (eval (is-function $op-type)) $is-func
           (match $is-func True
-            (chain (eval (interpret-children $args $space)) $reduced_args
-              (chain (cons $op $reduced_args) $reduced_atom (eval (call $reduced_atom %Undefined% $space))) )
+            (chain (eval (interpret-children $atom $space)) $reduced_atom
+              (eval (call $reduced_atom $type $space)) )
             (chain (eval (interpret-children $atom $space)) $reduced_atom (eval (call $reduced_atom $type $space))) )))
       (eval (type-cast $atom $type $space)) )))
 
@@ -525,5 +525,19 @@ mod tests {
         let result = run_program(program);
         assert!(result.is_ok_and(|res| res.len() == 1 && res[0].len() == 1 &&
             atoms_are_equivalent(&res[0][0], &expr!("a" ("c" a b) c d))));
+    }
+
+    #[test]
+    fn test_operation_is_expression() {
+        let program = "
+            (: foo (-> (-> A A)))
+            (: a A)
+            (= (foo) bar)
+            (= (bar $x) $x)
+
+            !(eval (interpret ((foo) a) %Undefined% &self))
+        ";
+
+        assert_eq_metta_results!(run_program(program), Ok(vec![vec![expr!("a")]]));
     }
 }

--- a/lib/src/metta/types.rs
+++ b/lib/src/metta/types.rs
@@ -425,7 +425,7 @@ pub fn get_type_bindings(space: &dyn Space, atom: &Atom, typ: &Atom) -> Vec<(Ato
     result
 }
 
-fn get_meta_type(atom: &Atom) -> Atom {
+pub fn get_meta_type(atom: &Atom) -> Atom {
     match atom {
         Atom::Symbol(_) => ATOM_TYPE_SYMBOL,
         Atom::Variable(_) => ATOM_TYPE_VARIABLE,


### PR DESCRIPTION
Add minimal MeTTa interpreter implementation in Rust (`interpreter2.rs`) and MeTTa interpreter written using the minimal MeTTa instructions (`stdlib2.rs`). One can switch to the new implementation editing [`metta/runner/mod.rs` lines 13-20](https://github.com/vsbogd/hyperon-experimental/blob/c394546eec90244084cd4e82f9ac0baa1c04e11d/lib/src/metta/runner/mod.rs#L12-L20).

As implementation is not finished yet and not fully integrated with a code in this mode about 3 old Rust unit tests fails. But all unit tests in `interpreter2.rs` and `stdlib2.rs` are expected to be green. Main change is inside `...2.rs` files, other code is almost not touched.