### PR TITLE
Minimal interpreter: adding function/return and fix most of the tests

### DIFF
--- a/c/src/metta.rs
+++ b/c/src/metta.rs
@@ -554,13 +554,15 @@ pub extern "C" fn atom_error_message(atom: *const atom_ref_t, buf: *mut c_char, 
 ///
 #[no_mangle] pub extern "C" fn ATOM_TYPE_GROUNDED_SPACE() -> atom_t { rust_type_atom::<DynSpace>().into() }
 
-/// @brief Creates a Symbol atom for the special MeTTa symbol used to indicate empty results in
-/// case expressions.
+/// @brief Creates a Symbol atom for the special MeTTa symbol used to indicate empty results
+/// returned by function.
 /// @ingroup metta_language_group
 /// @return  The `atom_t` representing the Void atom
 /// @note The returned `atom_t` must be freed with `atom_free()`
 ///
-#[no_mangle] pub extern "C" fn VOID_SYMBOL() -> atom_t { hyperon::metta::VOID_SYMBOL.into() }
+#[no_mangle] pub extern "C" fn EMPTY_SYMBOL() -> atom_t {
+    hyperon::metta::EMPTY_SYMBOL.into()
+}
 
 /// @brief Checks whether Atom `atom` has Type `typ` in context of `space`
 /// @ingroup metta_language_group
@@ -705,7 +707,7 @@ pub extern "C" fn step_has_next(step: *const step_result_t) -> bool {
     step.has_next()
 }
 
-/// @brief Consumes a `step_result_t` and provides the ultimate outcome of a MeTTa interpreter session 
+/// @brief Consumes a `step_result_t` and provides the ultimate outcome of a MeTTa interpreter session
 /// @ingroup interpreter_group
 /// @param[in]  step  A pointer to a `step_result_t` to render
 /// @param[in]  callback  A function that will be called to provide a vector of all atoms resulting from the interpreter session

--- a/docs/minimal-metta.md
+++ b/docs/minimal-metta.md
@@ -32,7 +32,7 @@ allowed developing the first stable version with less effort (see `eval` and
 `Return`). If an instruction returns the atom which is not from the minimal set
 it is not interpreted further and returned as a part of the final result.
 
-## Error/Empty/NotReducible/Void
+## Error/Empty/NotReducible/()
 
 There are atoms which can be returned to designate a special situation in a code:
 - `(Error <atom> <message>)` means the interpretation is finished with error;
@@ -46,8 +46,8 @@ There are atoms which can be returned to designate a special situation in a code
   which returns `NotReducible` explicitly; this atom is introduced to separate
   the situations when atom should be returned "as is" from `Empty` when atom
   should be removed from results;
-- `Void` is a unit result which is mainly used by functions with side effects
-  which has no meaningful value to return.
+- Empty expression `()` is a unit result which is mainly used by functions with
+  side effects which has no meaningful value to return.
 
 These atoms are not interpreted further as they are not a part of the minimal
 set of instructions.
@@ -72,7 +72,7 @@ returns no results then `NotReducible` atom is a result of the instruction. Grou
 function can return a list of atoms, empty result, `Error(<message>)` or
 `NoReduce` result. The result of the instruction for a special values are the
 following:
-- empty result returns `Void` atom;
+- empty result returns unit `()` result;
 - `Error(<message>)` returns `(Error <original-atom> <message>)` atom;
 - `NoReduce` returns `NotReducible` atom.
 

--- a/lib/src/atom/matcher.rs
+++ b/lib/src/atom/matcher.rs
@@ -1597,10 +1597,11 @@ mod test {
     fn bindings_cleanup() -> Result<(), &'static str> {
         let mut bindings = Bindings::new()
             .add_var_equality(&VariableAtom::new("a"), &VariableAtom::new("b"))?
-            .add_var_binding_v2(VariableAtom::new("b"), expr!("B"))?
-            .add_var_binding_v2(VariableAtom::new("c"), expr!("C"))?;
+            .add_var_binding_v2(VariableAtom::new("b"), expr!("B" d))?
+            .add_var_binding_v2(VariableAtom::new("c"), expr!("c"))?
+            .add_var_binding_v2(VariableAtom::new("d"), expr!("D"))?;
         bindings.cleanup(&[&VariableAtom::new("b")].into());
-        assert_eq!(bindings, bind!{ b: expr!("B") });
+        assert_eq!(bindings, bind!{ b: expr!("B" d) });
         Ok(())
     }
 

--- a/lib/src/metta/interpreter2.rs
+++ b/lib/src/metta/interpreter2.rs
@@ -301,7 +301,7 @@ fn interpret_atom_root<'a, T: SpaceRef<'a>>(space: T, interpreted_atom: Interpre
     if root {
         result.iter_mut().for_each(|interpreted| {
             let InterpretedAtom(atom, bindings) = interpreted;
-            bindings.cleanup(&atom.iter().filter_type::<&VariableAtom>().collect());
+            *bindings = bindings.narrow_vars(&atom.iter().filter_type::<&VariableAtom>().collect());
         });
     }
     result

--- a/lib/src/metta/interpreter2.rs
+++ b/lib/src/metta/interpreter2.rs
@@ -307,10 +307,6 @@ fn interpret_atom_root<'a, T: SpaceRef<'a>>(space: T, interpreted_atom: Interpre
     result
 }
 
-fn return_unit() -> Atom {
-    VOID_SYMBOL
-}
-
 fn return_not_reducible() -> Atom {
     NOT_REDUCIBLE_SYMBOL
 }
@@ -338,7 +334,7 @@ fn eval<'a, T: SpaceRef<'a>>(space: T, atom: Atom, bindings: Bindings) -> Vec<In
                         // let a caller know that function is not defined on a
                         // passed input data. Thus we can interpreter empty result
                         // by any way we like.
-                        vec![InterpretedAtom(return_unit(), bindings)]
+                        vec![]
                     } else {
                         results.into_iter()
                             .map(|atom| InterpretedAtom(atom, bindings.clone()))
@@ -584,7 +580,7 @@ mod tests {
     #[test]
     fn interpret_atom_evaluate_grounded_expression_empty() {
         let result = interpret_atom(&space(""), InterpretedAtom(expr!("eval" ({ReturnNothing()} {6})), bind!{}));
-        assert_eq!(result, vec![atom("Void", bind!{})]);
+        assert_eq!(result, vec![]);
     }
 
     #[test]

--- a/lib/src/metta/interpreter2.rs
+++ b/lib/src/metta/interpreter2.rs
@@ -237,7 +237,7 @@ fn interpret_atom_root<'a, T: SpaceRef<'a>>(space: T, interpreted_atom: Interpre
         },
         Some([op, args @ ..]) if *op == UNIFY_SYMBOL => {
             match args {
-                [atom, pattern, then, else_] => match_(bindings, atom, pattern, then, else_),
+                [atom, pattern, then, else_] => unify(bindings, atom, pattern, then, else_),
                 _ => {
                     let error: String = format!("expected: ({} <atom> <pattern> <then> <else>), found: {}", UNIFY_SYMBOL, atom);
                     vec![InterpretedAtom(error_atom(atom, error), bindings)]
@@ -457,8 +457,8 @@ fn function<'a, T: SpaceRef<'a>>(space: T, bindings: Bindings, body: Atom, call:
     }
 }
 
-fn match_(bindings: Bindings, atom: &Atom, pattern: &Atom, then: &Atom, else_: &Atom) -> Vec<InterpretedAtom> {
-    // TODO: Should match_() be symmetrical or not. While it is symmetrical then
+fn unify(bindings: Bindings, atom: &Atom, pattern: &Atom, then: &Atom, else_: &Atom) -> Vec<InterpretedAtom> {
+    // TODO: Should unify() be symmetrical or not. While it is symmetrical then
     // if variable is matched by variable then both variables have the same
     // priority. Thus interpreter can use any of them further. This sometimes
     // looks unexpected. For example see `metta_car` unit test where variable

--- a/lib/src/metta/mod.rs
+++ b/lib/src/metta/mod.rs
@@ -33,7 +33,6 @@ pub const NOT_REDUCIBLE_SYMBOL : Atom = sym!("NotReducible");
 pub const NO_VALID_ALTERNATIVES : Atom = sym!("NoValidAlternatives");
 
 pub const EMPTY_SYMBOL : Atom = sym!("Empty");
-pub const VOID_SYMBOL : Atom = sym!("Void");
 
 pub const EVAL_SYMBOL : Atom = sym!("eval");
 pub const CHAIN_SYMBOL : Atom = sym!("chain");
@@ -44,6 +43,17 @@ pub const FUNCTION_SYMBOL : Atom = sym!("function");
 pub const RETURN_SYMBOL : Atom = sym!("return");
 
 pub const INTERPRET_SYMBOL : Atom = sym!("interpret");
+
+//TODO: convert these from functions to static strcutures, when Atoms are Send+Sync
+#[allow(non_snake_case)]
+pub fn UNIT_ATOM() -> Atom {
+    Atom::expr([])
+}
+
+#[allow(non_snake_case)]
+pub fn UNIT_TYPE() -> Atom {
+    Atom::expr([ARROW_SYMBOL])
+}
 
 /// Initializes an error expression atom
 pub fn error_atom(err_atom: Option<Atom>, err_code: Option<Atom>, message: String) -> Atom {

--- a/lib/src/metta/mod.rs
+++ b/lib/src/metta/mod.rs
@@ -40,7 +40,8 @@ pub const CHAIN_SYMBOL : Atom = sym!("chain");
 pub const UNIFY_SYMBOL : Atom = sym!("unify");
 pub const DECONS_SYMBOL : Atom = sym!("decons");
 pub const CONS_SYMBOL : Atom = sym!("cons");
-pub const CHAIN_PLUS_SYMBOL : Atom = sym!("chain+");
+pub const FUNCTION_SYMBOL : Atom = sym!("function");
+pub const RETURN_SYMBOL : Atom = sym!("return");
 
 pub const INTERPRET_SYMBOL : Atom = sym!("interpret");
 

--- a/lib/src/metta/mod.rs
+++ b/lib/src/metta/mod.rs
@@ -40,6 +40,7 @@ pub const CHAIN_SYMBOL : Atom = sym!("chain");
 pub const UNIFY_SYMBOL : Atom = sym!("unify");
 pub const DECONS_SYMBOL : Atom = sym!("decons");
 pub const CONS_SYMBOL : Atom = sym!("cons");
+pub const INTERPRET_SYMBOL : Atom = sym!("interpret");
 
 /// Initializes an error expression atom
 pub fn error_atom(err_atom: Option<Atom>, err_code: Option<Atom>, message: String) -> Atom {

--- a/lib/src/metta/mod.rs
+++ b/lib/src/metta/mod.rs
@@ -40,6 +40,8 @@ pub const CHAIN_SYMBOL : Atom = sym!("chain");
 pub const UNIFY_SYMBOL : Atom = sym!("unify");
 pub const DECONS_SYMBOL : Atom = sym!("decons");
 pub const CONS_SYMBOL : Atom = sym!("cons");
+pub const CHAIN_PLUS_SYMBOL : Atom = sym!("chain+");
+
 pub const INTERPRET_SYMBOL : Atom = sym!("interpret");
 
 /// Initializes an error expression atom

--- a/lib/src/metta/runner/mod.rs
+++ b/lib/src/metta/runner/mod.rs
@@ -14,7 +14,6 @@ use std::sync::Arc;
 mod environment;
 pub use environment::{Environment, EnvBuilder};
 
-#[cfg(not(feature = "minimal"))]
 pub mod stdlib;
 #[cfg(not(feature = "minimal"))]
 use super::interpreter::{interpret, interpret_init, interpret_step, InterpreterState};

--- a/lib/src/metta/runner/stdlib.metta
+++ b/lib/src/metta/runner/stdlib.metta
@@ -86,7 +86,7 @@
       ; recursion because interpreter called by `collapse` evaluates
       ; `type-cast` again.
       (chain (eval (collapse-get-type $atom $space)) $actual-types
-        (chain (eval (foldl $actual-types False
+        (chain (eval (foldl-atom $actual-types False
           $a $b (chain (eval (match-types $b $type True False)) $is-b-comp
             (chain (eval (or $a $is-b-comp)) $or $or) ))) $is-some-comp
           (eval (if $is-some-comp
@@ -104,10 +104,10 @@
       ($_ (return False))
     ))))))
 
-(: filter (-> Expression Variable Atom Expression))
-(= (filter $list $var $filter)
+(: filter-atom (-> Expression Variable Atom Expression))
+(= (filter-atom $list $var $filter)
   (function (eval (if-decons $list $head $tail
-    (chain (eval (filter $tail $var $filter)) $tail-filtered
+    (chain (eval (filter-atom $tail $var $filter)) $tail-filtered
       (chain (eval (apply $head $var $filter)) $filter-expr
         (chain $filter-expr $is-filtered
           (eval (if $is-filtered
@@ -115,22 +115,22 @@
             (return $tail-filtered) )))))
     (return ()) ))))
 
-(: map (-> Expression Variable Atom Expression))
-(= (map $list $var $map)
+(: map-atom (-> Expression Variable Atom Expression))
+(= (map-atom $list $var $map)
   (function (eval (if-decons $list $head $tail
-    (chain (eval (map $tail $var $map)) $tail-mapped
+    (chain (eval (map-atom $tail $var $map)) $tail-mapped
       (chain (eval (apply $head $var $map)) $map-expr
         (chain $map-expr $head-mapped
           (chain (cons $head-mapped $tail-mapped) $res (return $res)) )))
     (return ()) ))))
 
-(: foldl (-> Expression Atom Variable Variable Atom Atom))
-(= (foldl $list $init $a $b $op)
+(: foldl-atom (-> Expression Atom Variable Variable Atom Atom))
+(= (foldl-atom $list $init $a $b $op)
   (function (eval (if-decons $list $head $tail
     (chain (eval (apply $init $a $op)) $op-init
       (chain (eval (apply $head $b $op-init)) $op-head
         (chain $op-head $head-folded
-          (chain (eval (foldl $tail $head-folded $a $b $op)) $res (return $res)) )))
+          (chain (eval (foldl-atom $tail $head-folded $a $b $op)) $res (return $res)) )))
     (return $init) ))))
 
 (= (interpret $atom $type $space)

--- a/lib/src/metta/runner/stdlib.metta
+++ b/lib/src/metta/runner/stdlib.metta
@@ -244,20 +244,25 @@
     (let $pattern $atom (let* $tail $template))
     $template )))
 
-(: car (-> Expression Atom))
-(= (car $atom)
+(: car-atom (-> Expression Atom))
+(= (car-atom $atom)
   (eval (if-decons $atom $head $_
     $head
-    (Error (car $atom) "car expects a non-empty expression as an argument") )))
+    (Error (car-atom $atom) "car-atom expects a non-empty expression as an argument") )))
 
-(: cdr (-> Expression Expression))
-(= (cdr $atom)
+(: cdr-atom (-> Expression Expression))
+(= (cdr-atom $atom)
   (eval (if-decons $atom $_ $tail
     $tail
-    (Error (cdr $atom) "cdr expects a non-empty expression as an argument") )))
+    (Error (cdr-atom $atom) "cdr-atom expects a non-empty expression as an argument") )))
 
 (: quote (-> Atom Atom))
 (= (quote $atom) NotReducible)
 
 (: unquote (-> %Undefined% %Undefined%))
 (= (unquote (quote $atom)) $atom)
+
+; TODO: there is no way to define operation which consumes any number of
+; arguments  and returns unit
+(= (nop) ())
+(= (nop $x) ())

--- a/lib/src/metta/runner/stdlib.metta
+++ b/lib/src/metta/runner/stdlib.metta
@@ -13,8 +13,8 @@
 (: id (-> Atom Atom))
 (= (id $x) $x)
 
-(: insert (-> Atom Variable Atom Atom))
-(= (insert $atom $var $templ)
+(: apply (-> Atom Variable Atom Atom))
+(= (apply $atom $var $templ)
   (function (chain (eval (id $atom)) $var (return $templ))) )
 
 (: if-non-empty-expression (-> Atom Atom Atom Atom))
@@ -108,7 +108,7 @@
 (= (filter $list $var $filter)
   (function (eval (if-decons $list $head $tail
     (chain (eval (filter $tail $var $filter)) $tail-filtered
-      (chain (eval (insert $head $var $filter)) $filter-expr
+      (chain (eval (apply $head $var $filter)) $filter-expr
         (chain $filter-expr $is-filtered
           (eval (if $is-filtered
             (chain (cons $head $tail-filtered) $res (return $res))
@@ -119,7 +119,7 @@
 (= (map $list $var $map)
   (function (eval (if-decons $list $head $tail
     (chain (eval (map $tail $var $map)) $tail-mapped
-      (chain (eval (insert $head $var $map)) $map-expr
+      (chain (eval (apply $head $var $map)) $map-expr
         (chain $map-expr $head-mapped
           (chain (cons $head-mapped $tail-mapped) $res (return $res)) )))
     (return ()) ))))
@@ -127,8 +127,8 @@
 (: foldl (-> Expression Atom Variable Variable Atom Atom))
 (= (foldl $list $init $a $b $op)
   (function (eval (if-decons $list $head $tail
-    (chain (eval (insert $init $a $op)) $op-init
-      (chain (eval (insert $head $b $op-init)) $op-head
+    (chain (eval (apply $init $a $op)) $op-init
+      (chain (eval (apply $head $b $op-init)) $op-head
         (chain $op-head $head-folded
           (chain (eval (foldl $tail $head-folded $a $b $op)) $res (return $res)) )))
     (return $init) ))))

--- a/lib/src/metta/runner/stdlib.metta
+++ b/lib/src/metta/runner/stdlib.metta
@@ -81,10 +81,18 @@
   (function (chain (eval (get-metatype $atom)) $meta
     (eval (if-equal $type $meta
       (return $atom)
-      (chain (eval (get-type $atom $space)) $actual-type
-        (eval (match-types $actual-type $type
-          (return $atom)
-          (return (Error $atom BadType)) ))))))))
+      ; TODO: the proper way to get types is something like
+      ; `(collapse (get-type <atom> <space>))` but it leads to the infinite
+      ; recursion because interpreter called by `collapse` evaluates
+      ; `type-cast` again.
+      (chain (eval (collapse-get-type $atom $space)) $actual-types
+        (chain (eval (foldl $actual-types False
+          $a $b (chain (eval (match-types $b $type True False)) $is-b-comp
+            (chain (eval (or $a $is-b-comp)) $or $or) ))) $is-some-comp
+          (eval (if $is-some-comp
+            (return $atom)
+            (return (Error $atom BadType)) )))))))))
+
 
 (= (is-function $type)
   (function (chain (eval (get-metatype $type)) $meta

--- a/lib/src/metta/runner/stdlib.metta
+++ b/lib/src/metta/runner/stdlib.metta
@@ -195,3 +195,9 @@
   (eval (if-decons $atom $_ $tail
     $tail
     (Error (cdr $atom) "cdr expects a non-empty expression as an argument") )))
+
+(: quote (-> Atom Atom))
+(= (quote $atom) NotReducible)
+
+(: unquote (-> (Atom %Undefined%)))
+(= (unquote (quote $atom)) $atom)

--- a/lib/src/metta/runner/stdlib.metta
+++ b/lib/src/metta/runner/stdlib.metta
@@ -96,6 +96,35 @@
       ($_ (return False))
     ))))))
 
+(: filter (-> Expression Variable Atom Expression))
+(= (filter $list $var $filter)
+  (function (eval (if-decons $list $head $tail
+    (chain (eval (filter $tail $var $filter)) $tail-filtered
+      (chain (eval (insert $head $var $filter)) $filter-expr
+        (chain $filter-expr $is-filtered
+          (eval (if $is-filtered
+            (chain (cons $head $tail-filtered) $res (return $res))
+            (return $tail-filtered) )))))
+    (return ()) ))))
+
+(: map (-> Expression Variable Atom Expression))
+(= (map $list $var $map)
+  (function (eval (if-decons $list $head $tail
+    (chain (eval (map $tail $var $map)) $tail-mapped
+      (chain (eval (insert $head $var $map)) $map-expr
+        (chain $map-expr $head-mapped
+          (chain (cons $head-mapped $tail-mapped) $res (return $res)) )))
+    (return ()) ))))
+
+(: foldl (-> Expression Atom Variable Variable Atom Atom))
+(= (foldl $list $init $a $b $op)
+  (function (eval (if-decons $list $head $tail
+    (chain (eval (insert $init $a $op)) $op-init
+      (chain (eval (insert $head $b $op-init)) $op-head
+        (chain $op-head $head-folded
+          (chain (eval (foldl $tail $head-folded $a $b $op)) $res (return $res)) )))
+    (return $init) ))))
+
 (= (interpret $atom $type $space)
   (function (chain (eval (get-metatype $atom)) $meta
     (eval (if-equal $type Atom
@@ -186,6 +215,12 @@
 (: if (-> Bool Atom Atom $t))
 (= (if True $then $else) $then)
 (= (if False $then $else) $else)
+
+(: or (-> Bool Bool Bool))
+(= (or False False) False)
+(= (or False True) True)
+(= (or True False) True)
+(= (or True True) True)
 
 (: match (-> Atom Atom Atom %Undefined%))
 (= (match $space $pattern $template)

--- a/lib/src/metta/runner/stdlib.metta
+++ b/lib/src/metta/runner/stdlib.metta
@@ -48,24 +48,6 @@
 (= (switch-internal $atom (($pattern $template) $tail))
   (unify $atom $pattern $template (eval (switch $atom $tail))))
 
-; FIXME: subst and reduce are not used in interpreter implementation
-; we could remove them
-
-(: subst (-> Atom Variable Atom Atom))
-(= (subst $atom $var $templ)
-  (unify $atom $var $templ
-    (Error (subst $atom $var $templ)
-      "subst expects a variable as a second argument") ))
-
-(: reduce (-> Atom Variable Atom Atom))
-(= (reduce $atom $var $templ)
-  (chain (eval $atom) $res
-    (eval (if-empty $res Empty
-      (eval (if-error $res $res
-        (eval (if-not-reducible $res
-          (eval (subst $atom $var $templ))
-          (eval (reduce $res $var $templ)) ))))))))
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; MeTTa interpreter implementation ;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/lib/src/metta/runner/stdlib.metta
+++ b/lib/src/metta/runner/stdlib.metta
@@ -10,11 +10,12 @@
 (: cons (-> Atom Atom Atom))
 (: decons (-> Atom Atom))
 
+(: id (-> Atom Atom))
+(= (id $x) $x)
+
 (: insert (-> Atom Variable Atom Atom))
 (= (insert $atom $var $templ)
-  (function (chain (eval (quote $atom)) $x
-    (chain (eval (unquote $x)) $var
-      (return $templ) ))))
+  (function (chain (eval (id $atom)) $var (return $templ))) )
 
 (: if-non-empty-expression (-> Atom Atom Atom Atom))
 (= (if-non-empty-expression $atom $then $else)
@@ -46,7 +47,7 @@
 
 (: return-on-error (-> Atom Atom Atom))
 (= (return-on-error $atom $then)
-  (function (eval (if-empty $atom Empty
+  (function (eval (if-empty $atom (return (return Empty))
     (eval (if-error $atom (return (return $atom))
       (return $then) ))))))
 

--- a/lib/src/metta/runner/stdlib.metta
+++ b/lib/src/metta/runner/stdlib.metta
@@ -1,175 +1,180 @@
 (: ErrorType Type)
 (: Error (-> Atom Atom ErrorType))
+(: ReturnType Type)
+(: return (-> Atom ReturnType))
 
+(: function (-> Atom Atom))
 (: eval (-> Atom Atom))
 (: chain (-> Atom Variable Atom Atom))
-(: chain+ (-> Atom Variable Atom Atom))
 (: unify (-> Atom Atom Atom Atom Atom))
 (: cons (-> Atom Atom Atom))
 (: decons (-> Atom Atom))
 
-(: ReturnType Type)
-(: return (-> Atom ReturnType))
-
-(: if-return (-> Atom Atom Atom Atom))
-(= (if-return $atom $then $else)
-  (eval (if-decons $atom $head $_
-    (eval (if-equal $head return $then $else))
-    $else )))
-
-(= (chain-eval $expr $var $templ)
-  (chain+ (eval $expr) $res
-    (eval (if-return $res
-      (unify $res (return $ret)
-        (unify $var $ret $templ
-          (Error (chain-eval $expr $var $templ) "$ret cannot be matched with $var"))
-        (Error (chain-eval $expr $var $templ) "(return $ret) is expected") )
-      (chain $res $var $templ) ))))
+(: insert (-> Atom Variable Atom Atom))
+(= (insert $atom $var $templ)
+  (function (chain (eval (quote $atom)) $x
+    (chain (eval (unquote $x)) $var
+      (return $templ) ))))
 
 (: if-non-empty-expression (-> Atom Atom Atom Atom))
 (= (if-non-empty-expression $atom $then $else)
-  (chain (eval (get-metatype $atom)) $type
+  (function (chain (eval (get-metatype $atom)) $type
     (eval (if-equal $type Expression
-      (eval (if-equal $atom () $else $then))
-      $else ))))
+      (eval (if-equal $atom () (return $else) (return $then)))
+      (return $else) )))))
 
 (: if-decons (-> Atom Variable Variable Atom Atom Atom))
 (= (if-decons $atom $head $tail $then $else)
-  (eval (if-non-empty-expression $atom
+  (function (eval (if-non-empty-expression $atom
     (chain (decons $atom) $list
-      (unify $list ($head $tail) $then $else) )
-    $else )))
+      (unify $list ($head $tail) (return $then) (return $else)) )
+    (return $else) ))))
 
 (: if-empty (-> Atom Atom Atom Atom))
 (= (if-empty $atom $then $else)
-  (eval (if-equal $atom Empty $then $else)))
+  (function (eval (if-equal $atom Empty (return $then) (return $else)))) )
 
 (: if-not-reducible (-> Atom Atom Atom Atom))
 (= (if-not-reducible $atom $then $else)
-  (eval (if-equal $atom NotReducible $then $else)))
+  (function (eval (if-equal $atom NotReducible (return $then) (return $else)))) )
 
 (: if-error (-> Atom Atom Atom Atom))
 (= (if-error $atom $then $else)
-  (eval (if-decons $atom $head $_
-    (eval (if-equal $head Error $then $else))
-    $else )))
+  (function (eval (if-decons $atom $head $_
+    (eval (if-equal $head Error (return $then) (return $else)))
+    (return $else) ))))
 
 (: return-on-error (-> Atom Atom Atom))
 (= (return-on-error $atom $then)
-  (eval (if-empty $atom Empty
-    (eval (if-error $atom $atom
-      $then )))))
+  (function (eval (if-empty $atom Empty
+    (eval (if-error $atom (return (return $atom))
+      (return $then) ))))))
 
 (: switch (-> %Undefined% Expression Atom))
 (= (switch $atom $cases)
-  (chain (decons $cases) $list
-    (eval (chain-eval (switch-internal $atom $list) $res
-      (eval (if-not-reducible $res Empty $res)) ))))
+  (function (chain (decons $cases) $list
+    (chain (eval (switch-internal $atom $list)) $res
+      (chain (eval (if-not-reducible $res Empty $res)) $x (return $x)) ))))
 
 (= (switch-internal $atom (($pattern $template) $tail))
-  (unify $atom $pattern $template (eval (switch $atom $tail))))
+  (function (unify $atom $pattern
+    (return $template)
+    (chain (eval (switch $atom $tail)) $ret (return $ret)) )))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; MeTTa interpreter implementation ;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (= (match-types $type1 $type2 $then $else)
-    (eval (if-equal $type1 %Undefined% $then
-      (eval (if-equal $type2 %Undefined% $then
-        (eval (if-equal $type1 Atom $then
-          (eval (if-equal $type2 Atom $then
-            (unify $type1 $type2 $then $else) )))))))))
+  (function (eval (if-equal $type1 %Undefined%
+    (return $then)
+    (eval (if-equal $type2 %Undefined%
+      (return $then)
+      (eval (if-equal $type1 Atom
+        (return $then)
+        (eval (if-equal $type2 Atom
+          (return $then)
+          (unify $type1 $type2 (return $then) (return $else)) ))))))))))
 
 (= (type-cast $atom $type $space)
-  (chain (eval (get-metatype $atom)) $meta
-    (eval (if-equal $type $meta $atom
+  (function (chain (eval (get-metatype $atom)) $meta
+    (eval (if-equal $type $meta
+      (return $atom)
       (chain (eval (get-type $atom $space)) $actual-type
         (eval (match-types $actual-type $type
-          $atom
-          (Error $atom BadType) )))))))
+          (return $atom)
+          (return (Error $atom BadType)) ))))))))
 
 (= (is-function $type)
-  (chain (eval (get-metatype $type)) $meta
-    (eval (switch ($type $meta)
-      (
-        (($_ Expression)
-          (eval (chain-eval (car $type) $head
-            (unify $head -> True False) )))
-        ($_ False) )))))
+  (function (chain (eval (get-metatype $type)) $meta
+    (eval (switch ($type $meta) (
+      (($_ Expression)
+        (eval (if-decons $type $head $_tail
+          (unify $head -> (return True) (return False))
+          (return (Error (is-function $type) "is-function non-empty expression as an argument")) )))
+      ($_ (return False))
+    ))))))
 
 (= (interpret $atom $type $space)
-  (chain (eval (get-metatype $atom)) $meta
-    (eval (if-equal $type Atom $atom
-      (eval (if-equal $type $meta $atom
-        (eval (switch ($type $meta)
-          (
-            (($_type Variable) $atom)
-            (($_type Symbol) (eval (type-cast $atom $type $space)))
-            (($_type Grounded) (eval (type-cast $atom $type $space)))
-            (($_type Expression) (eval (interpret-expression $atom $type $space))) )))))))))
+  (function (chain (eval (get-metatype $atom)) $meta
+    (eval (if-equal $type Atom
+      (return $atom)
+      (eval (if-equal $type $meta
+        (return $atom)
+        (eval (switch ($type $meta) (
+          (($_type Variable) (return $atom))
+          (($_type Symbol)
+            (chain (eval (type-cast $atom $type $space)) $ret (return $ret)))
+          (($_type Grounded)
+            (chain (eval (type-cast $atom $type $space)) $ret (return $ret)))
+          (($_type Expression)
+            (chain (eval (interpret-expression $atom $type $space)) $ret (return $ret)))
+        ))))))))))
 
 (= (interpret-expression $atom $type $space)
-  (eval (if-decons $atom $op $args
+  (function (eval (if-decons $atom $op $args
     (chain (eval (get-type $op $space)) $op-type
-      (eval (chain-eval (is-function $op-type) $is-func
+      (chain (eval (is-function $op-type)) $is-func
         (unify $is-func True
-          (eval (chain-eval (interpret-func $atom $op-type $type $space) $reduced-atom
-            (eval (metta-call $reduced-atom $type $space)) ))
-          (eval (chain-eval (interpret-tuple $atom $space) $reduced-atom
-            (eval (metta-call $reduced-atom $type $space)) ))))))
-    (eval (type-cast $atom $type $space)) )))
+          (chain (eval (interpret-func $atom $op-type $type $space)) $reduced-atom
+            (chain (eval (metta-call $reduced-atom $type $space)) $ret (return $ret)) )
+          (chain (eval (interpret-tuple $atom $space)) $reduced-atom
+            (chain (eval (metta-call $reduced-atom $type $space)) $ret (return $ret)) ))))
+    (chain (eval (type-cast $atom $type $space)) $ret (return $ret)) ))))
 
 (= (interpret-func $expr $type $ret-type $space)
-  (eval (if-decons $expr $op $args
-    (eval (chain-eval (interpret $op $type $space) $reduced-op
+  (function (eval (if-decons $expr $op $args
+    (chain (eval (interpret $op $type $space)) $reduced-op
       (eval (return-on-error $reduced-op
         (eval (if-decons $type $arrow $arg-types
-          (eval (chain-eval (interpret-args $expr $args $arg-types $ret-type $space) $reduced-args
+          (chain (eval (interpret-args $expr $args $arg-types $ret-type $space)) $reduced-args
             (eval (return-on-error $reduced-args
-              (chain (cons $reduced-op $reduced-args) $r (return $r))))))
-          (Error $type "Function type expected") ))))))
-    (Error $expr "Non-empty expression atom is expected") )))
+              (chain (cons $reduced-op $reduced-args) $r (return $r)))))
+          (return (Error $type "Function type expected")) )))))
+    (return (Error $expr "Non-empty expression atom is expected")) ))))
 
 (= (interpret-args $atom $args $arg-types $ret-type $space)
-  (unify $args ()
-    (eval (chain-eval (car $arg-types) $actual-ret-type
-      (eval (match-types $actual-ret-type $ret-type () (Error $atom BadType)))))
+  (function (unify $args ()
+    (eval (if-decons $arg-types $actual-ret-type $_tail
+      (eval (match-types $actual-ret-type $ret-type
+        (return ())
+        (return (Error $atom BadType)) ))
+      (return (Error (interpret-args $atom $args $arg-types $ret-type $space) "interpret-args expects a non-empty value for $arg-types argument")) ))
     (eval (if-decons $args $head $tail
       (eval (if-decons $arg-types $head-type $tail-types
-        (eval (chain-eval (interpret $head $head-type $space) $reduced-head
+        (chain (eval (interpret $head $head-type $space)) $reduced-head
           ; check that head was changed otherwise Error or Empty in the head
           ; can be just an argument which is passed by intention
           (eval (if-equal $reduced-head $head
-            (eval (interpret-args-tail $atom $reduced-head $tail $tail-types $ret-type $space))
+            (chain (eval (interpret-args-tail $atom $reduced-head $tail $tail-types $ret-type $space)) $ret (return $ret))
             (eval (return-on-error $reduced-head
-              (eval (interpret-args-tail $atom $reduced-head $tail $tail-types $ret-type $space)) ))))))
-        (Error $atom BadType) ))
-      (Error (interpret-atom $atom $args $arg-types $space)
-        "Non-empty expression atom is expected") ))))
+              (chain (eval (interpret-args-tail $atom $reduced-head $tail $tail-types $ret-type $space)) $ret (return $ret)) )))))
+        (return (Error $atom BadType)) ))
+      (return (Error (interpret-atom $atom $args $arg-types $space) "Non-empty expression atom is expected")) )))))
 
 (= (interpret-args-tail $atom $head $args-tail $args-tail-types $ret-type $space)
-  (eval (chain-eval (interpret-args $atom $args-tail $args-tail-types $ret-type $space) $reduced-tail
+  (function (chain (eval (interpret-args $atom $args-tail $args-tail-types $ret-type $space)) $reduced-tail
     (eval (return-on-error $reduced-tail
-      (cons $head $reduced-tail) )))))
+      (chain (cons $head $reduced-tail) $ret (return $ret)) )))))
 
 (= (interpret-tuple $atom $space)
-  (unify $atom ()
-    $atom
+  (function (unify $atom ()
+    (return $atom)
     (eval (if-decons $atom $head $tail
-      (eval (chain-eval (interpret $head %Undefined% $space) $rhead
-        (eval (if-empty $rhead Empty
-          (eval (chain-eval (interpret-tuple $tail $space) $rtail
-            (eval (if-empty $rtail Empty
-              (cons $rhead $rtail) ))))))))
-      (Error (interpret-tuple $atom $space) "Non-empty expression atom is expected as an argument") ))))
+      (chain (eval (interpret $head %Undefined% $space)) $rhead
+        (eval (if-empty $rhead (return Empty)
+          (chain (eval (interpret-tuple $tail $space)) $rtail
+            (eval (if-empty $rtail (return Empty)
+              (chain (cons $rhead $rtail) $ret (return $ret)) ))))))
+      (return (Error (interpret-tuple $atom $space) "Non-empty expression atom is expected as an argument")) )))))
 
 (= (metta-call $atom $type $space)
-  (eval (if-error $atom $atom
-    (eval (chain-eval $atom $result
-      (eval (if-not-reducible $result $atom
-        (eval (if-empty $result Empty
-          (eval (if-error $result $result
-            (eval (interpret $result $type $space)) )))))))))))
+  (function (eval (if-error $atom (return $atom)
+    (chain (eval $atom) $result
+      (eval (if-not-reducible $result (return $atom)
+        (eval (if-empty $result (return Empty)
+          (eval (if-error $result (return $result)
+            (chain (eval (interpret $result $type $space)) $ret (return $ret)) )))))))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Standard library written in MeTTa ;
@@ -210,5 +215,5 @@
 (: quote (-> Atom Atom))
 (= (quote $atom) NotReducible)
 
-(: unquote (-> (Atom %Undefined%)))
+(: unquote (-> %Undefined% %Undefined%))
 (= (unquote (quote $atom)) $atom)

--- a/lib/src/metta/runner/stdlib.metta
+++ b/lib/src/metta/runner/stdlib.metta
@@ -1,9 +1,4 @@
-;`$then`, `$else` should be of `Atom` type to avoid evaluation
-; and infinite cycle in inference
-(: if (-> Bool Atom Atom $t))
-(= (if True $then $else) $then)
-(= (if False $then $else) $else)
-
+(: ErrorType Type)
 (: Error (-> Atom Atom ErrorType))
 
 (: if-non-empty-expression (-> Atom Atom Atom Atom))
@@ -151,6 +146,12 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Standard library written in MeTTa ;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;`$then`, `$else` should be of `Atom` type to avoid evaluation
+; and infinite cycle in inference
+(: if (-> Bool Atom Atom $t))
+(= (if True $then $else) $then)
+(= (if False $then $else) $else)
 
 (: match (-> Atom Atom Atom %Undefined%))
 (= (match $space $pattern $template)

--- a/lib/src/metta/runner/stdlib.metta
+++ b/lib/src/metta/runner/stdlib.metta
@@ -230,6 +230,12 @@
 (= (or True False) True)
 (= (or True True) True)
 
+(: and (-> Bool Bool Bool))
+(= (and False False) False)
+(= (and False True) False)
+(= (and True False) False)
+(= (and True True) True)
+
 (: match (-> Atom Atom Atom %Undefined%))
 (= (match $space $pattern $template)
   (unify $pattern $space $template Empty))

--- a/lib/src/metta/runner/stdlib.metta
+++ b/lib/src/metta/runner/stdlib.metta
@@ -1,6 +1,31 @@
 (: ErrorType Type)
 (: Error (-> Atom Atom ErrorType))
 
+(: eval (-> Atom Atom))
+(: chain (-> Atom Variable Atom Atom))
+(: chain+ (-> Atom Variable Atom Atom))
+(: unify (-> Atom Atom Atom Atom Atom))
+(: cons (-> Atom Atom Atom))
+(: decons (-> Atom Atom))
+
+(: ReturnType Type)
+(: return (-> Atom ReturnType))
+
+(: if-return (-> Atom Atom Atom Atom))
+(= (if-return $atom $then $else)
+  (eval (if-decons $atom $head $_
+    (eval (if-equal $head return $then $else))
+    $else )))
+
+(= (chain-eval $expr $var $templ)
+  (chain+ (eval $expr) $res
+    (eval (if-return $res
+      (unify $res (return $ret)
+        (unify $var $ret $templ
+          (Error (chain-eval $expr $var $templ) "$ret cannot be matched with $var"))
+        (Error (chain-eval $expr $var $templ) "(return $ret) is expected") )
+      (chain $res $var $templ) ))))
+
 (: if-non-empty-expression (-> Atom Atom Atom Atom))
 (= (if-non-empty-expression $atom $then $else)
   (chain (eval (get-metatype $atom)) $type
@@ -38,8 +63,9 @@
 (: switch (-> %Undefined% Expression Atom))
 (= (switch $atom $cases)
   (chain (decons $cases) $list
-    (chain (eval (switch-internal $atom $list)) $res
-      (eval (if-not-reducible $res Empty $res)) )))
+    (eval (chain-eval (switch-internal $atom $list) $res
+      (eval (if-not-reducible $res Empty $res)) ))))
+
 (= (switch-internal $atom (($pattern $template) $tail))
   (unify $atom $pattern $template (eval (switch $atom $tail))))
 
@@ -55,18 +81,20 @@
             (unify $type1 $type2 $then $else) )))))))))
 
 (= (type-cast $atom $type $space)
-  (chain (eval (get-type $atom $space)) $actual-type
-    (chain (eval (get-metatype $atom)) $meta
-      (eval (if-equal $type $meta $atom
-        (eval (match-types $actual-type $type $atom (Error $atom BadType))) )))))
+  (chain (eval (get-metatype $atom)) $meta
+    (eval (if-equal $type $meta $atom
+      (chain (eval (get-type $atom $space)) $actual-type
+        (eval (match-types $actual-type $type
+          $atom
+          (Error $atom BadType) )))))))
 
 (= (is-function $type)
   (chain (eval (get-metatype $type)) $meta
     (eval (switch ($type $meta)
       (
         (($_ Expression)
-          (chain (eval (car $type)) $head
-            (unify $head -> True False) ))
+          (eval (chain-eval (car $type) $head
+            (unify $head -> True False) )))
         ($_ False) )))))
 
 (= (interpret $atom $type $space)
@@ -83,65 +111,65 @@
 (= (interpret-expression $atom $type $space)
   (eval (if-decons $atom $op $args
     (chain (eval (get-type $op $space)) $op-type
-      (chain (eval (is-function $op-type)) $is-func
+      (eval (chain-eval (is-function $op-type) $is-func
         (unify $is-func True
-          (chain (eval (interpret-func $atom $op-type $type $space)) $reduced-atom
-            (eval (call $reduced-atom $type $space)) )
-          (chain (eval (interpret-tuple $atom $space)) $reduced-atom
-            (eval (call $reduced-atom $type $space)) ))))
+          (eval (chain-eval (interpret-func $atom $op-type $type $space) $reduced-atom
+            (eval (metta-call $reduced-atom $type $space)) ))
+          (eval (chain-eval (interpret-tuple $atom $space) $reduced-atom
+            (eval (metta-call $reduced-atom $type $space)) ))))))
     (eval (type-cast $atom $type $space)) )))
 
 (= (interpret-func $expr $type $ret-type $space)
   (eval (if-decons $expr $op $args
-    (chain (eval (interpret $op $type $space)) $reduced-op
+    (eval (chain-eval (interpret $op $type $space) $reduced-op
       (eval (return-on-error $reduced-op
         (eval (if-decons $type $arrow $arg-types
-          (chain (eval (interpret-args $expr $args $arg-types $ret-type $space)) $reduced-args
+          (eval (chain-eval (interpret-args $expr $args $arg-types $ret-type $space) $reduced-args
             (eval (return-on-error $reduced-args
-              (cons $reduced-op $reduced-args) )))
-          (Error $type "Function type expected") )))))
+              (chain (cons $reduced-op $reduced-args) $r (return $r))))))
+          (Error $type "Function type expected") ))))))
     (Error $expr "Non-empty expression atom is expected") )))
 
 (= (interpret-args $atom $args $arg-types $ret-type $space)
   (unify $args ()
-    (chain (eval (car $arg-types)) $actual-ret-type
-      (eval (match-types $actual-ret-type $ret-type () (Error $atom BadType))))
+    (eval (chain-eval (car $arg-types) $actual-ret-type
+      (eval (match-types $actual-ret-type $ret-type () (Error $atom BadType)))))
     (eval (if-decons $args $head $tail
       (eval (if-decons $arg-types $head-type $tail-types
-        (chain (eval (interpret $head $head-type $space)) $reduced-head
+        (eval (chain-eval (interpret $head $head-type $space) $reduced-head
           ; check that head was changed otherwise Error or Empty in the head
           ; can be just an argument which is passed by intention
           (eval (if-equal $reduced-head $head
             (eval (interpret-args-tail $atom $reduced-head $tail $tail-types $ret-type $space))
             (eval (return-on-error $reduced-head
-              (eval (interpret-args-tail $atom $reduced-head $tail $tail-types $ret-type $space)) )))))
+              (eval (interpret-args-tail $atom $reduced-head $tail $tail-types $ret-type $space)) ))))))
         (Error $atom BadType) ))
       (Error (interpret-atom $atom $args $arg-types $space)
         "Non-empty expression atom is expected") ))))
 
 (= (interpret-args-tail $atom $head $args-tail $args-tail-types $ret-type $space)
-  (chain (eval (interpret-args $atom $args-tail $args-tail-types $ret-type $space)) $reduced-tail
+  (eval (chain-eval (interpret-args $atom $args-tail $args-tail-types $ret-type $space) $reduced-tail
     (eval (return-on-error $reduced-tail
-      (cons $head $reduced-tail) ))))
+      (cons $head $reduced-tail) )))))
 
 (= (interpret-tuple $atom $space)
   (unify $atom ()
     $atom
     (eval (if-decons $atom $head $tail
-      (chain (eval (interpret $head %Undefined% $space)) $rhead
+      (eval (chain-eval (interpret $head %Undefined% $space) $rhead
         (eval (if-empty $rhead Empty
-          (chain (eval (interpret-tuple $tail $space)) $rtail
+          (eval (chain-eval (interpret-tuple $tail $space) $rtail
             (eval (if-empty $rtail Empty
-              (cons $rhead $rtail) ))))))
+              (cons $rhead $rtail) ))))))))
       (Error (interpret-tuple $atom $space) "Non-empty expression atom is expected as an argument") ))))
 
-(= (call $atom $type $space)
+(= (metta-call $atom $type $space)
   (eval (if-error $atom $atom
-    (chain (eval $atom) $result
+    (eval (chain-eval $atom $result
       (eval (if-not-reducible $result $atom
         (eval (if-empty $result Empty
           (eval (if-error $result $result
-            (eval (interpret $result $type $space)) ))))))))))
+            (eval (interpret $result $type $space)) )))))))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Standard library written in MeTTa ;

--- a/lib/src/metta/runner/stdlib.metta
+++ b/lib/src/metta/runner/stdlib.metta
@@ -184,9 +184,6 @@
     (let $pattern $atom (let* $tail $template))
     $template )))
 
-(: case (-> %Undefined% Expression Atom))
-(= (case $atom $cases) (switch $atom $cases))
-
 (: car (-> Expression Atom))
 (= (car $atom)
   (eval (if-decons $atom $head $_

--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -23,15 +23,6 @@ use super::arithmetics::*;
 
 pub const VOID_SYMBOL : Atom = sym!("%void%");
 
-//TODO: convert these from functions to static strcutures, when Atoms are Send+Sync
-#[allow(non_snake_case)]
-pub fn UNIT_ATOM() -> Atom {
-    Atom::expr([])
-}
-#[allow(non_snake_case)]
-pub fn UNIT_TYPE() -> Atom {
-    Atom::expr([ARROW_SYMBOL])
-}
 fn unit_result() -> Result<Vec<Atom>, ExecError> {
     Ok(vec![UNIT_ATOM()])
 }

--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -1195,7 +1195,7 @@ pub static METTA_CODE: &'static str = "
     (: Error (-> Atom Atom ErrorType))
 ";
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "minimal")))]
 mod tests {
     use super::*;
     use crate::metta::runner::{Metta, EnvBuilder};

--- a/lib/src/metta/runner/stdlib2.rs
+++ b/lib/src/metta/runner/stdlib2.rs
@@ -17,16 +17,6 @@ use super::arithmetics::*;
 
 pub const VOID_SYMBOL : Atom = sym!("%void%");
 
-//TODO: convert these from functions to static strcutures, when Atoms are Send+Sync
-#[allow(non_snake_case)]
-pub fn UNIT_ATOM() -> Atom {
-    Atom::expr([])
-}
-#[allow(non_snake_case)]
-pub fn UNIT_TYPE() -> Atom {
-    Atom::expr([ARROW_SYMBOL])
-}
-
 #[derive(Clone, PartialEq, Debug)]
 pub struct GetTypeOp {}
 
@@ -138,7 +128,7 @@ fn assert_results_equal(actual: &Vec<Atom>, expected: &Vec<Atom>, atom: &Atom) -
     log::debug!("assert_results_equal: actual: {:?}, expected: {:?}, actual atom: {:?}", actual, expected, atom);
     let report = format!("\nExpected: {:?}\nGot: {:?}", expected, actual);
     match vec_eq_no_order(actual.iter(), expected.iter()) {
-        Ok(()) => Ok(vec![VOID_SYMBOL]),
+        Ok(()) => Ok(vec![UNIT_ATOM()]),
         Err(diff) => Err(ExecError::Runtime(format!("{}\n{}", report, diff)))
     }
 }
@@ -678,7 +668,7 @@ mod tests {
         ";
         assert_eq!(metta.run(SExprParser::new(program)), Ok(vec![]));
         assert_eq!(metta.run(SExprParser::new("!(assertEqual (foo A) (bar A))")), Ok(vec![
-            vec![VOID_SYMBOL],
+            vec![UNIT_ATOM()],
         ]));
         assert_eq!(metta.run(SExprParser::new("!(assertEqual (foo A) (bar B))")), Ok(vec![
             vec![expr!("Error" ({assert.clone()} ("foo" "A") ("bar" "B")) "\nExpected: [B]\nGot: [A]\nMissed result: B")],
@@ -701,7 +691,7 @@ mod tests {
         ";
         assert_eq!(metta.run(SExprParser::new(program)), Ok(vec![]));
         assert_eq!(metta.run(SExprParser::new("!(assertEqualToResult (foo) (A B))")), Ok(vec![
-            vec![VOID_SYMBOL],
+            vec![UNIT_ATOM()],
         ]));
         assert_eq!(metta.run(SExprParser::new("!(assertEqualToResult (bar) (A))")), Ok(vec![
             vec![expr!("Error" ({assert.clone()} ("bar") ("A")) "\nExpected: [A]\nGot: [C]\nMissed result: A")],

--- a/lib/src/metta/runner/stdlib2.rs
+++ b/lib/src/metta/runner/stdlib2.rs
@@ -604,22 +604,22 @@ mod tests {
     }
 
     #[test]
-    fn metta_filter_out_errors() {
-        assert_eq!(run_program("!(eval (filter () $x (eval (if-error $x False True))))"), Ok(vec![vec![expr!()]]));
-        assert_eq!(run_program("!(eval (filter (a (b) $c) $x (eval (if-error $x False True))))"), Ok(vec![vec![expr!("a" ("b") c)]]));
-        assert_eq!(run_program("!(eval (filter (a (Error (b) \"Test error\") $c) $x (eval (if-error $x False True))))"), Ok(vec![vec![expr!("a" c)]]));
+    fn metta_filter_atom() {
+        assert_eq!(run_program("!(eval (filter-atom () $x (eval (if-error $x False True))))"), Ok(vec![vec![expr!()]]));
+        assert_eq!(run_program("!(eval (filter-atom (a (b) $c) $x (eval (if-error $x False True))))"), Ok(vec![vec![expr!("a" ("b") c)]]));
+        assert_eq!(run_program("!(eval (filter-atom (a (Error (b) \"Test error\") $c) $x (eval (if-error $x False True))))"), Ok(vec![vec![expr!("a" c)]]));
     }
 
     #[test]
-    fn metta_map() {
-        assert_eq!(run_program("!(eval (map () $x ($x mapped)))"), Ok(vec![vec![expr!()]]));
-        assert_eq!(run_program("!(eval (map (a (b) $c) $x (mapped $x)))"), Ok(vec![vec![expr!(("mapped" "a") ("mapped" ("b")) ("mapped" c))]]));
+    fn metta_map_atom() {
+        assert_eq!(run_program("!(eval (map-atom () $x ($x mapped)))"), Ok(vec![vec![expr!()]]));
+        assert_eq!(run_program("!(eval (map-atom (a (b) $c) $x (mapped $x)))"), Ok(vec![vec![expr!(("mapped" "a") ("mapped" ("b")) ("mapped" c))]]));
     }
 
     #[test]
-    fn metta_foldl() {
-        assert_eq!(run_program("!(eval (foldl () 1 $a $b (eval (+ $a $b))))"), Ok(vec![vec![expr!({Number::Integer(1)})]]));
-        assert_eq!(run_program("!(eval (foldl (1 2 3) 0 $a $b (eval (+ $a $b))))"), Ok(vec![vec![expr!({Number::Integer(6)})]]));
+    fn metta_foldl_atom() {
+        assert_eq!(run_program("!(eval (foldl-atom () 1 $a $b (eval (+ $a $b))))"), Ok(vec![vec![expr!({Number::Integer(1)})]]));
+        assert_eq!(run_program("!(eval (foldl-atom (1 2 3) 0 $a $b (eval (+ $a $b))))"), Ok(vec![vec![expr!({Number::Integer(6)})]]));
     }
 
     #[test]

--- a/lib/src/metta/runner/stdlib2.rs
+++ b/lib/src/metta/runner/stdlib2.rs
@@ -540,17 +540,17 @@ mod tests {
 
 
     #[test]
-    fn metta_car() {
-        let result = run_program("!(eval (car (A $b)))");
+    fn metta_car_atom() {
+        let result = run_program("!(eval (car-atom (A $b)))");
         assert_eq!(result, Ok(vec![vec![expr!("A")]]));
-        let result = run_program("!(eval (car ($a B)))");
+        let result = run_program("!(eval (car-atom ($a B)))");
         //assert_eq!(result, Ok(vec![vec![expr!(a)]]));
         assert!(result.is_ok_and(|res| res.len() == 1 && res[0].len() == 1 &&
             atoms_are_equivalent(&res[0][0], &expr!(a))));
-        let result = run_program("!(eval (car ()))");
-        assert_eq!(result, Ok(vec![vec![expr!("Error" ("car" ()) "\"car expects a non-empty expression as an argument\"")]]));
-        let result = run_program("!(eval (car A))");
-        assert_eq!(result, Ok(vec![vec![expr!("Error" ("car" "A") "\"car expects a non-empty expression as an argument\"")]]));
+        let result = run_program("!(eval (car-atom ()))");
+        assert_eq!(result, Ok(vec![vec![expr!("Error" ("car-atom" ()) "\"car-atom expects a non-empty expression as an argument\"")]]));
+        let result = run_program("!(eval (car-atom A))");
+        assert_eq!(result, Ok(vec![vec![expr!("Error" ("car-atom" "A") "\"car-atom expects a non-empty expression as an argument\"")]]));
     }
 
     #[test]

--- a/lib/src/metta/runner/stdlib2.rs
+++ b/lib/src/metta/runner/stdlib2.rs
@@ -563,32 +563,6 @@ mod tests {
     }
 
     #[test]
-    fn metta_reduce_chain() {
-        assert_eq!(run_program("
-            (= (foo $x) (bar $x))
-            (= (bar $x) (baz $x))
-            (= (baz $x) $x)
-            !(eval (reduce (foo A) $x (reduced $x)))
-        "), Ok(vec![vec![expr!("reduced" "A")]]));
-        assert_eq!(run_program("
-            !(eval (reduce (foo A) $x (reduced $x)))
-        "), Ok(vec![vec![expr!("reduced" ("foo" "A"))]]));
-        assert_eq!(run_program("
-            (= (foo A) (Error (foo A) \"Test error\"))
-            !(eval (reduce (foo A) $x (reduced $x)))
-        "), Ok(vec![vec![expr!("Error" ("foo" "A") "\"Test error\"")]]));
-    }
-
-    #[test]
-    fn metta_reduce_reduce() {
-        assert_eq!(run_program("
-            (= (foo $x) (reduce (bar $x) $t $t))
-            (= (bar $x) $x)
-            !(eval (reduce (foo A) $x $x))
-        "), Ok(vec![vec![expr!("A")]]));
-    }
-
-    #[test]
     fn metta_type_cast() {
         assert_eq!(run_program("(: a A) !(eval (type-cast a A &self))"), Ok(vec![vec![expr!("a")]]));
         assert_eq!(run_program("(: a A) !(eval (type-cast a B &self))"), Ok(vec![vec![expr!("Error" "a" "BadType")]]));

--- a/lib/src/metta/runner/stdlib2.rs
+++ b/lib/src/metta/runner/stdlib2.rs
@@ -178,7 +178,7 @@ fn assert_results_equal(actual: &Vec<Atom>, expected: &Vec<Atom>, atom: &Atom) -
     log::debug!("assert_results_equal: actual: {:?}, expected: {:?}, actual atom: {:?}", actual, expected, atom);
     let report = format!("\nExpected: {:?}\nGot: {:?}", expected, actual);
     match vec_eq_no_order(actual.iter(), expected.iter()) {
-        Ok(()) => Ok(vec![UNIT_ATOM()]),
+        Ok(()) => unit_result(),
         Err(diff) => Err(ExecError::Runtime(format!("{}\n{}", report, diff)))
     }
 }
@@ -374,7 +374,7 @@ impl Grounded for PragmaOp {
             .map_err(|_| "pragma! expects symbol atom as a key")?.name();
         let value = args.get(1).ok_or_else(arg_error)?;
         self.settings.borrow_mut().insert(key.into(), value.clone());
-        Ok(vec![])
+        unit_result()
     }
 
     fn match_(&self, other: &Atom) -> MatchResultIter {

--- a/lib/src/metta/runner/stdlib2.rs
+++ b/lib/src/metta/runner/stdlib2.rs
@@ -798,6 +798,18 @@ mod tests {
         assert_eq!(result, Ok(vec![vec![]]));
     }
 
+    #[test]
+    fn metta_quote_unquote() {
+        let header = "
+            (= (foo) A)
+            (= (bar $x) $x)
+        ";
+        assert_eq!(run_program(&format!("{header} !(bar (foo))")), Ok(vec![vec![sym!("A")]]), "sanity check");
+        assert_eq!(run_program(&format!("{header} !(bar (quote (foo)))")), Ok(vec![vec![expr!("quote" ("foo"))]]), "quote");
+        assert_eq!(run_program(&format!("{header} !(bar (unquote (quote (foo))))")), Ok(vec![vec![expr!("A")]]), "unquote before call");
+        assert_eq!(run_program(&format!("{header} !(unquote (bar (quote (foo))))")), Ok(vec![vec![expr!("A")]]), "unquote after call");
+    }
+
 
     #[test]
     fn test_frog_reasoning() {

--- a/lib/src/metta/runner/stdlib2.rs
+++ b/lib/src/metta/runner/stdlib2.rs
@@ -570,6 +570,25 @@ mod tests {
     }
 
     #[test]
+    fn metta_filter_out_errors() {
+        assert_eq!(run_program("!(eval (filter () $x (eval (if-error $x False True))))"), Ok(vec![vec![expr!()]]));
+        assert_eq!(run_program("!(eval (filter (a (b) $c) $x (eval (if-error $x False True))))"), Ok(vec![vec![expr!("a" ("b") c)]]));
+        assert_eq!(run_program("!(eval (filter (a (Error (b) \"Test error\") $c) $x (eval (if-error $x False True))))"), Ok(vec![vec![expr!("a" c)]]));
+    }
+
+    #[test]
+    fn metta_map() {
+        assert_eq!(run_program("!(eval (map () $x ($x mapped)))"), Ok(vec![vec![expr!()]]));
+        assert_eq!(run_program("!(eval (map (a (b) $c) $x (mapped $x)))"), Ok(vec![vec![expr!(("mapped" "a") ("mapped" ("b")) ("mapped" c))]]));
+    }
+
+    #[test]
+    fn metta_foldl() {
+        assert_eq!(run_program("!(eval (foldl () 1 $a $b (eval (+ $a $b))))"), Ok(vec![vec![expr!({Number::Integer(1)})]]));
+        assert_eq!(run_program("!(eval (foldl (1 2 3) 0 $a $b (eval (+ $a $b))))"), Ok(vec![vec![expr!({Number::Integer(6)})]]));
+    }
+
+    #[test]
     fn metta_interpret_single_atom_as_atom() {
         let result = run_program("!(eval (interpret A Atom &self))");
         assert_eq!(result, Ok(vec![vec![expr!("A")]]));

--- a/lib/src/metta/runner/stdlib2.rs
+++ b/lib/src/metta/runner/stdlib2.rs
@@ -743,7 +743,7 @@ mod tests {
     }
 
     #[test]
-    fn metta_let() {
+    fn metta_let_novar() {
         let result = run_program("!(let (P A $b) (P $a B) (P $b $a))");
         assert_eq!(result, Ok(vec![vec![expr!("P" "B" "A")]]));
         let result = run_program("

--- a/lib/tests/metta.rs
+++ b/lib/tests/metta.rs
@@ -1,7 +1,4 @@
-#[cfg(not(feature = "minimal"))]
-use hyperon::metta::runner::stdlib::UNIT_ATOM;
-#[cfg(feature = "minimal")]
-use hyperon::metta::runner::stdlib2::UNIT_ATOM;
+use hyperon::metta::UNIT_ATOM;
 use hyperon::metta::text::*;
 use hyperon::metta::runner::{Metta, EnvBuilder};
 

--- a/python/hyperon/atoms.py
+++ b/python/hyperon/atoms.py
@@ -120,7 +120,7 @@ class AtomType:
 
 class Atoms:
 
-    VOID = Atom._from_catom(hp.CAtoms.VOID)
+    EMPTY = Atom._from_catom(hp.CAtoms.EMPTY)
 
 class GroundedAtom(Atom):
     """
@@ -186,7 +186,7 @@ class GroundedObject:
         self.id = id
 
     def __repr__(self):
-        """Returns the object's ID if present, or a string representation of 
+        """Returns the object's ID if present, or a string representation of
         its content if not."""
         # Overwrite Python default representation of a string to use
         # double quotes instead of single quotes.
@@ -213,7 +213,7 @@ class ValueObject(GroundedObject):
         obj1 = ValueObject(5)
         obj2 = ValueObject(5)
         obj3 = ValueObject(6)
-        
+
         print(obj1 == obj2)  # True
         print(obj1 == obj3)  # False
     """

--- a/python/hyperonpy.cpp
+++ b/python/hyperonpy.cpp
@@ -791,7 +791,7 @@ PYBIND11_MODULE(hyperonpy, m) {
 #define ADD_SYMBOL(t, d) .def_property_readonly_static(#t, [](py::object) { return CAtom(t ## _SYMBOL()); }, d " atom type")
 
     py::class_<CAtoms>(m, "CAtoms")
-        ADD_SYMBOL(VOID, "Void");
+        ADD_SYMBOL(EMPTY, "Empty");
 
     py::class_<CMetta>(m, "CMetta");
     m.def("metta_new", [](CSpace space, EnvBuilder env_builder) {

--- a/python/tests/scripts/b5_types_prelim.metta
+++ b/python/tests/scripts/b5_types_prelim.metta
@@ -84,7 +84,9 @@
 ; This list is badly typed, because S and Z are not the same type
 !(assertEqualToResult
   (Cons S (Cons Z Nil))
-  ((Error (Cons Z Nil) BadType)))
+  ((Error Z BadType)))
+  ; TODO: MINIMAL replace test result after migration on minimal MeTTa
+  ;((Error (Cons Z Nil) BadType)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/python/tests/scripts/b5_types_prelim.metta
+++ b/python/tests/scripts/b5_types_prelim.metta
@@ -84,7 +84,7 @@
 ; This list is badly typed, because S and Z are not the same type
 !(assertEqualToResult
   (Cons S (Cons Z Nil))
-  ((Error Z BadType)))
+  ((Error (Cons Z Nil) BadType)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/python/tests/scripts/b5_types_prelim.metta
+++ b/python/tests/scripts/b5_types_prelim.metta
@@ -81,12 +81,12 @@
    (Cons (S Z) (Cons Z Nil))
   ((Cons (S Z) (Cons Z Nil))))
 
+; TODO: MINIMAL This test has different behavior in old and new versions of the
+;       interpreter versions. Uncomment it after migration to the minimal MeTTa.
 ; This list is badly typed, because S and Z are not the same type
-!(assertEqualToResult
-  (Cons S (Cons Z Nil))
-  ((Error Z BadType)))
-  ; TODO: MINIMAL replace test result after migration on minimal MeTTa
-  ;((Error (Cons Z Nil) BadType)))
+;!(assertEqualToResult
+;  (Cons S (Cons Z Nil))
+;  ((Error (Cons Z Nil) BadType)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/python/tests/test_examples.py
+++ b/python/tests/test_examples.py
@@ -96,31 +96,31 @@ class ExamplesTest(HyperonTestCase):
         metta = MeTTa(env_builder=Environment.test_env())
 
         metta.run('''
-            (= (Fritz croaks) True)
-            (= (Tweety chirps) True)
-            (= (Tweety yellow) True)
-            (= (Tweety eats_flies) True)
-            (= (Fritz eats_flies) True)
+            (= (croaks Fritz) True)
+            (= (chirps Tweety) True)
+            (= (yellow Tweety) True)
+            (= (eats_flies Tweety) True)
+            (= (eats_flies Fritz) True)
         ''')
 
-        fritz_frog = metta.run('!(if (and ($x croaks) ($x eats_flies)) (= ($x frog) True) nop)')[0]
-        self.assertEqual(metta.parse_all('(= (Fritz frog) True)'), fritz_frog)
+        fritz_frog = metta.run('!(if (and (croaks $x) (eats_flies $x)) (= (frog $x) True) nop)')[0]
+        self.assertEqual(metta.parse_all('(= (frog Fritz) True)'), fritz_frog)
         metta.space().add_atom(fritz_frog[0])
 
-        self.assertEqualMettaRunnerResults([metta.parse_all('(= (Fritz green) True)')],
-                metta.run('!(if ($x frog) (= ($x green) True) nop)'))
+        self.assertEqualMettaRunnerResults([metta.parse_all('(= (green Fritz) True)')],
+                metta.run('!(if (frog $x) (= (green $x) True) nop)'))
 
     def test_infer_function_application_type(self):
         metta = MeTTa(env_builder=Environment.test_env())
 
         metta.run('''
-           (= (: (apply $f $x) $r) (and (: $f (=> $a $r)) (: $x $a)))
+           (= (: (apply\' $f $x) $r) (and (: $f (=> $a $r)) (: $x $a)))
 
            (= (: reverse (=> String String)) True)
            (= (: "Hello" String) True)
         ''')
 
-        output = metta.run('!(if (: (apply reverse "Hello") $t) $t Wrong)')
+        output = metta.run('!(if (: (apply\' reverse "Hello") $t) $t Wrong)')
         self.assertEqualMettaRunnerResults(output, [[S('String')]])
 
     def test_plus_reduces_Z(self):


### PR DESCRIPTION
Improving semantics of minimal MeTTa `chain` to make code more predictable. I didn't change the documentation yet because I am going to experiment with `eval/chain/return` further and then finalize the semantics. After adding `function/return` I managed to write MeTTa interpreter in minimal MeTTa which now passes almost all of the tests except:
- Minecraft related tests
- one test in minimal MeTTa Rust test pack
- `f1_import` test

List of changes:
Implement `function` and `return` symbols to allow coding function call flows. Make `chain` one-step operation, i.e. `chain` makes one step and inserts the result into a provided template. One can make `chain` work in a loop by: 
- using nested `chain`, then `chain` waits while nested `chain` returns result
- using nested `function`, then `chain` waits for a `function` to return result
Thus nested `chain` + `function` expressions represent the call stack of the program.

Import `pragma!`, `bind!`, space operations, state operations from stdlib to stdlib of minimal MeTTa.
Implement `case`, `quote/unquote`, `id`, `car-atom`, `cdr-atom`, `or`, `and`, `fold`, `filter` and `map` in minimal MeTTa.
Change `get-type` implementation to be compatible with both Rust and minimal MeTTa interpreters.
Fix type casting issue when type errors were returned for non-deterministic types when one of the types was not compatible with required type.
Fix `test_examples.py` to be compatible with minimal MeTTa standard library.
Adapt "returning unit" from grounded functions fix from `main` branch.