### PR TITLE
Adding `Parser` trait

### DIFF
--- a/c/src/metta.rs
+++ b/c/src/metta.rs
@@ -1093,7 +1093,7 @@ impl runner_state_t {
 pub extern "C" fn runner_state_new_with_parser(metta: *const metta_t, parser: sexpr_parser_t) -> runner_state_t {
     let metta = unsafe{ &*metta }.borrow();
     let parser = parser.into_inner();
-    let state = RunnerState::new_with_parser(metta, parser);
+    let state = RunnerState::new_with_parser(metta, Box::new(parser));
     state.into()
 }
 

--- a/lib/src/metta/text.rs
+++ b/lib/src/metta/text.rs
@@ -217,6 +217,22 @@ impl SyntaxNode {
     }
 }
 
+/// Implemented on a type that yields atoms to be interpreted as MeTTa code.  Typically
+/// by parsing source text
+pub trait Parser {
+    fn next_atom(&mut self, tokenizer: &Tokenizer) -> Result<Option<Atom>, String>;
+}
+
+impl Parser for SExprParser<'_> {
+    fn next_atom(&mut self, tokenizer: &Tokenizer) -> Result<Option<Atom>, String> {
+        self.parse(tokenizer)
+    }
+}
+
+/// Provides a parser for MeTTa code written in S-Expression Syntax
+///
+/// NOTE: The SExprParser type is short-lived, and can be created cheaply to evaluate a specific block
+/// of MeTTa source code.
 #[derive(Clone)]
 pub struct SExprParser<'a> {
     text: &'a str,


### PR DESCRIPTION
This PR adds a `Parser` trait, and changes `Metta::run` to accept any `impl Parser` instead of a `SExprParser`

I gathered this was a direction we want to go anyway, to allow additional syntaxes.

However my reason for needing this change right now is that the module loader needs a way to retain ownership of text before it's parsed, but keeping the text buffer along-side the parser would result in a self-referential object.  So this change lets me create an `OwningSExprParser` that owns the text it's parsing.

This is a tiny step towards merging the module system.