### PR TITLE
added sealed operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target/
 Cargo.lock
 .DS_Store
 .vscode
+.aider*

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -12,6 +12,15 @@ env_logger = "0.8.4"
 directories = "5.0.1" # For Environment to find platform-specific config location
 smallvec = "1.10.0"
 
+[dependencies.uuid]
+version = "1.5.0"
+features = [
+    "v4",                # Lets you generate random UUIDs
+    "fast-rng",          # Use a faster (but still sufficiently random) RNG
+    "macro-diagnostics", # Enable better diagnostics for compile-time UUIDs
+]
+
+
 [lib]
 name = "hyperon"
 path = "src/lib.rs"

--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -1124,26 +1124,9 @@ fn replace_vars(var_list: &mut Atom, template: &mut Atom) -> HashSet<VariableAto
     external_vars
 }
 
-// fn seal_vars(var_list: &mut Atom, term: &mut Atom, external_vars: &HashSet<VariableAtom>) {
-//     let mut local_var_mapper = ReplacingMapper::new(VariableAtom::make_unique);
-
-//     var_list.iter_mut().filter_type::<&mut VariableAtom>()
-//         .filter(|var| external_vars.contains(var))
-//         .for_each(|var| local_var_mapper.replace(var));
-
-//     term.iter_mut().filter_type::<&mut VariableAtom>()
-//         .for_each(|var| match local_var_mapper.mapping_mut().get(var) {
-//             Some(v) => *var = v.clone(),
-//             None => {},
-//         });
-// }
-
 fn seal_vars(var_list: &mut Atom, term: &mut Atom, external_vars: &HashSet<VariableAtom>) {
     let mut var_to_uuid = HashMap::new();
 
-    println!("seal_vars var_list {:?}", var_list);
-    println!("seal_vars term {:?}", term);
-    println!("seal_vars external_vars {:?}", external_vars);
     var_list.iter_mut().filter_type::<&mut VariableAtom>()
         .filter(|var| external_vars.contains(var))
         .for_each(|var| {
@@ -1151,10 +1134,7 @@ fn seal_vars(var_list: &mut Atom, term: &mut Atom, external_vars: &HashSet<Varia
             let _ = var_to_uuid.entry(var_name.to_string())
                 .or_insert_with(Uuid::new_v4)
                 .to_string();
-            //*var = VariableAtom::new(uuid);
         });
-
-    println!("seal_vars var_to_uuid {:?}", var_to_uuid);
 
     term.iter_mut().filter_type::<&mut VariableAtom>()
         .for_each(|var| {
@@ -1162,10 +1142,6 @@ fn seal_vars(var_list: &mut Atom, term: &mut Atom, external_vars: &HashSet<Varia
                 *var = VariableAtom::new(uuid.to_string());
             }
         });
-
-    println!("seal_vars var_list {:?}", var_list);
-    println!("seal_vars term {:?}", term);
-    println!("seal_vars external_vars {:?}", external_vars);
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -1793,8 +1769,6 @@ mod tests {
     fn sealed_op_runner() {
         let nested = run_program("!(sealed ($x) (sealed ($a $b) (=($a $x $c) ($b))))");
         let simple_replace = run_program("!(sealed ($x $y) (=($y $z)))");
-        //println!("{:?}", &nested.unwrap());
-        //println!("{:?}", &simple_replace.unwrap());
 
         assert!(crate::atom::matcher::atoms_are_equivalent(&nested.unwrap()[0][0], &expr!("="(a b c) (z))));
         assert!(crate::atom::matcher::atoms_are_equivalent(&simple_replace.unwrap()[0][0], &expr!("="(y z))));

--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -18,6 +18,7 @@ use std::collections::HashMap;
 use std::iter::FromIterator;
 use std::path::PathBuf;
 use regex::Regex;
+use uuid::Uuid;
 
 use super::arithmetics::*;
 
@@ -1116,9 +1117,6 @@ impl Grounded for SealedOp {
     }
 }
 
-use uuid::Uuid;
-use std::collections::HashMap;
-
 fn replace_vars(var_list: &mut Atom, template: &mut Atom) -> HashSet<VariableAtom> {
     let mut external_vars = HashSet::new();
     collect_vars(&var_list, &mut external_vars);
@@ -1126,25 +1124,48 @@ fn replace_vars(var_list: &mut Atom, template: &mut Atom) -> HashSet<VariableAto
     external_vars
 }
 
+// fn seal_vars(var_list: &mut Atom, term: &mut Atom, external_vars: &HashSet<VariableAtom>) {
+//     let mut local_var_mapper = ReplacingMapper::new(VariableAtom::make_unique);
+
+//     var_list.iter_mut().filter_type::<&mut VariableAtom>()
+//         .filter(|var| external_vars.contains(var))
+//         .for_each(|var| local_var_mapper.replace(var));
+
+//     term.iter_mut().filter_type::<&mut VariableAtom>()
+//         .for_each(|var| match local_var_mapper.mapping_mut().get(var) {
+//             Some(v) => *var = v.clone(),
+//             None => {},
+//         });
+// }
+
 fn seal_vars(var_list: &mut Atom, term: &mut Atom, external_vars: &HashSet<VariableAtom>) {
     let mut var_to_uuid = HashMap::new();
 
+    println!("seal_vars var_list {:?}", var_list);
+    println!("seal_vars term {:?}", term);
+    println!("seal_vars external_vars {:?}", external_vars);
     var_list.iter_mut().filter_type::<&mut VariableAtom>()
         .filter(|var| external_vars.contains(var))
         .for_each(|var| {
             let var_name = var.name();
-            let uuid = var_to_uuid.entry(var_name.to_string())
+            let _ = var_to_uuid.entry(var_name.to_string())
                 .or_insert_with(Uuid::new_v4)
                 .to_string();
-            *var = Atom::sym(&format!("${}", uuid));
+            //*var = VariableAtom::new(uuid);
         });
+
+    println!("seal_vars var_to_uuid {:?}", var_to_uuid);
 
     term.iter_mut().filter_type::<&mut VariableAtom>()
         .for_each(|var| {
             if let Some(uuid) = var_to_uuid.get(&var.name().to_string()) {
-                *var = Atom::sym(&format!("${}", uuid));
+                *var = VariableAtom::new(uuid.to_string());
             }
         });
+
+    println!("seal_vars var_list {:?}", var_list);
+    println!("seal_vars term {:?}", term);
+    println!("seal_vars external_vars {:?}", external_vars);
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -1770,13 +1791,13 @@ mod tests {
 
     #[test]
     fn sealed_op_runner() {
-        //let nested = run_program("!(sealed ($x) (sealed ($a $b) (=($a $x $c) ($d))))");
-        let simple = run_program("!(sealed ($x $y) (=($y $z)))");
+        let nested = run_program("!(sealed ($x) (sealed ($a $b) (=($a $x $c) ($b))))");
+        let simple_replace = run_program("!(sealed ($x $y) (=($y $z)))");
         //println!("{:?}", &nested.unwrap());
-        println!("{:?}", &simple.unwrap());
+        //println!("{:?}", &simple_replace.unwrap());
 
-        //assert!(crate::atom::matcher::atoms_are_equivalent(&nested.unwrap()[0][0], &expr!("="(a b c) (z))));
-        //assert!(crate::atom::matcher::atoms_are_equivalent(&simple.unwrap()[0][0], &expr!("="(y z))));
+        assert!(crate::atom::matcher::atoms_are_equivalent(&nested.unwrap()[0][0], &expr!("="(a b c) (z))));
+        assert!(crate::atom::matcher::atoms_are_equivalent(&simple_replace.unwrap()[0][0], &expr!("="(y z))));
     }
 
     #[test]


### PR DESCRIPTION
added new operator sealed.
format: (sealed (Expression with sealed variable list) (Term with variables to seal))
example: (sealed ($x $y) (= ($x $y) ($a $b))
$x and $y should be replaced with new unique variables in the Term value
this new version uses UUID values to make them more explicitly unique rather than the ReplacingMapper