### PR TITLE
Removing Rc<RefCell<T>> pattern from metta_t in hyperonc

### DIFF
--- a/python/hyperon/runner.py
+++ b/python/hyperon/runner.py
@@ -24,9 +24,6 @@ class MeTTa:
     def __del__(self):
         hp.metta_free(self.cmetta)
 
-    def copy(self):
-        return MeTTa(cmetta = hp.metta_clone(self.cmetta))
-
     def space(self):
         return GroundingSpaceRef._from_cspace(hp.metta_space(self.cmetta))
 

--- a/python/hyperonpy.cpp
+++ b/python/hyperonpy.cpp
@@ -681,7 +681,6 @@ PYBIND11_MODULE(hyperonpy, m) {
         return CMetta(metta_new(space.ptr(), tokenizer.ptr(), cwd));
     }, "New MeTTa interpreter instance");
     m.def("metta_free", [](CMetta metta) { metta_free(metta.obj); }, "Free MeTTa interpreter");
-    m.def("metta_clone", [](CMetta metta) { metta_clone_handle(metta.ptr()); }, "Clone MeTTa interpreter");
     m.def("metta_space", [](CMetta metta) { return CSpace(metta_space(metta.ptr())); }, "Get space of MeTTa interpreter");
     m.def("metta_tokenizer", [](CMetta metta) { return CTokenizer(metta_tokenizer(metta.ptr())); }, "Get tokenizer of MeTTa interpreter");
     m.def("metta_run", [](CMetta metta, CSExprParser& parser) {


### PR DESCRIPTION
In the case of hyperonc's `metta_t`, the `Rc<RefCell<T>>` (aka `Shared<T>`) pattern is unsound and obnoxious to work with.  Also it doesn't add much value.

The usage pattern for `metta_t` lead to a violation of RefCell's contract with `unsafe`.  (using `as_mut` to gain access to the `RefCell`'s inner value while demonstrably not having exclusive access)  Luckily it never caused any problems because the underlying `Metta` object was never changed.  But it was a bug waiting to happen if simple state was ever added to the Metta struct.

Also, The Metta (Rust type) never needs to be mutable because it is 100% internally mutable.  

Finally, the top-level runner has a simple life-cycle, unlike other objects where we rely on reference counting for deallocation and embed handles within other objects (`DynSpace`, `Shared<Tokenizer>`, etc.)

I believe the simplest and best solution is to make the C api use a simple Box for `metta_t`, rather than a `Shared<T>`.  This PR does that.