### PR TITLE
turn module path to file path in extend-py

### DIFF
--- a/python/hyperon/runner.py
+++ b/python/hyperon/runner.py
@@ -133,9 +133,10 @@ class MeTTa:
         if not isinstance(mod_name, str):
             mod_name = repr(mod_name)
         mod = MeTTa.load_py_module(self, mod_name)
-        if (mod is None):
+        if mod is None:
             # If that failed, try and load the module from a file
-            file_name = mod_name + ".py"
+            file_name = mod_name if ".py" in mod_name else \
+                        mod_name.replace('.', '/') + ".py"
 
             # Check each search path directory in order, until we find the module we're looking for
             num_search_paths = hp.metta_search_path_cnt(self.cmetta)

--- a/python/hyperon/runner.py
+++ b/python/hyperon/runner.py
@@ -142,15 +142,15 @@ class MeTTa:
             num_search_paths = hp.metta_search_path_cnt(self.cmetta)
             search_path_idx = 0
             found_path = None
-            while (search_path_idx < num_search_paths):
+            while search_path_idx < num_search_paths:
                 search_path = hp.metta_nth_search_path(self.cmetta, search_path_idx)
                 test_path = os.path.join(search_path, file_name)
-                if (os.path.exists(test_path)):
+                if os.path.exists(test_path):
                     found_path = test_path
                     break
                 search_path_idx += 1
 
-            if (found_path is not None):
+            if found_path is not None:
                 MeTTa.load_py_module_from_path(self, mod_name, found_path)
             else:
                 raise RuntimeError("Failed to load module " + mod_name + "; could not locate file: " + file_name)

--- a/python/hyperon/runner.py
+++ b/python/hyperon/runner.py
@@ -136,7 +136,7 @@ class MeTTa:
         if mod is None:
             # If that failed, try and load the module from a file
             file_name = mod_name if ".py" in mod_name else \
-                        mod_name.replace('.', '/') + ".py"
+                        mod_name.replace('.', os.sep) + ".py"
 
             # Check each search path directory in order, until we find the module we're looking for
             num_search_paths = hp.metta_search_path_cnt(self.cmetta)


### PR DESCRIPTION
The reason for the change.
`MeTTa.load_py_module(self, mod_name)` in `load_py_module_from_mod_or_file` may fail even if `mod_name` is a relative path w.r.t. cwd. It happens if `mod_name` contains submodules, e.g. `(extend-py! A.B)`. This doesn't happen with `export PYTHONPATH="${PYTHONPATH}:."`. Thus, this change might not be required. However, since we have
```py
# If that failed, try and load the module from a file
file_name = mod_name if ".py"
```
this means that we try to turn the module name into the file path. Turning `A.B` into `A.B.py` will not work in any case. If we turn it into `A/B.py` it will make more sense. It makes adding `.` to `PYTHONPATH` unnecessary.