### PR TITLE
Add clear error about incorrect grounded Python function implementation

### DIFF
--- a/python/hyperonpy.cpp
+++ b/python/hyperonpy.cpp
@@ -136,6 +136,9 @@ exec_error_t py_execute(const struct gnd_t* _cgnd, const struct atom_vec_t* _arg
         }
         py::list result = call_execute_on_grounded_atom(pyobj, pytyp, args);
         for (py::handle atom:  result) {
+            if (!py::hasattr(atom, "catom")) {
+                return exec_error_runtime("Grounded operation which is defined using unwrap=False should return atom instead of Python type");
+            }
             atom_vec_push(ret, atom_clone(atom.attr("catom").cast<CAtom>().ptr()));
         }
         return exec_error_no_err();

--- a/python/tests/test_atom.py
+++ b/python/tests/test_atom.py
@@ -95,6 +95,16 @@ class AtomTest(unittest.TestCase):
         self.assertEqual(interpret(space, E(x2Atom, ValueAtom(1))),
                 [ValueAtom(2)])
 
+    def test_grounded_returns_python_value_unwrap_false(self):
+        def x2_op(atom):
+            return [2 * atom.get_object().value]
+        x2Atom = OperationAtom('*2', x2_op, type_names=["int", "int"], unwrap=False)
+        expr = E(x2Atom, ValueAtom(1))
+
+        space = GroundingSpaceRef()
+        self.assertEqual(interpret(space, expr),
+                [E(S('Error'), expr, S('Grounded operation which is defined using unwrap=False should return atom instead of Python type'))])
+
     def test_plan(self):
         space = GroundingSpaceRef()
         interpreter = Interpreter(space, E(x2Atom, ValueAtom(1)))


### PR DESCRIPTION
In case when Python grounded function defined with `unwrap=False` returns Python atom the code throws AttributeError in `hyperonpy.cpp` and final error is not very clear: `(Error (*2 1) Exception caught: AttributeError: 'OperationObject' object has no attribute 'catom')`
This is to fix this and return more clear error: `(Error (*2 1) Grounded operation which is defined using unwrap=False should return atom instead of Python type)`