### PR TITLE
Disable variable_operation feature by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ cargo build
 cargo test
 ```
 
+The experimental features can be enabled by editing
+[Cargo.toml](./lib/Cargo.toml) file before compilation or by using `--features`
+[command line option](https://doc.rust-lang.org/cargo/reference/features.html#command-line-feature-options).
+See comments in the `[features]` section of the file for the features
+descriptions.
+
 Run examples:
 ```
 cargo run --example sorted_list

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -19,6 +19,8 @@ crate-type = ["lib"]
 
 [features]
 default = []
+# Add one of the features below into default list to enable.
+# See https://doc.rust-lang.org/cargo/reference/features.html#the-features-section
 minimal = [] # enables minimal MeTTa interpreter
 variable_operation = [] # enables evaluation of the expressions which have
                         # a variable on the first position, doesn't affect

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -18,7 +18,8 @@ path = "src/lib.rs"
 crate-type = ["lib"]
 
 [features]
-default = ["variable_operation"]
-#default = ["variable_operation", "minimal"]
-minimal = []
-variable_operation = []
+default = []
+minimal = [] # enables minimal MeTTa interpreter
+variable_operation = [] # enables evaluation of the expressions which have
+                        # a variable on the first position, doesn't affect
+                        # minimal MeTTa functionality


### PR DESCRIPTION
Add comments to the features. Disable `variable_operation` feature by default. This is to change behaviour according to comments https://github.com/trueagi-io/hyperon-experimental/issues/242#issuecomment-1801136493 and https://github.com/trueagi-io/hyperon-experimental/issues/242#issuecomment-1803609289