### PR TITLE
change arg type to atom in print and trace

### DIFF
--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -758,7 +758,7 @@ impl Display for PrintlnOp {
 
 impl Grounded for PrintlnOp {
     fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_UNDEFINED, UNIT_TYPE()])
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_ATOM, UNIT_TYPE()])
     }
 
     fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
@@ -816,7 +816,7 @@ impl Display for TraceOp {
 
 impl Grounded for TraceOp {
     fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_UNDEFINED, Atom::var("a"), Atom::var("a")])
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_ATOM, Atom::var("a"), Atom::var("a")])
     }
 
     fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {


### PR DESCRIPTION
with this change one can print what actually is during expression evaluation 

this program will print now *(woman $Y)* vs printing *False* without these changes
```
(= (woman $X) False)
(= (sisters (woman $X) (woman $Y)) (trace! (woman $Y) True))
!(let $W (sisters $X $Y) $W)
 ```