### PR TITLE
fix return type of car/cdr-atom

### DIFF
--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -325,7 +325,7 @@ impl Display for CarAtomOp {
 
 impl Grounded for CarAtomOp {
     fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_EXPRESSION, ATOM_TYPE_ATOM])
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_EXPRESSION, ATOM_TYPE_UNDEFINED])
     }
 
     fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
@@ -352,7 +352,7 @@ impl Display for CdrAtomOp {
 
 impl Grounded for CdrAtomOp {
     fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_EXPRESSION, ATOM_TYPE_ATOM])
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_EXPRESSION, ATOM_TYPE_UNDEFINED])
     }
 
     fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {


### PR DESCRIPTION
#483 fixes the return type of `let`. #224 is an old similar issue. I don't see the reason not to fix the return type of `car-atom` / `cdr-atom` as well and close this old issue. It seems that this fix doesn't affect any test.