### PR TITLE
Stop evaluation of expressions with variables as operations

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -18,5 +18,7 @@ path = "src/lib.rs"
 crate-type = ["lib"]
 
 [features]
-#default = ["minimal"]
+default = ["variable_operation"]
+#default = ["variable_operation", "minimal"]
 minimal = []
+variable_operation = []

--- a/python/tests/test_examples.py
+++ b/python/tests/test_examples.py
@@ -96,19 +96,19 @@ class ExamplesTest(HyperonTestCase):
         metta = MeTTa(env_builder=Environment.test_env())
 
         metta.run('''
-            (= (Fritz croaks) True)
-            (= (Tweety chirps) True)
-            (= (Tweety yellow) True)
-            (= (Tweety eats_flies) True)
-            (= (Fritz eats_flies) True)
+            (= (croaks Fritz) True)
+            (= (chirps Tweety) True)
+            (= (yellow Tweety) True)
+            (= (eats_flies Tweety) True)
+            (= (eats_flies Fritz) True)
         ''')
 
-        fritz_frog = metta.run('!(if (and ($x croaks) ($x eats_flies)) (= ($x frog) True) nop)')[0]
-        self.assertEqual(metta.parse_all('(= (Fritz frog) True)'), fritz_frog)
+        fritz_frog = metta.run('!(if (and (croaks $x) (eats_flies $x)) (= (frog $x) True) nop)')[0]
+        self.assertEqual(metta.parse_all('(= (frog Fritz) True)'), fritz_frog)
         metta.space().add_atom(fritz_frog[0])
 
-        self.assertEqualMettaRunnerResults([metta.parse_all('(= (Fritz green) True)')],
-                metta.run('!(if ($x frog) (= ($x green) True) nop)'))
+        self.assertEqualMettaRunnerResults([metta.parse_all('(= (green Fritz) True)')],
+                metta.run('!(if (frog $x) (= (green $x) True) nop)'))
 
     def test_infer_function_application_type(self):
         metta = MeTTa(env_builder=Environment.test_env())


### PR DESCRIPTION
This is fast fix for #242 to unblock PLN work. This code doesn't use `pragma!` because at the moment `pragma!` settings are not reachable from the interpreter. More elegant fixes described in the issue could be implemented after migration to the minimal MeTTa.