### PR TITLE
Fixing Optimized build when nesting a Space within an Atom, Adding new test for C API, etc.

### DIFF
--- a/c/src/atom.rs
+++ b/c/src/atom.rs
@@ -795,6 +795,12 @@ impl Drop for atom_vec_t {
     }
 }
 
+impl Clone for atom_vec_t {
+    fn clone(&self) -> Self {
+        self.as_slice().to_vec().into()
+    }
+}
+
 /// @brief Function signature for a callback providing access to an `atom_vec_t`
 /// @ingroup atom_vec_group
 /// @param[in]  vec  The `atom_vec_t` being provided.  This vec should not be modified or freed by the callback.
@@ -810,6 +816,18 @@ pub type c_atom_vec_callback_t = extern "C" fn(vec: *const atom_vec_t, context: 
 #[no_mangle]
 pub extern "C" fn atom_vec_new() -> atom_vec_t {
     atom_vec_t::new()
+}
+
+/// @brief Creates a new `atom_vec_t` by cloning an existing `atom_vec_t`
+/// @ingroup atom_vec_group
+/// @param[in]  vec  A pointer to an existing `atom_vec_t` to clone
+/// @return A newly created `atom_vec_t`
+/// @note The caller must take ownership responsibility for the returned `atom_vec_t`
+///
+#[no_mangle]
+pub extern "C" fn atom_vec_clone(vec: *const atom_vec_t) -> atom_vec_t {
+    let vec = unsafe{ &*vec };
+    vec.clone()
 }
 
 /// @brief Creates a new `atom_vec_t` from a C-style array

--- a/c/src/space.rs
+++ b/c/src/space.rs
@@ -39,7 +39,7 @@ impl space_t {
         unsafe{ Box::from_raw(self.space.cast_mut()).0 }
     }
     pub(crate) fn borrow(&self) -> &DynSpace {
-        unsafe{ &(*self.space).0 }
+        unsafe{ &(&*self.space).0 }
     }
 }
 
@@ -91,9 +91,9 @@ pub extern "C" fn space_free(space: space_t) {
 /// @note The caller must take ownership responsibility for the returned `space_t`, and free it with `space_free()`
 ///
 #[no_mangle]
-pub extern "C" fn space_clone_handle(space: *const space_t) -> *mut space_t {
-    let space = unsafe { &(*space).space };
-    Box::into_raw(Box::new(space_t{ space: space.clone() }))
+pub extern "C" fn space_clone_handle(space: *const space_t) -> space_t {
+    let space = unsafe { &*space }.borrow();
+    space.clone().into()
 }
 
 /// @brief Checks if two `space_t` handles refer to the same underlying Space

--- a/python/hyperonpy.cpp
+++ b/python/hyperonpy.cpp
@@ -447,7 +447,7 @@ PYBIND11_MODULE(hyperonpy, m) {
                     throw std::runtime_error("Grounded Space Atoms can't have a custom type");
                 }
                 atom_free(undefined);
-                space_t* space = object.attr("cspace").cast<CSpace>().ptr();
+                space_t* space = object.attr("cspace").cast<CSpace&>().ptr();
                 return CAtom(atom_gnd_for_space(space));
             } else {
                 atom_t typ = atom_clone(ctyp.ptr());


### PR DESCRIPTION
There are 3 C API fixes / improvements in this PR:

1. Adding C api test: test_space_nested_in_atom, which corresponds to they Python test `test_match_nested_grounding_space`, but without relying on Python.

2. Fixing oversight in C API in signature of `space_clone_handle()`, which I missed in the C API regularization pass a few weeks ago.

3. Adding `atom_vec_clone()` function, because it's convenient