### PR TITLE
Rework rust test functions & add stdlib comparison operators

### DIFF
--- a/lib/examples/sorted_list.rs
+++ b/lib/examples/sorted_list.rs
@@ -18,9 +18,9 @@ fn main() -> Result<(), String> {
     "))?;
 
     assert_eq!(metta.run(SExprParser::new("!(insert 1 Nil)"))?[0],
-        vec![metta.parse_one_atom("(Cons 1 Nil)")?]);
+        vec![SExprParser::new("(Cons 1 Nil)").parse(&*metta.tokenizer().borrow())?.unwrap()]);
     assert_eq!(metta.run(SExprParser::new("(insert 3 (insert 2 (insert 1 Nil)))"))?[0],
-        vec![metta.parse_one_atom("(Cons 1 (Cons 2 (Cons 3 Nil)))")?]);
+        vec![SExprParser::new("(Cons 1 (Cons 2 (Cons 3 Nil)))").parse(&*metta.tokenizer().borrow())?.unwrap()]);
 
     Ok(())
 }

--- a/lib/examples/sorted_list.rs
+++ b/lib/examples/sorted_list.rs
@@ -1,8 +1,8 @@
-use hyperon::metta::*;
-use hyperon::metta::interpreter::*;
+use hyperon::metta::runner::*;
 
-fn main() {
-    let space = metta_space("
+fn main() -> Result<(), String> {
+    let metta = Metta::new(None);
+    metta.run_program_str("
         (: List (-> $a Type))
         (: Nil (List $a))
         (: Cons (-> $a (List $a) (List $a)))
@@ -15,11 +15,12 @@ fn main() {
         (= (insert $x (Cons $head $tail)) (if (< $x $head)
                                               (Cons $x (Cons $head $tail))
                                               (Cons $head (insert $x $tail))))
-    ");
+    ")?;
 
+    assert_eq!(metta.run_program_str("!(insert 1 Nil)")?[0],
+        vec![metta.parse_one_atom("(Cons 1 Nil)")?]);
+    assert_eq!(metta.run_program_str("(insert 3 (insert 2 (insert 1 Nil)))")?[0],
+        vec![metta.parse_one_atom("(Cons 1 (Cons 2 (Cons 3 Nil)))")?]);
 
-    assert_eq!(interpret(&space, &metta_atom("(insert 1 Nil)")),
-        Ok(vec![metta_atom("(Cons 1 Nil)")]));
-    assert_eq!(interpret(&space, &metta_atom("(insert 3 (insert 2 (insert 1 Nil)))")),
-        Ok(vec![metta_atom("(Cons 1 (Cons 2 (Cons 3 Nil)))")]));
+    Ok(())
 }

--- a/lib/examples/sorted_list.rs
+++ b/lib/examples/sorted_list.rs
@@ -1,8 +1,8 @@
-use hyperon::metta::runner::*;
+use hyperon::metta::{runner::*, text::SExprParser};
 
 fn main() -> Result<(), String> {
     let metta = Metta::new(None);
-    metta.run_program_str("
+    metta.run(SExprParser::new("
         (: List (-> $a Type))
         (: Nil (List $a))
         (: Cons (-> $a (List $a) (List $a)))
@@ -15,11 +15,11 @@ fn main() -> Result<(), String> {
         (= (insert $x (Cons $head $tail)) (if (< $x $head)
                                               (Cons $x (Cons $head $tail))
                                               (Cons $head (insert $x $tail))))
-    ")?;
+    "))?;
 
-    assert_eq!(metta.run_program_str("!(insert 1 Nil)")?[0],
+    assert_eq!(metta.run(SExprParser::new("!(insert 1 Nil)"))?[0],
         vec![metta.parse_one_atom("(Cons 1 Nil)")?]);
-    assert_eq!(metta.run_program_str("(insert 3 (insert 2 (insert 1 Nil)))")?[0],
+    assert_eq!(metta.run(SExprParser::new("(insert 3 (insert 2 (insert 1 Nil)))"))?[0],
         vec![metta.parse_one_atom("(Cons 1 (Cons 2 (Cons 3 Nil)))")?]);
 
     Ok(())

--- a/lib/src/common/mod.rs
+++ b/lib/src/common/mod.rs
@@ -14,11 +14,7 @@ mod arithmetics;
 pub use arithmetics::*;
 
 use crate::*;
-use crate::metta::runner::*;
-use crate::space::DynSpace;
-use crate::space::grounding::GroundingSpace;
-use crate::common::shared::Shared;
-use crate::metta::text::Tokenizer;
+use crate::metta::text::{Tokenizer, SExprParser};
 use std::cell::RefCell;
 use std::fmt::{Debug, Display};
 use std::collections::HashMap;
@@ -38,10 +34,9 @@ pub struct Operation {
 
 impl Grounded for &'static Operation {
     fn type_(&self) -> Atom {
-        //TODO: I think we want to be able to parse the type in the context of the current runner, rather than makeing a new one
-        //QUESTION: Why don't we parse the type once, and store the parsed type atom, rather than parsing it each time the accessor is called?
-        let metta = Metta::new_core(DynSpace::new(GroundingSpace::new()), Shared::new(Tokenizer::new()), None);
-        metta.parse_one_atom(self.typ).unwrap()
+        //TODO: Replace this parsing with a static Atom
+        let mut parser = SExprParser::new(self.typ);
+        parser.parse(&Tokenizer::new()).unwrap().unwrap()
     }
 
     fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {

--- a/lib/src/common/mod.rs
+++ b/lib/src/common/mod.rs
@@ -14,11 +14,17 @@ mod arithmetics;
 pub use arithmetics::*;
 
 use crate::*;
+use crate::metta::runner::*;
+use crate::space::DynSpace;
+use crate::space::grounding::GroundingSpace;
+use crate::common::shared::Shared;
+use crate::metta::text::Tokenizer;
 use std::cell::RefCell;
 use std::fmt::{Debug, Display};
 use std::collections::HashMap;
 
-use crate::metta::metta_atom;
+#[cfg(test)]
+pub(crate) mod test_utils;
 
 // TODO: move Operation and arithmetics under metta package as it uses metta_atom
 // Operation implements stateless operations as GroundedAtom.
@@ -32,7 +38,10 @@ pub struct Operation {
 
 impl Grounded for &'static Operation {
     fn type_(&self) -> Atom {
-        metta_atom(self.typ)
+        //TODO: I think we want to be able to parse the type in the context of the current runner, rather than makeing a new one
+        //QUESTION: Why don't we parse the type once, and store the parsed type atom, rather than parsing it each time the accessor is called?
+        let metta = Metta::new_core(DynSpace::new(GroundingSpace::new()), Shared::new(Tokenizer::new()), None);
+        metta.parse_one_atom(self.typ).unwrap()
     }
 
     fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {

--- a/lib/src/common/test_utils.rs
+++ b/lib/src/common/test_utils.rs
@@ -1,0 +1,17 @@
+
+use crate::*;
+use crate::metta::runner::{Metta, EnvBuilder};
+use crate::space::grounding::GroundingSpace;
+
+pub(crate) fn metta_space(text: &str) -> GroundingSpace {
+    let metta = Metta::new(Some(EnvBuilder::test_env()));
+    let atoms = metta.parse_all_atoms(text).unwrap();
+    let mut space = GroundingSpace::new();
+    atoms.into_iter().for_each(|atom| space.add(atom));
+    space
+}
+
+pub(crate) fn metta_atom(atom_str: &str) -> Atom {
+    let metta = Metta::new(Some(EnvBuilder::test_env()));
+    metta.parse_one_atom(atom_str).expect("Single atom is expected")
+}

--- a/lib/src/common/test_utils.rs
+++ b/lib/src/common/test_utils.rs
@@ -1,17 +1,23 @@
 
 use crate::*;
-use crate::metta::runner::{Metta, EnvBuilder};
+use crate::metta::runner::*;
+use crate::metta::runner::EnvBuilder;
+use crate::metta::text::SExprParser;
 use crate::space::grounding::GroundingSpace;
 
 pub(crate) fn metta_space(text: &str) -> GroundingSpace {
     let metta = Metta::new(Some(EnvBuilder::test_env()));
-    let atoms = metta.parse_all_atoms(text).unwrap();
     let mut space = GroundingSpace::new();
-    atoms.into_iter().for_each(|atom| space.add(atom));
+    let mut parser = SExprParser::new(text);
+    while let Some(atom) = parser.parse(&metta.tokenizer().borrow()).unwrap() {
+        space.add(atom);
+    }
     space
 }
 
 pub(crate) fn metta_atom(atom_str: &str) -> Atom {
     let metta = Metta::new(Some(EnvBuilder::test_env()));
-    metta.parse_one_atom(atom_str).expect("Single atom is expected")
+    let mut parser = SExprParser::new(atom_str);
+    let atom = parser.parse(&metta.tokenizer().borrow()).unwrap().expect("Single atom is expected");
+    atom
 }

--- a/lib/src/common/test_utils.rs
+++ b/lib/src/common/test_utils.rs
@@ -1,23 +1,19 @@
 
 use crate::*;
-use crate::metta::runner::*;
-use crate::metta::runner::EnvBuilder;
-use crate::metta::text::SExprParser;
+use crate::metta::text::{Tokenizer, SExprParser};
 use crate::space::grounding::GroundingSpace;
 
 pub(crate) fn metta_space(text: &str) -> GroundingSpace {
-    let metta = Metta::new(Some(EnvBuilder::test_env()));
     let mut space = GroundingSpace::new();
     let mut parser = SExprParser::new(text);
-    while let Some(atom) = parser.parse(&metta.tokenizer().borrow()).unwrap() {
+    while let Some(atom) = parser.parse(&Tokenizer::new()).unwrap() {
         space.add(atom);
     }
     space
 }
 
 pub(crate) fn metta_atom(atom_str: &str) -> Atom {
-    let metta = Metta::new(Some(EnvBuilder::test_env()));
     let mut parser = SExprParser::new(atom_str);
-    let atom = parser.parse(&metta.tokenizer().borrow()).unwrap().expect("Single atom is expected");
+    let atom = parser.parse(&Tokenizer::new()).unwrap().expect("Single atom is expected");
     atom
 }

--- a/lib/src/metta/interpreter.rs
+++ b/lib/src/metta/interpreter.rs
@@ -724,6 +724,8 @@ impl<T: Debug> Debug for AlternativeInterpretationsPlan<'_, T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::common::*;
+    use crate::common::test_utils::*;
 
     #[test]
     fn test_match_all() {

--- a/lib/src/metta/interpreter2.rs
+++ b/lib/src/metta/interpreter2.rs
@@ -575,9 +575,8 @@ mod tests {
     fn interpret_atom_evaluate_pure_expression_variable_name_conflict() {
         let space = space("(= (foo ($W)) True)");
         let result = interpret_atom(&space, atom("(eval (foo $W))", bind!{}));
-        assert_eq!(result[0].0, metta_atom("True"));
+        assert_eq!(result[0].0, sym!("True"));
     }
-
 
     #[test]
     fn interpret_atom_evaluate_grounded_expression() {

--- a/lib/src/metta/interpreter2.rs
+++ b/lib/src/metta/interpreter2.rs
@@ -402,6 +402,7 @@ fn cons(bindings: Bindings, head: Atom, tail: ExpressionAtom) -> Vec<Interpreted
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::common::test_utils::{metta_atom, metta_space};
 
     #[test]
     fn interpret_atom_evaluate_incorrect_args() {
@@ -468,7 +469,7 @@ mod tests {
     fn interpret_atom_evaluate_pure_expression_variable_name_conflict() {
         let space = space("(= (foo ($W)) True)");
         let result = interpret_atom(&space, atom("(eval (foo $W))", bind!{}));
-        assert_eq!(result[0].0, sym!("True"));
+        assert_eq!(result[0].0, metta_atom("True"));
     }
 
 

--- a/lib/src/metta/mod.rs
+++ b/lib/src/metta/mod.rs
@@ -7,11 +7,7 @@ pub mod interpreter2;
 pub mod types;
 pub mod runner;
 
-use text::{SExprParser, Tokenizer};
-use regex::Regex;
-
 use crate::*;
-use crate::common::*;
 use crate::space::grounding::GroundingSpace;
 
 pub const ATOM_TYPE_UNDEFINED : Atom = sym!("%Undefined%");
@@ -82,51 +78,4 @@ pub fn atom_error_message(atom: &Atom) -> &str {
         _ => panic!("{}", PANIC_STR)
     }
 }
-
-//QUESTION: These functions below seem to only be used in tests.  If that's the case, should we
-// move them into a test-only module so they aren't exposed as part of the public API?
-//Alternatively rewrite the tests to use a runner?
-//
-//Also, a "Metta::parse_atoms() -> Vec<Atom>" method
-// might be useful to parse atoms with the context of a runner's tokenizer as a compliment to
-// RunnerState::new_with_atoms
-
-// TODO: use stdlib to parse input text
-pub fn metta_space(text: &str) -> GroundingSpace {
-    let tokenizer = common_tokenizer();
-    let mut parser = SExprParser::new(text);
-    let mut space = GroundingSpace::new();
-    loop {
-        let atom = parser.parse(&tokenizer).unwrap();
-        if let Some(atom) = atom {
-            space.add(atom);
-        } else {
-            break;
-        }
-    }
-    space
-}
-
-fn common_tokenizer() -> Tokenizer {
-    let mut tokenizer = Tokenizer::new();
-    tokenizer.register_token(Regex::new(r"\d+").unwrap(),
-        |n| Atom::value(n.parse::<i32>().unwrap()));
-    tokenizer.register_token(Regex::new(r"true|false").unwrap(),
-        |b| Atom::value(b.parse::<bool>().unwrap()));
-    tokenizer.register_token(Regex::new(r"<").unwrap(), |_| Atom::gnd(LT));
-    tokenizer
-}
-
-// TODO: use stdlib to parse input text
-pub fn metta_atom(atom: &str) -> Atom {
-    let tokenizer = common_tokenizer();
-    let mut parser = SExprParser::new(atom);
-    let atom = parser.parse(&tokenizer).unwrap();
-    if let Some(atom) = atom {
-        atom
-    } else {
-        panic!("Single atom is expected");
-    }
-}
-
 

--- a/lib/src/metta/runner/arithmetics.rs
+++ b/lib/src/metta/runner/arithmetics.rs
@@ -7,10 +7,21 @@ use std::fmt::Display;
 pub const ATOM_TYPE_NUMBER : Atom = sym!("Number");
 pub const ATOM_TYPE_BOOL : Atom = sym!("Bool");
 
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Debug)]
 pub enum Number {
     Integer(i64),
     Float(f64),
+}
+
+impl PartialEq<Self> for Number {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Number::Integer(a), Number::Integer(b)) => a == b,
+            (Number::Integer(a), Number::Float(b)) => (*a as f64) == *b,
+            (Number::Float(a), Number::Integer(b)) => *a == (*b as f64),
+            (Number::Float(a), Number::Float(b)) => a == b,
+        }
+    }
 }
 
 trait IntoNumber {
@@ -147,7 +158,6 @@ def_binary_number_op!(LessOp, <, ATOM_TYPE_BOOL, Bool);
 def_binary_number_op!(GreaterOp, >, ATOM_TYPE_BOOL, Bool);
 def_binary_number_op!(LessEqOp, <=, ATOM_TYPE_BOOL, Bool);
 def_binary_number_op!(GreaterEqOp, >=, ATOM_TYPE_BOOL, Bool);
-def_binary_number_op!(EqualOp, ==, ATOM_TYPE_BOOL, Bool);
 
 #[cfg(test)]
 mod tests {

--- a/lib/src/metta/runner/mod.rs
+++ b/lib/src/metta/runner/mod.rs
@@ -250,32 +250,6 @@ impl Metta {
         state.run_to_completion()
     }
 
-    /// Parses a string into a single Atom
-    pub fn parse_one_atom(&self, text: &str) -> Result<Atom, String> {
-        let mut parser = SExprParser::new(text);
-        let atom = parser.parse(&*self.tokenizer().borrow())?;
-        if let Some(atom) = atom {
-            Ok(atom)
-        } else {
-            panic!("Expected a single atom");
-        }
-    }
-
-    /// Parses a string into a vector of Atoms
-    pub fn parse_all_atoms(&self, text: &str) -> Result<Vec<Atom>, String> {
-        let mut parser = SExprParser::new(text);
-        let mut atoms = vec![];
-        loop {
-            let atom = parser.parse(&*self.tokenizer().borrow())?;
-            if let Some(atom) = atom {
-                atoms.push(atom)
-            } else {
-                break;
-            }
-        }
-        Ok(atoms)
-    }
-
     // TODO: this method is deprecated and should be removed after switching
     // to the minimal MeTTa
     pub fn evaluate_atom(&self, atom: Atom) -> Result<Vec<Atom>, String> {

--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -1207,8 +1207,10 @@ pub static METTA_CODE: &'static str = "
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::metta::text::*;
     use crate::metta::runner::{Metta, EnvBuilder};
     use crate::metta::types::validate_atom;
+    use crate::common::test_utils::*;
 
     fn run_program(program: &str) -> Result<Vec<Vec<Atom>>, String> {
         let metta = Metta::new(Some(EnvBuilder::test_env()));

--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -1083,6 +1083,32 @@ impl Grounded for ChangeStateOp {
     }
 }
 
+#[derive(Clone, PartialEq, Debug)]
+pub struct EqualOp {}
+
+impl Display for EqualOp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "==")
+    }
+}
+
+impl Grounded for EqualOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_ATOM, ATOM_TYPE_ATOM, ATOM_TYPE_BOOL])
+    }
+
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        let arg_error = || ExecError::from(concat!(stringify!($op), " expects two arguments"));
+        let a = args.get(0).ok_or_else(arg_error)?;
+        let b = args.get(1).ok_or_else(arg_error)?;
+
+        Ok(vec![Atom::gnd(Bool(a == b))])
+    }
+
+    fn match_(&self, other: &Atom) -> MatchResultIter {
+        match_by_equality(self, other)
+    }
+}
 
 fn regex(regex: &str) -> Regex {
     Regex::new(regex).unwrap()

--- a/lib/src/metta/runner/stdlib2.rs
+++ b/lib/src/metta/runner/stdlib2.rs
@@ -411,8 +411,11 @@ pub static METTA_CODE: &'static str = include_str!("stdlib.metta");
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::metta::text::SExprParser;
     use crate::metta::runner::EnvBuilder;
     use crate::matcher::atoms_are_equivalent;
+    use crate::common::Operation;
+    use crate::common::test_utils::metta_space;
 
     use std::convert::TryFrom;
 

--- a/lib/src/metta/types.rs
+++ b/lib/src/metta/types.rs
@@ -158,15 +158,16 @@ fn get_args(expr: &ExpressionAtom) -> &[Atom] {
 /// use hyperon::{Atom, expr, assert_eq_no_order};
 /// use hyperon::metta::ATOM_TYPE_UNDEFINED;
 /// use hyperon::metta::runner::*;
+/// use hyperon::metta::text::SExprParser;
 /// use hyperon::metta::types::get_atom_types;
 ///
 /// let metta = Metta::new(None);
-/// metta.run_program_str("
+/// metta.run(SExprParser::new("
 ///     (: f (-> A B))
 ///     (: a A)
 ///     (: a B)
 ///     (: b B)
-/// ").unwrap();
+/// ")).unwrap();
 ///
 /// let space = metta.space();
 /// assert_eq_no_order!(get_atom_types(&space, &expr!(x)), vec![ATOM_TYPE_UNDEFINED]);
@@ -390,10 +391,11 @@ fn get_matched_types(space: &dyn Space, atom: &Atom, typ: &Atom) -> Vec<(Atom, B
 /// ```
 /// use hyperon::expr;
 /// use hyperon::metta::runner::*;
+/// use hyperon::metta::text::SExprParser;
 /// use hyperon::metta::types::check_type;
 ///
 /// let metta = Metta::new(None);
-/// metta.run_program_str("(: a A) (: a B)").unwrap();
+/// metta.run(SExprParser::new("(: a A) (: a B)")).unwrap();
 ///
 /// assert!(check_type(&metta.space(), &expr!("a"), &expr!("B")));
 /// ```
@@ -410,10 +412,11 @@ pub fn check_type(space: &dyn Space, atom: &Atom, typ: &Atom) -> bool {
 /// ```
 /// use hyperon::{expr, bind};
 /// use hyperon::metta::runner::*;
+/// use hyperon::metta::text::SExprParser;
 /// use hyperon::metta::types::get_type_bindings;
 ///
 /// let metta = Metta::new(None);
-/// metta.run_program_str("(: a (List A))").unwrap();
+/// metta.run(SExprParser::new("(: a (List A))")).unwrap();
 /// let types = get_type_bindings(&metta.space(), &expr!("a"), &expr!("List" t));
 ///
 /// assert_eq!(types, vec![(expr!("List" "A"), bind!{ t: expr!("A") })]);
@@ -451,10 +454,11 @@ fn check_meta_type(atom: &Atom, typ: &Atom) -> bool {
 /// ```
 /// use hyperon::expr;
 /// use hyperon::metta::runner::*;
+/// use hyperon::metta::text::SExprParser;
 /// use hyperon::metta::types::validate_atom;
 ///
 /// let metta = Metta::new(None);
-/// metta.run_program_str("(: foo (-> A B)) (: a A) (: b B)").unwrap();
+/// metta.run(SExprParser::new("(: foo (-> A B)) (: a A) (: b B)")).unwrap();
 ///
 /// let space = metta.space();
 /// assert!(validate_atom(&space, &expr!("foo" "a")));

--- a/lib/src/metta/types.rs
+++ b/lib/src/metta/types.rs
@@ -472,7 +472,25 @@ pub fn validate_atom(space: &dyn Space, atom: &Atom) -> bool {
 mod tests {
     use super::*;
     use crate::atom::matcher::atoms_are_equivalent;
-    use crate::common::test_utils::{metta_atom as atom, metta_space};
+    use crate::metta::runner::*;
+    use crate::metta::text::SExprParser;
+
+    fn metta_space(text: &str) -> GroundingSpace {
+        let metta = Metta::new(Some(EnvBuilder::test_env()));
+        let mut space = GroundingSpace::new();
+        let mut parser = SExprParser::new(text);
+        while let Some(atom) = parser.parse(&*metta.tokenizer().borrow()).unwrap() {
+            space.add(atom);
+        }
+        space
+    }
+
+    fn atom(atom_str: &str) -> Atom {
+        let metta = Metta::new(Some(EnvBuilder::test_env()));
+        let mut parser = SExprParser::new(atom_str);
+        let atom = parser.parse(&*metta.tokenizer().borrow()).unwrap().expect("Single atom is expected");
+        atom
+    }
 
     fn grammar_space() -> GroundingSpace {
         let mut space = GroundingSpace::new();

--- a/lib/src/metta/types.rs
+++ b/lib/src/metta/types.rs
@@ -156,16 +156,19 @@ fn get_args(expr: &ExpressionAtom) -> &[Atom] {
 ///
 /// ```
 /// use hyperon::{Atom, expr, assert_eq_no_order};
-/// use hyperon::metta::{metta_space, ATOM_TYPE_UNDEFINED};
+/// use hyperon::metta::ATOM_TYPE_UNDEFINED;
+/// use hyperon::metta::runner::*;
 /// use hyperon::metta::types::get_atom_types;
 ///
-/// let space = metta_space("
+/// let metta = Metta::new(None);
+/// metta.run_program_str("
 ///     (: f (-> A B))
 ///     (: a A)
 ///     (: a B)
 ///     (: b B)
-/// ");
+/// ").unwrap();
 ///
+/// let space = metta.space();
 /// assert_eq_no_order!(get_atom_types(&space, &expr!(x)), vec![ATOM_TYPE_UNDEFINED]);
 /// assert_eq_no_order!(get_atom_types(&space, &expr!({1})), vec![expr!("i32")]);
 /// assert_eq_no_order!(get_atom_types(&space, &expr!("na")), vec![ATOM_TYPE_UNDEFINED]);
@@ -386,12 +389,13 @@ fn get_matched_types(space: &dyn Space, atom: &Atom, typ: &Atom) -> Vec<(Atom, B
 ///
 /// ```
 /// use hyperon::expr;
-/// use hyperon::metta::metta_space;
+/// use hyperon::metta::runner::*;
 /// use hyperon::metta::types::check_type;
 ///
-/// let space = metta_space("(: a A) (: a B)");
+/// let metta = Metta::new(None);
+/// metta.run_program_str("(: a A) (: a B)").unwrap();
 ///
-/// assert!(check_type(&space, &expr!("a"), &expr!("B")));
+/// assert!(check_type(&metta.space(), &expr!("a"), &expr!("B")));
 /// ```
 pub fn check_type(space: &dyn Space, atom: &Atom, typ: &Atom) -> bool {
     check_meta_type(atom, typ) || !get_matched_types(space, atom, typ).is_empty()
@@ -405,11 +409,12 @@ pub fn check_type(space: &dyn Space, atom: &Atom, typ: &Atom) -> bool {
 ///
 /// ```
 /// use hyperon::{expr, bind};
-/// use hyperon::metta::metta_space;
+/// use hyperon::metta::runner::*;
 /// use hyperon::metta::types::get_type_bindings;
 ///
-/// let space = metta_space("(: a (List A))");
-/// let types = get_type_bindings(&space, &expr!("a"), &expr!("List" t));
+/// let metta = Metta::new(None);
+/// metta.run_program_str("(: a (List A))").unwrap();
+/// let types = get_type_bindings(&metta.space(), &expr!("a"), &expr!("List" t));
 ///
 /// assert_eq!(types, vec![(expr!("List" "A"), bind!{ t: expr!("A") })]);
 /// ```
@@ -445,11 +450,13 @@ fn check_meta_type(atom: &Atom, typ: &Atom) -> bool {
 ///
 /// ```
 /// use hyperon::expr;
-/// use hyperon::metta::metta_space;
+/// use hyperon::metta::runner::*;
 /// use hyperon::metta::types::validate_atom;
 ///
-/// let space = metta_space("(: foo (-> A B)) (: a A) (: b B)");
+/// let metta = Metta::new(None);
+/// metta.run_program_str("(: foo (-> A B)) (: a A) (: b B)").unwrap();
 ///
+/// let space = metta.space();
 /// assert!(validate_atom(&space, &expr!("foo" "a")));
 /// assert!(!validate_atom(&space, &expr!("foo" "b")));
 /// ```
@@ -461,8 +468,7 @@ pub fn validate_atom(space: &dyn Space, atom: &Atom) -> bool {
 mod tests {
     use super::*;
     use crate::atom::matcher::atoms_are_equivalent;
-    use crate::metta::metta_space;
-    use crate::metta::metta_atom as atom;
+    use crate::common::test_utils::{metta_atom as atom, metta_space};
 
     fn grammar_space() -> GroundingSpace {
         let mut space = GroundingSpace::new();
@@ -890,7 +896,7 @@ mod tests {
             (: p X)
             (: p P)
         ");
-        assert_eq!(get_atom_types(&space, &metta_atom("(= (foo) (bar p))")),
+        assert_eq!(get_atom_types(&space, &atom("(= (foo) (bar p))")),
             vec![expr!("Type")]);
     }
 

--- a/python/hyperon/runner.py
+++ b/python/hyperon/runner.py
@@ -49,10 +49,10 @@ class RunnerState:
 class MeTTa:
     """This class contains the MeTTa program execution utilities"""
 
-    def __init__(self, space = None, env_builder = None, cmetta = None):
+    def __init__(self, cmetta = None, space = None, env_builder = None):
         self.pymods = {}
 
-      if cmetta is not None:
+        if cmetta is not None:
             self.cmetta = cmetta
         else:
             if space is None:


### PR DESCRIPTION
This PR addresses the comment in `lib/metta/mod.rs` about the functions `metta_space` and `metta_atom`.

These functions are both moved into a test-only module called `common::test_utils`, and they are re-implemented in terms of a test-only runner.

NOTE: This PR sits on top of the extensive https://github.com/trueagi-io/hyperon-experimental/pull/450 PR, but actually has only one unique commit.