### PR TITLE
Minimal MeTTa interpreter fixes and optimizations

### DIFF
--- a/c/src/metta.rs
+++ b/c/src/metta.rs
@@ -275,6 +275,14 @@ pub extern "C" fn sexpr_parser_parse(
 ///
 #[no_mangle] pub extern "C" fn ATOM_TYPE_GROUNDED_SPACE() -> atom_t { rust_type_atom::<DynSpace>().into() }
 
+/// @brief Creates a Symbol atom for the special MeTTa symbol used to indicate empty results in
+/// case expressions.
+/// @ingroup metta_language_group
+/// @return  The `atom_t` representing the Void atom
+/// @note The returned `atom_t` must be freed with `atom_free()`
+///
+#[no_mangle] pub extern "C" fn VOID_SYMBOL() -> atom_t { hyperon::metta::VOID_SYMBOL.into() }
+
 /// @brief Checks whether Atom `atom` has Type `typ` in context of `space`
 /// @ingroup metta_language_group
 /// @param[in]  space  A pointer to the `space_t` representing the space context in which to perform the check

--- a/c/tests/check_space.c
+++ b/c/tests/check_space.c
@@ -231,6 +231,7 @@ START_TEST (test_space_nested_in_atom)
     space_t runner_space = space_new_grounding_space();
     tokenizer_t tokenizer = tokenizer_new();
     metta_t runner = metta_new(&runner_space, &tokenizer, ".");
+    metta_load_module(&runner, "stdlib");
 
     tokenizer_register_token(&tokenizer, "nested", &TOKEN_API_CLONE_ATOM, &space_atom);
 

--- a/doc/minimal-metta.md
+++ b/doc/minimal-metta.md
@@ -294,6 +294,32 @@ such possibility the additional instruction is needed. It could mark a set of
 results as joined and when their evaluation is finished would assemble them
 into an expression.
 
+## Special matching syntax
+
+Sometimes it is convenient to change the semantics of the matching within a
+pattern. Some real examples are provided below. One possible way to extend
+matching syntax is embrace atoms by expressions with matching modifier on a
+first position. For instance `(:<mod> <atom>)` could apply `<mod>` rule to
+match the `<atom>`. How to eliminate interference of this syntax with symbol
+atoms used by programmers is an open question.
+
+### Syntax to match atom by equality
+
+In many situations we need to check that atom is equal to some symbol. `unify`
+doesn't work well in such cases because when checked atom is a variable it is
+matched with anything (for instance `(unify $x Empty then else)` returns
+`then`). It would be convenient to have a special syntax to match the atom by
+equality. For instance `(unify <atom> (:= Empty) then else)` should match
+`<atom>` with pattern only when `<atom>` is `Empty`.
+
+### Syntax to match part of the expression
+
+We could have a specific syntax which would allow matching part of the
+expressions. For example such syntax could be used to match head and tail of
+the expression without using `cons`/`decons`. Another example is matching part
+of the expression with some gap, i.e. `(A ... D ...)` could match `(A B C D E)`
+atom.
+
 # Links
 
 1. Lucius Gregory Meredith, Ben Goertzel, Jonathan Warrell, and Adam

--- a/doc/minimal-metta.md
+++ b/doc/minimal-metta.md
@@ -137,7 +137,7 @@ Reduce in loop until result is calculated:
         (eval (reduce $res $var $templ)) ))))
 ```
 
-[Link](https://github.com/vsbogd/hyperon-experimental/blob/f64bf92edf632a538aa6277b6048dbd418924435/lib/src/metta/runner/stdlib.rs#L1199-L1263)
+[Link](https://github.com/trueagi-io/hyperon-experimental/blob/27861e63af1417df4780d9314eaf2e8a3b5cde06/lib/src/metta/runner/stdlib2.rs#L234-L302)
 to the full code of the interpreter in MeTTa (not finished yet).
 
 # Properties
@@ -146,7 +146,7 @@ to the full code of the interpreter in MeTTa (not finished yet).
 
 The following program implements a Turing machine using the minimal MeTTa
 instruction set (the full code of the example can be found
-[here](https://github.com/vsbogd/hyperon-experimental/blob/f64bf92edf632a538aa6277b6048dbd418924435/lib/src/metta/interpreter2.rs#L526-L566)):
+[here](https://github.com/trueagi-io/hyperon-experimental/blob/27861e63af1417df4780d9314eaf2e8a3b5cde06/lib/src/metta/interpreter2.rs#L628-L669)):
 
 ```metta
            (= (tm $rule $state $tape)

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -16,3 +16,6 @@ smallvec = "1.10.0"
 name = "hyperon"
 path = "src/lib.rs"
 crate-type = ["lib"]
+
+[features]
+minimal = []

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -18,4 +18,5 @@ path = "src/lib.rs"
 crate-type = ["lib"]
 
 [features]
+#default = ["minimal"]
 minimal = []

--- a/lib/benches/interpreter2.rs
+++ b/lib/benches/interpreter2.rs
@@ -1,0 +1,29 @@
+#![feature(test)]
+
+extern crate test;
+
+use test::Bencher;
+
+use hyperon::*;
+use hyperon::space::grounding::*;
+use hyperon::metta::interpreter2::*;
+use hyperon::metta::*;
+
+fn chain_atom(size: isize) -> Atom {
+    let mut atom = Atom::expr([CHAIN_SYMBOL, Atom::sym("A"), Atom::var("x"), Atom::var("x")]);
+    for _i in (1..size).step_by(1) {
+        atom = Atom::expr([CHAIN_SYMBOL, atom, Atom::var("x"), Atom::var("x")])
+    }
+    atom
+}
+
+#[bench]
+fn chain_x100(bencher: &mut Bencher) {
+    let atom = chain_atom(100);
+    let expected = Ok(vec![expr!("A")]);
+    bencher.iter(|| {
+        let space = GroundingSpace::new();
+        let res = interpret(space, &atom);
+        assert_eq!(res, expected);
+    })
+}

--- a/lib/src/atom/iter.rs
+++ b/lib/src/atom/iter.rs
@@ -130,17 +130,17 @@ mod test {
 
     #[test]
     fn atom_iter_mut_collect() {
-        assert_eq!(expr!("A").iter().collect::<Vec<&Atom>>(), vec![&expr!("A")]);
-        assert_eq!(expr!(a).iter().collect::<Vec<&Atom>>(), vec![&expr!(a)]);
-        assert_eq!(expr!({1}).iter().collect::<Vec<&Atom>>(), vec![&expr!({1})]);
+        assert_eq!(expr!("A").iter_mut().collect::<Vec<&mut Atom>>(), vec![&mut expr!("A")]);
+        assert_eq!(expr!(a).iter_mut().collect::<Vec<&mut Atom>>(), vec![&mut expr!(a)]);
+        assert_eq!(expr!({1}).iter_mut().collect::<Vec<&mut Atom>>(), vec![&mut expr!({1})]);
     }
 
     #[test]
     fn expr_iter_mut_collect() {
-        assert_eq!(expr!("A" a {1}).iter().collect::<Vec<&Atom>>(),
-            vec![&expr!("A"), &expr!(a), &expr!({1})]);
-        assert_eq!(expr!("A" (a {1})).iter().collect::<Vec<&Atom>>(),
-            vec![&expr!("A"), &expr!(a), &expr!({1})]);
+        assert_eq!(expr!("A" a {1}).iter_mut().collect::<Vec<&mut Atom>>(),
+            vec![&mut expr!("A"), &mut expr!(a), &mut expr!({1})]);
+        assert_eq!(expr!("A" (a {1})).iter_mut().collect::<Vec<&mut Atom>>(),
+            vec![&mut expr!("A"), &mut expr!(a), &mut expr!({1})]);
     }
 
     #[test]

--- a/lib/src/metta/interpreter.rs
+++ b/lib/src/metta/interpreter.rs
@@ -88,6 +88,7 @@ pub struct InterpreterState<'a, T: SpaceRef<'a>> {
 impl<'a, T: SpaceRef<'a>> InterpreterState<'a, T> {
 
     /// INTERNAL USE ONLY. Create an InterpreterState that is ready to yield results
+    #[cfg(not(feature = "minimal"))]
     pub(crate) fn new_finished(_space: T, results: Vec<Atom>) -> Self {
         Self {
             step_result: StepResult::Return(results.into_iter().map(|atom| InterpretedAtom(atom, Bindings::new())).collect()),

--- a/lib/src/metta/mod.rs
+++ b/lib/src/metta/mod.rs
@@ -33,6 +33,8 @@ pub const NOT_REDUCIBLE_SYMBOL : Atom = sym!("NotReducible");
 pub const NO_VALID_ALTERNATIVES : Atom = sym!("NoValidAlternatives");
 
 pub const EMPTY_SYMBOL : Atom = sym!("Empty");
+pub const VOID_SYMBOL : Atom = sym!("Void");
+
 pub const EVAL_SYMBOL : Atom = sym!("eval");
 pub const CHAIN_SYMBOL : Atom = sym!("chain");
 pub const UNIFY_SYMBOL : Atom = sym!("unify");

--- a/lib/src/metta/mod.rs
+++ b/lib/src/metta/mod.rs
@@ -35,7 +35,7 @@ pub const NO_VALID_ALTERNATIVES : Atom = sym!("NoValidAlternatives");
 pub const EMPTY_SYMBOL : Atom = sym!("Empty");
 pub const EVAL_SYMBOL : Atom = sym!("eval");
 pub const CHAIN_SYMBOL : Atom = sym!("chain");
-pub const MATCH_SYMBOL : Atom = sym!("match");
+pub const UNIFY_SYMBOL : Atom = sym!("unify");
 pub const DECONS_SYMBOL : Atom = sym!("decons");
 pub const CONS_SYMBOL : Atom = sym!("cons");
 

--- a/lib/src/metta/mod.rs
+++ b/lib/src/metta/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod text;
 pub mod interpreter;
+#[cfg(feature = "minimal")]
 pub mod interpreter2;
 pub mod types;
 pub mod runner;

--- a/lib/src/metta/runner/mod.rs
+++ b/lib/src/metta/runner/mod.rs
@@ -387,7 +387,7 @@ mod tests {
             !(foo)
         ";
 
-        let metta = Metta::new(DynSpace::new(GroundingSpace::new()), Shared::new(Tokenizer::new()));
+        let metta = new_metta_rust();
         metta.tokenizer().borrow_mut().register_token(Regex::new("error").unwrap(),
             |_| Atom::gnd(ErrorOp{}));
         let result = metta.run(&mut SExprParser::new(program));
@@ -438,7 +438,7 @@ mod tests {
             !(empty)
         ";
 
-        let metta = Metta::new(DynSpace::new(GroundingSpace::new()), Shared::new(Tokenizer::new()));
+        let metta = new_metta_rust();
         metta.tokenizer().borrow_mut().register_token(Regex::new("empty").unwrap(),
             |_| Atom::gnd(ReturnAtomOp(expr!())));
         let result = metta.run(&mut SExprParser::new(program));

--- a/lib/src/metta/runner/stdlib2.rs
+++ b/lib/src/metta/runner/stdlib2.rs
@@ -517,6 +517,13 @@ pub static METTA_CODE: &'static str = "
 (: let (-> Atom %Undefined% Atom Atom))
 (= (let $pattern $atom $template)
   (unify $atom $pattern $template Empty))
+
+(: let* (-> Expression Atom Atom))
+(= (let* $pairs $template)
+  (eval (if-decons $pairs ($pattern $atom) $tail
+    (let $pattern $atom (let* $tail $template))
+    $template )))
+
 ";
 
 #[cfg(test)]
@@ -774,6 +781,18 @@ mod tests {
             ");
         assert_eq!(result, Ok(vec![vec![]]));
         let result = run_program("!(let (P A $b) (P B C) (P C B))");
+        assert_eq!(result, Ok(vec![vec![]]));
+    }
+
+    #[test]
+    fn metta_let_var() {
+        let result = run_program("!(let* () result)");
+        assert_eq!(result, Ok(vec![vec![expr!("result")]]));
+        let result = run_program("!(let* ( ((P A $b) (P $a B)) ) (P $b $a))");
+        assert_eq!(result, Ok(vec![vec![expr!("P" "B" "A")]]));
+        let result = run_program("!(let* ( ((P $a) (P A)) ((P B) (P $b)) ) (P $b $a))");
+        assert_eq!(result, Ok(vec![vec![expr!("P" "B" "A")]]));
+        let result = run_program("!(let* ( ((P $a) (P A)) ((P B) (P C)) ) (P $b $a))");
         assert_eq!(result, Ok(vec![vec![]]));
     }
 

--- a/lib/src/metta/runner/stdlib2.rs
+++ b/lib/src/metta/runner/stdlib2.rs
@@ -365,39 +365,41 @@ pub static METTA_CODE: &'static str = "
 
 (: Error (-> Atom Atom ErrorType))
 
+(: if-non-empty-expression (-> Atom Atom Atom Atom))
 (= (if-non-empty-expression $atom $then $else)
   (chain (eval (get-metatype $atom)) $type
     (eval (if-equal $type Expression
       (eval (if-equal $atom () $else $then))
       $else ))))
 
+(: if-decons (-> Atom Variable Variable Atom Atom Atom))
 (= (if-decons $atom $head $tail $then $else)
   (eval (if-non-empty-expression $atom
     (chain (decons $atom) $list
       (unify $list ($head $tail) $then $else) )
     $else )))
 
+(: if-empty (-> Atom Atom Atom Atom))
 (= (if-empty $atom $then $else)
   (eval (if-equal $atom Empty $then $else)))
 
+(: if-not-reducible (-> Atom Atom Atom Atom))
 (= (if-not-reducible $atom $then $else)
   (eval (if-equal $atom NotReducible $then $else)))
 
+(: if-error (-> Atom Atom Atom Atom))
 (= (if-error $atom $then $else)
   (eval (if-decons $atom $head $_
     (eval (if-equal $head Error $then $else))
     $else )))
 
+(: return-on-error (-> Atom Atom Atom))
 (= (return-on-error $atom $then)
   (eval (if-empty $atom Empty
     (eval (if-error $atom $atom
       $then )))))
 
-(= (car $atom)
-  (eval (if-decons $atom $head $_
-    $head
-    (Error (car $atom) \"car expects a non-empty expression as an argument\") )))
-
+(: switch (-> %Undefined% Expression Atom))
 (= (switch $atom $cases)
   (chain (decons $cases) $list
     (chain (eval (switch-internal $atom $list)) $res
@@ -408,11 +410,13 @@ pub static METTA_CODE: &'static str = "
 ; FIXME: subst and reduce are not used in interpreter implementation
 ; we could remove them
 
+(: subst (-> Atom Variable Atom Atom))
 (= (subst $atom $var $templ)
   (unify $atom $var $templ
     (Error (subst $atom $var $templ)
       \"subst expects a variable as a second argument\") ))
 
+(: reduce (-> Atom Variable Atom Atom))
 (= (reduce $atom $var $templ)
   (chain (eval $atom) $res
     (eval (if-empty $res Empty
@@ -541,6 +545,18 @@ pub static METTA_CODE: &'static str = "
 
 (: case (-> %Undefined% Expression Atom))
 (= (case $atom $cases) (switch $atom $cases))
+
+(: car (-> Expression Atom))
+(= (car $atom)
+  (eval (if-decons $atom $head $_
+    $head
+    (Error (car $atom) \"car expects a non-empty expression as an argument\") )))
+
+(: cdr (-> Expression Expression))
+(= (cdr $atom)
+  (eval (if-decons $atom $_ $tail
+    $tail
+    (Error (cdr $atom) \"cdr expects a non-empty expression as an argument\") )))
 
 ";
 

--- a/lib/src/metta/runner/stdlib2.rs
+++ b/lib/src/metta/runner/stdlib2.rs
@@ -535,6 +535,9 @@ pub static METTA_CODE: &'static str = "
     (let $pattern $atom (let* $tail $template))
     $template )))
 
+(: case (-> %Undefined% Expression Atom))
+(= (case $atom $cases) (switch $atom $cases))
+
 ";
 
 #[cfg(test)]

--- a/python/hyperon/atoms.py
+++ b/python/hyperon/atoms.py
@@ -91,6 +91,10 @@ class AtomType:
     GROUNDED = Atom._from_catom(hp.CAtomType.GROUNDED)
     GROUNDED_SPACE = Atom._from_catom(hp.CAtomType.GROUNDED_SPACE)
 
+class Atoms:
+
+    VOID = Atom._from_catom(hp.CAtoms.VOID)
+
 class GroundedAtom(Atom):
 
     def __init__(self, catom):

--- a/python/hyperonpy.cpp
+++ b/python/hyperonpy.cpp
@@ -426,6 +426,7 @@ struct CSExprParser {
 };
 
 struct CAtomType {};
+struct CAtoms {};
 
 PYBIND11_MODULE(hyperonpy, m) {
     m.doc() = "Python API of the Hyperon library";
@@ -689,6 +690,11 @@ PYBIND11_MODULE(hyperonpy, m) {
             get_atom_types(space.ptr(), atom.ptr(), copy_atoms, &atoms);
             return atoms;
         }, "Get types of the given atom");
+
+#define ADD_SYMBOL(t, d) .def_property_readonly_static(#t, [](py::object) { return CAtom(t ## _SYMBOL()); }, d " atom type")
+
+    py::class_<CAtoms>(m, "CAtoms")
+        ADD_SYMBOL(VOID, "Void");
 
     py::class_<CMetta>(m, "CMetta").def(py::init(&cmetta_from_inner_ptr_as_int));
     m.def("metta_new", [](CSpace space, CTokenizer tokenizer, char const* cwd) {

--- a/python/tests/scripts/b5_types_prelim.metta
+++ b/python/tests/scripts/b5_types_prelim.metta
@@ -55,7 +55,7 @@
 ; The following will be accepted by the interpreter
 !(assertEqualToResult
    (Add Z Ten)
-  ((Add Z Ten)))
+  ((Add Z Ten) (Error Ten BadType)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/python/tests/scripts/b5_types_prelim.metta
+++ b/python/tests/scripts/b5_types_prelim.metta
@@ -55,7 +55,7 @@
 ; The following will be accepted by the interpreter
 !(assertEqualToResult
    (Add Z Ten)
-  ((Add Z Ten) (Error Ten BadType)))
+  ((Add Z Ten)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -84,7 +84,7 @@
 ; This list is badly typed, because S and Z are not the same type
 !(assertEqualToResult
   (Cons S (Cons Z Nil))
-  ((Error (Cons Z Nil) BadType)))
+  ((Error Z BadType)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/python/tests/scripts/b5_types_prelim.metta
+++ b/python/tests/scripts/b5_types_prelim.metta
@@ -84,7 +84,7 @@
 ; This list is badly typed, because S and Z are not the same type
 !(assertEqualToResult
   (Cons S (Cons Z Nil))
-  ((Error Z BadType)))
+  ((Error (Cons Z Nil) BadType)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/python/tests/test_custom_space.py
+++ b/python/tests/test_custom_space.py
@@ -132,7 +132,6 @@ class CustomSpaceTest(HyperonTestCase):
         space_atom = G(nested)
 
         runner = MeTTa()
-        runner.space().add_atom(space_atom)
         runner.tokenizer().register_token("nested", lambda token: space_atom)
 
         result = runner.run("!(match nested (A $x) $x)")

--- a/python/tests/test_run_metta.py
+++ b/python/tests/test_run_metta.py
@@ -72,7 +72,7 @@ class MeTTaTest(HyperonTestCase):
 
     def process_exceptions(self, results):
         for result in results:
-            self.assertEqual(result, [Atoms.VOID])
+            self.assertEqual(result, [])
 
     def test_scripts(self):
         self.process_exceptions(MeTTa().import_file(f"{pwd}/scripts/a1_symbols.metta"))

--- a/python/tests/test_run_metta.py
+++ b/python/tests/test_run_metta.py
@@ -1,6 +1,6 @@
 import unittest
 
-from hyperon import MeTTa
+from hyperon import MeTTa, Atoms
 from test_common import HyperonTestCase
 
 from pathlib import Path
@@ -72,7 +72,7 @@ class MeTTaTest(HyperonTestCase):
 
     def process_exceptions(self, results):
         for result in results:
-            self.assertEqual(result, [])
+            self.assertEqual(result, [Atoms.VOID])
 
     def test_scripts(self):
         self.process_exceptions(MeTTa().import_file(f"{pwd}/scripts/a1_symbols.metta"))

--- a/repl/Cargo.toml
+++ b/repl/Cargo.toml
@@ -22,5 +22,6 @@ name = "metta"
 path = "src/main.rs"
 
 [features]
-# default = ["python"]
+# default = ["python", "minimal"]
 python = ["pyo3", "semver"]
+minimal = ["hyperon/minimal"]

--- a/repl/src/metta_shim.rs
+++ b/repl/src/metta_shim.rs
@@ -8,7 +8,10 @@ use hyperon::space::*;
 use hyperon::space::grounding::GroundingSpace;
 use hyperon::metta::*;
 use hyperon::metta::runner::Metta;
+#[cfg(not(feature = "minimal"))]
 use hyperon::metta::runner::stdlib::register_rust_tokens;
+#[cfg(feature = "minimal")]
+use hyperon::metta::runner::stdlib2::register_rust_tokens;
 use hyperon::metta::text::Tokenizer;
 use hyperon::metta::text::SExprParser;
 use hyperon::common::shared::Shared;


### PR DESCRIPTION
Next batch of minimal MeTTa related fixes and changes:
- `minimal` feature is added to switch core library to the minimal MeTTa interpreter at compile time, one can run Rust unit tests using `cargo test --features minimal`
- minimal MeTTa's `match` is renamed to `unify` because previous `match` definition has different order of arguments and thus incompatible with new one, old `match` is added into minimal MeTTa standard library
- pattern matcher syntax extensions suggestions are added to the minimal MeTTa docs, docs are fixed
- `assert...`, `collapse`, `superpose`, `let` and `let*`, `case`, `match` and `pragma!` are added into minimal MeTTa standard library, some of them are added as grounded atoms because they require the working atomspace to evaluate arguments which is not implemented yet
- `Void` is added as a result of `assert...` operation, this is to handle https://github.com/trueagi-io/hyperon-experimental/issues/390 in minimal MeTTa
- `NotReducible` is returned instead of `Empty` by minimal MeTTa interpreter when function definition is not found. This corresponds to the previous interpreter's behavior. Two major use-cases are type constructors (which are usually have no definition only type declaration) and partially defined functions (which return results on some arguments and stay non-reducible on others).
- benchmark for the nested `chain` operation is added and `chain` implementation is optimized
- few small fixes

Better to review commit by commit.