### PR TITLE
Minimal interpreter performance fixes

### DIFF
--- a/lib/benches/interpreter2.rs
+++ b/lib/benches/interpreter2.rs
@@ -1,6 +1,7 @@
 #![feature(test)]
 #[cfg(feature = "minimal")]
 mod interpreter2_bench {
+
 extern crate test;
 
 use test::Bencher;
@@ -18,6 +19,18 @@ fn chain_atom(size: isize) -> Atom {
     atom
 }
 
+
+#[bench]
+fn chain_x10(bencher: &mut Bencher) {
+    let atom = chain_atom(10);
+    let expected = Ok(vec![expr!("A")]);
+    bencher.iter(|| {
+        let space = GroundingSpace::new();
+        let res = interpret(space, &atom);
+        assert_eq!(res, expected);
+    })
+}
+
 #[bench]
 fn chain_x100(bencher: &mut Bencher) {
     let atom = chain_atom(100);
@@ -28,4 +41,16 @@ fn chain_x100(bencher: &mut Bencher) {
         assert_eq!(res, expected);
     })
 }
+
+#[bench]
+fn chain_x1000(bencher: &mut Bencher) {
+    let atom = chain_atom(1000);
+    let expected = Ok(vec![expr!("A")]);
+    bencher.iter(|| {
+        let space = GroundingSpace::new();
+        let res = interpret(space, &atom);
+        assert_eq!(res, expected);
+    })
+}
+
 }

--- a/lib/benches/interpreter2.rs
+++ b/lib/benches/interpreter2.rs
@@ -8,8 +8,8 @@ use test::Bencher;
 
 use hyperon::*;
 use hyperon::space::grounding::*;
-use hyperon::metta::interpreter2::*;
 use hyperon::metta::*;
+use hyperon::metta::interpreter2::*;
 
 fn chain_atom(size: isize) -> Atom {
     let mut atom = Atom::expr([CHAIN_SYMBOL, Atom::sym("A"), Atom::var("x"), Atom::var("x")]);
@@ -22,33 +22,33 @@ fn chain_atom(size: isize) -> Atom {
 
 #[bench]
 fn chain_x10(bencher: &mut Bencher) {
+    let space = GroundingSpace::new();
     let atom = chain_atom(10);
     let expected = Ok(vec![expr!("A")]);
-    bencher.iter(|| {
-        let space = GroundingSpace::new();
-        let res = interpret(space, &atom);
+    bencher.iter(move || {
+        let res = interpret(&space, &atom);
         assert_eq!(res, expected);
     })
 }
 
 #[bench]
 fn chain_x100(bencher: &mut Bencher) {
+    let space = GroundingSpace::new();
     let atom = chain_atom(100);
     let expected = Ok(vec![expr!("A")]);
-    bencher.iter(|| {
-        let space = GroundingSpace::new();
-        let res = interpret(space, &atom);
+    bencher.iter(move || {
+        let res = interpret(&space, &atom);
         assert_eq!(res, expected);
     })
 }
 
 #[bench]
 fn chain_x1000(bencher: &mut Bencher) {
+    let space = GroundingSpace::new();
     let atom = chain_atom(1000);
     let expected = Ok(vec![expr!("A")]);
-    bencher.iter(|| {
-        let space = GroundingSpace::new();
-        let res = interpret(space, &atom);
+    bencher.iter(move || {
+        let res = interpret(&space, &atom);
         assert_eq!(res, expected);
     })
 }

--- a/lib/src/atom/matcher.rs
+++ b/lib/src/atom/matcher.rs
@@ -134,6 +134,7 @@ impl Bindings {
         }
     }
 
+    #[allow(dead_code)] //TODO: MINIMAL only silence the warning until interpreter2 replaces interpreter
     pub(crate) fn len(&self) -> usize {
         self.id_by_var.len()
     }

--- a/lib/src/atom/mod.rs
+++ b/lib/src/atom/mod.rs
@@ -838,6 +838,16 @@ impl<'a> TryFrom<&'a Atom> for &'a [Atom] {
     }
 }
 
+impl<'a> TryFrom<&'a mut Atom> for &'a mut [Atom] {
+    type Error = &'static str;
+    fn try_from(atom: &mut Atom) -> Result<&mut [Atom], &'static str> {
+        match atom {
+            Atom::Expression(expr) => Ok(expr.children_mut().as_mut_slice()),
+            _ => Err("Atom is not an ExpressionAtom")
+        }
+    }
+}
+
 impl TryFrom<Atom> for SymbolAtom {
     type Error = &'static str;
     fn try_from(atom: Atom) -> Result<Self, &'static str> {

--- a/lib/src/metta/interpreter2.rs
+++ b/lib/src/metta/interpreter2.rs
@@ -52,8 +52,7 @@ struct Stack {
     vars: Rc<Variables>,
 }
 
-// FIXME: rename to no_handler
-fn nop_handler(_stack: Rc<RefCell<Stack>>, _atom: Atom, _bindings: Bindings) -> Option<Stack> {
+fn no_handler(_stack: Rc<RefCell<Stack>>, _atom: Atom, _bindings: Bindings) -> Option<Stack> {
     panic!("Unexpected state");
 }
 
@@ -66,7 +65,7 @@ impl Stack {
     fn finished(prev: Option<Rc<RefCell<Self>>>, atom: Atom) -> Self {
         // FIXME: here we don't need vars actually
         let vars = Rc::new(Variables::new());
-        Self{ prev, atom, ret: nop_handler, finished: true, vars }
+        Self{ prev, atom, ret: no_handler, finished: true, vars }
     }
 
     fn len(&self) -> usize {
@@ -468,7 +467,7 @@ fn atom_to_stack(atom: Atom, prev: Option<Rc<RefCell<Stack>>>) -> Stack {
             collapse_bind_to_stack(atom, prev)
         },
         _ => {
-            Stack::from_prev(prev, atom, nop_handler)
+            Stack::from_prev(prev, atom, no_handler)
         },
     };
     result
@@ -480,7 +479,7 @@ fn chain_to_stack(mut atom: Atom, prev: Option<Rc<RefCell<Stack>>>) -> Stack {
         Some([_op, nested, Atom::Variable(_var), _templ]) => nested,
         _ => {
             let error: String = format!("expected: ({} <nested> (: <var> Variable) <templ>), found: {}", CHAIN_SYMBOL, atom);
-            return Stack::from_prev(prev, error_atom(atom, error), nop_handler);
+            return Stack::from_prev(prev, error_atom(atom, error), no_handler);
         },
     };
     std::mem::swap(nested_arg, &mut nested);
@@ -519,7 +518,7 @@ fn function_to_stack(mut atom: Atom, prev: Option<Rc<RefCell<Stack>>>) -> Stack 
         Some([_op, nested @ Atom::Expression(_)]) => nested,
         _ => {
             let error: String = format!("expected: ({} (: <body> Expression)), found: {}", FUNCTION_SYMBOL, atom);
-            return Stack::from_prev(prev, error_atom(atom, error), nop_handler);
+            return Stack::from_prev(prev, error_atom(atom, error), no_handler);
         },
     };
     std::mem::swap(nested_arg, &mut nested);
@@ -554,7 +553,7 @@ fn collapse_bind_to_stack(mut atom: Atom, prev: Option<Rc<RefCell<Stack>>>) -> S
         Some([_op, nested @ Atom::Expression(_)]) => nested,
         _ => {
             let error: String = format!("expected: ({} (: <current> Expression)), found: {}", COLLAPSE_BIND, atom);
-            return Stack::from_prev(prev, error_atom(atom, error), nop_handler);
+            return Stack::from_prev(prev, error_atom(atom, error), no_handler);
         },
     };
     std::mem::swap(nested_arg, &mut nested);

--- a/lib/src/metta/interpreter2.rs
+++ b/lib/src/metta/interpreter2.rs
@@ -276,8 +276,8 @@ fn is_embedded_op(atom: &Atom) -> bool {
             || *op == CONS_SYMBOL
             || *op == DECONS_SYMBOL
             || *op == FUNCTION_SYMBOL
-            || *op == COLLAPSE_BIND
-            || *op == SUPERPOSE_BIND,
+            || *op == COLLAPSE_BIND_SYMBOL
+            || *op == SUPERPOSE_BIND_SYMBOL,
         _ => false,
     }
 }
@@ -326,7 +326,7 @@ fn interpret_nested_atom<'a, T: SpaceRef<'a>>(context: &InterpreterContext<'a, T
                 let error = format!("function doesn't have return statement, last atom: {}", stack.atom);
                 finished_result(error_atom(stack.atom, error), bindings, stack.prev)
             },
-            Some([op, ..]) if *op == COLLAPSE_BIND => {
+            Some([op, ..]) if *op == COLLAPSE_BIND_SYMBOL => {
                 collapse_bind(stack, bindings)
             },
             Some([op, ..]) if *op == UNIFY_SYMBOL => {
@@ -338,7 +338,7 @@ fn interpret_nested_atom<'a, T: SpaceRef<'a>>(context: &InterpreterContext<'a, T
             Some([op, ..]) if *op == CONS_SYMBOL => {
                 cons(stack, bindings)
             },
-            Some([op, ..]) if *op == SUPERPOSE_BIND => {
+            Some([op, ..]) if *op == SUPERPOSE_BIND_SYMBOL => {
                 superpose_bind(stack, bindings)
             },
             _ => {
@@ -463,7 +463,7 @@ fn atom_to_stack(atom: Atom, prev: Option<Rc<RefCell<Stack>>>) -> Stack {
         Some([op, ..]) if *op == FUNCTION_SYMBOL => {
             function_to_stack(atom, prev)
         },
-        Some([op, ..]) if *op == COLLAPSE_BIND => {
+        Some([op, ..]) if *op == COLLAPSE_BIND_SYMBOL => {
             collapse_bind_to_stack(atom, prev)
         },
         _ => {
@@ -552,7 +552,7 @@ fn collapse_bind_to_stack(mut atom: Atom, prev: Option<Rc<RefCell<Stack>>>) -> S
     let nested_arg = match atom_as_slice_mut(&mut atom) {
         Some([_op, nested @ Atom::Expression(_)]) => nested,
         _ => {
-            let error: String = format!("expected: ({} (: <current> Expression)), found: {}", COLLAPSE_BIND, atom);
+            let error: String = format!("expected: ({} (: <current> Expression)), found: {}", COLLAPSE_BIND_SYMBOL, atom);
             return Stack::from_prev(prev, error_atom(atom, error), no_handler);
         },
     };
@@ -681,7 +681,7 @@ fn superpose_bind(stack: Stack, bindings: Bindings) -> Vec<InterpretedAtom> {
     let collapsed = match_atom!{
         superpose ~ [_op, Atom::Expression(collapsed)] => collapsed,
         _ => {
-            let error: String = format!("expected: ({} (: <collapsed> Expression)), found: {}", SUPERPOSE_BIND, superpose);
+            let error: String = format!("expected: ({} (: <collapsed> Expression)), found: {}", SUPERPOSE_BIND_SYMBOL, superpose);
             return finished_result(error_atom(superpose, error), bindings, prev);
         }
     };

--- a/lib/src/metta/interpreter2.rs
+++ b/lib/src/metta/interpreter2.rs
@@ -2,7 +2,7 @@
 //!
 //! # Algorithm
 //!
-//! FIXME: explain an algorithm
+//! TODO: explain an algorithm
 
 use crate::*;
 use crate::atom::matcher::*;
@@ -43,11 +43,11 @@ struct Stack {
     // reference the same collapse-bind Stack instance. When some alternative
     // finishes it modifies the collapse-bind state adding the result to the
     // collapse-bind list of results.
-    // FIXME: Try representing Option via Stack::Bottom
+    // TODO: Try representing Option via Stack::Bottom
     prev: Option<Rc<RefCell<Self>>>,
     atom: Atom,
     ret: ReturnHandler,
-    // FIXME: Could it be replaced by calling a return handler when setting the flag?
+    // TODO: Could it be replaced by calling a return handler when setting the flag?
     finished: bool,
     vars: Rc<Variables>,
 }
@@ -78,7 +78,7 @@ impl Stack {
         self.fold(0, |len, _stack| len + 1)
     }
 
-    // FIXME: should it be replaced by Iterator implementation?
+    // TODO: should it be replaced by Iterator implementation?
     fn fold<T, F: FnMut(T, &Stack) -> T>(&self, mut val: T, mut app: F) -> T {
         val = app(val, self);
         match &self.prev {
@@ -179,7 +179,6 @@ fn atom_as_slice_mut(atom: &mut Atom) -> Option<&mut [Atom]> {
     <&mut [Atom]>::try_from(atom).ok()
 }
 
-// FIXME: return incorrect length as error_atom() from caller
 fn atom_into_array<const N: usize>(atom: Atom) -> Option<[Atom; N]> {
     <[Atom; N]>::try_from(atom).ok()
 }
@@ -187,7 +186,7 @@ fn atom_into_array<const N: usize>(atom: Atom) -> Option<[Atom; N]> {
 impl<'a, T: SpaceRef<'a>> InterpreterState<'a, T> {
 
     /// INTERNAL USE ONLY. Create an InterpreterState that is ready to yield results
-    #[allow(dead_code)] //TODO: only silence the warning until interpreter2 replaces interpreter
+    #[allow(dead_code)] //TODO: MINIMAL only silence the warning until interpreter2 replaces interpreter
     pub(crate) fn new_finished(space: T, results: Vec<Atom>) -> Self {
         Self {
             plan: vec![],
@@ -322,7 +321,8 @@ fn interpret_nested_atom<'a, T: SpaceRef<'a>>(context: &InterpreterContext<'a, T
             None => panic!("Unexpected state"),
         };
         let ret = prev.borrow().ret;
-        // FIXME: two copies of bindings here
+        // TODO: two copies of bindings here; we could try to include bindings
+        // into Stack and eliminate copying
         ret(prev, atom, bindings.clone())
             .map_or(vec![], |stack| vec![InterpretedAtom(stack, bindings)])
     } else {
@@ -335,9 +335,7 @@ fn interpret_nested_atom<'a, T: SpaceRef<'a>>(context: &InterpreterContext<'a, T
                 chain(stack, bindings)
             },
             Some([op, ..]) if *op == FUNCTION_SYMBOL => {
-                // FIXME: incorrect error
-                let error = format!("function doesn't have return statement, last atom: {}", stack.atom);
-                finished_result(error_atom(stack.atom, error), bindings, stack.prev)
+                panic!("Unexpected state")
             },
             Some([op, ..]) if *op == COLLAPSE_BIND_SYMBOL => {
                 collapse_bind(stack, bindings)
@@ -1132,6 +1130,7 @@ mod tests {
         assert_eq!(result, Ok(vec![metta_atom("((P $a B) $a)")]));
         let result = interpret(&space, &metta_atom("(collapse-bind (eval (color)))"));
         assert!(result.is_ok());
+        // FIXME: check correctly
         assert_eq!(result, Ok(vec![metta_atom("red"), metta_atom("green"), metta_atom("blue")]));
     }
 }

--- a/lib/src/metta/mod.rs
+++ b/lib/src/metta/mod.rs
@@ -37,7 +37,9 @@ pub const DECONS_SYMBOL : Atom = sym!("decons");
 pub const CONS_SYMBOL : Atom = sym!("cons");
 pub const FUNCTION_SYMBOL : Atom = sym!("function");
 pub const RETURN_SYMBOL : Atom = sym!("return");
+// FIXME: rename to *_SYMBOL
 pub const COLLAPSE_BIND : Atom = sym!("collapse-bind");
+// FIXME: rename to *_SYMBOL
 pub const SUPERPOSE_BIND : Atom = sym!("superpose-bind");
 
 pub const INTERPRET_SYMBOL : Atom = sym!("interpret");

--- a/lib/src/metta/mod.rs
+++ b/lib/src/metta/mod.rs
@@ -37,10 +37,8 @@ pub const DECONS_SYMBOL : Atom = sym!("decons");
 pub const CONS_SYMBOL : Atom = sym!("cons");
 pub const FUNCTION_SYMBOL : Atom = sym!("function");
 pub const RETURN_SYMBOL : Atom = sym!("return");
-// FIXME: rename to *_SYMBOL
-pub const COLLAPSE_BIND : Atom = sym!("collapse-bind");
-// FIXME: rename to *_SYMBOL
-pub const SUPERPOSE_BIND : Atom = sym!("superpose-bind");
+pub const COLLAPSE_BIND_SYMBOL : Atom = sym!("collapse-bind");
+pub const SUPERPOSE_BIND_SYMBOL : Atom = sym!("superpose-bind");
 
 pub const INTERPRET_SYMBOL : Atom = sym!("interpret");
 

--- a/lib/src/metta/runner/stdlib.metta
+++ b/lib/src/metta/runner/stdlib.metta
@@ -19,37 +19,28 @@
 (= (apply $atom $var $templ)
   (function (chain (eval (id $atom)) $var (return $templ))) )
 
-(: if-non-empty-expression (-> Atom Atom Atom Atom))
-(= (if-non-empty-expression $atom $then $else)
-  (function (chain (eval (get-metatype $atom)) $type
-    (eval (if-equal $type Expression
-      (eval (if-equal $atom () (return $else) (return $then)))
-      (return $else) )))))
-
-(: if-decons (-> Atom Variable Variable Atom Atom Atom))
-(= (if-decons $atom $head $tail $then $else)
-  (function (eval (if-non-empty-expression $atom
+(: if-decons-expr (-> Expression Variable Variable Atom Atom Atom))
+(= (if-decons-expr $atom $head $tail $then $else)
+  (function (eval (if-equal $atom ()
+    (return $else)
     (chain (decons $atom) $list
-      (unify $list ($head $tail) (return $then) (return $else)) )
-    (return $else) ))))
-
-(: if-empty (-> Atom Atom Atom Atom))
-(= (if-empty $atom $then $else)
-  (function (eval (if-equal $atom Empty (return $then) (return $else)))) )
-
-(: if-not-reducible (-> Atom Atom Atom Atom))
-(= (if-not-reducible $atom $then $else)
-  (function (eval (if-equal $atom NotReducible (return $then) (return $else)))) )
+      (unify $list ($head $tail) (return $then) (return $else)) )))))
 
 (: if-error (-> Atom Atom Atom Atom))
 (= (if-error $atom $then $else)
-  (function (eval (if-decons $atom $head $_
-    (eval (if-equal $head Error (return $then) (return $else)))
-    (return $else) ))))
+  (function (chain (eval (get-metatype $atom)) $meta
+    (eval (if-equal $meta Expression
+      (eval (if-equal $atom ()
+        (return $else)
+        (chain (decons $atom) $list
+          (unify $list ($head $tail)
+            (eval (if-equal $head Error (return $then) (return $else)))
+            (return $else) ))))
+      (return $else) )))))
 
 (: return-on-error (-> Atom Atom Atom))
 (= (return-on-error $atom $then)
-  (function (eval (if-empty $atom (return (return Empty))
+  (function (eval (if-equal $atom Empty (return (return Empty))
     (eval (if-error $atom (return (return $atom))
       (return $then) ))))))
 
@@ -57,7 +48,7 @@
 (= (switch $atom $cases)
   (function (chain (decons $cases) $list
     (chain (eval (switch-internal $atom $list)) $res
-      (chain (eval (if-not-reducible $res Empty $res)) $x (return $x)) ))))
+      (chain (eval (if-equal $res NotReducible Empty $res)) $x (return $x)) ))))
 
 (= (switch-internal $atom (($pattern $template) $tail))
   (function (unify $atom $pattern
@@ -105,7 +96,7 @@
   (function (chain (eval (get-metatype $type)) $meta
     (eval (switch ($type $meta) (
       (($type Expression)
-        (eval (if-decons $type $head $_tail
+        (eval (if-decons-expr $type $head $_tail
           (unify $head -> (return True) (return False))
           (return (Error (is-function $type) "is-function non-empty expression as an argument")) )))
       (($type $meta) (return False))
@@ -113,7 +104,7 @@
 
 (: filter-atom (-> Expression Variable Atom Expression))
 (= (filter-atom $list $var $filter)
-  (function (eval (if-decons $list $head $tail
+  (function (eval (if-decons-expr $list $head $tail
     (chain (eval (filter-atom $tail $var $filter)) $tail-filtered
       (chain (eval (apply $head $var $filter)) $filter-expr
         (chain $filter-expr $is-filtered
@@ -124,7 +115,7 @@
 
 (: map-atom (-> Expression Variable Atom Expression))
 (= (map-atom $list $var $map)
-  (function (eval (if-decons $list $head $tail
+  (function (eval (if-decons-expr $list $head $tail
     (chain (eval (map-atom $tail $var $map)) $tail-mapped
       (chain (eval (apply $head $var $map)) $map-expr
         (chain $map-expr $head-mapped
@@ -133,7 +124,7 @@
 
 (: foldl-atom (-> Expression Atom Variable Variable Atom Atom))
 (= (foldl-atom $list $init $a $b $op)
-  (function (eval (if-decons $list $head $tail
+  (function (eval (if-decons-expr $list $head $tail
     (chain (eval (apply $init $a $op)) $op-init
       (chain (eval (apply $head $b $op-init)) $op-head
         (chain $op-head $head-folded
@@ -177,7 +168,7 @@
         ))))))))))
 
 (= (interpret-expression $atom $type $space)
-  (function (eval (if-decons $atom $op $args
+  (function (eval (if-decons-expr $atom $op $args
     (chain (eval (get-type $op $space)) $op-type
       (chain (eval (is-function $op-type)) $is-func
         (unify $is-func True
@@ -188,10 +179,10 @@
     (chain (eval (type-cast $atom $type $space)) $ret (return $ret)) ))))
 
 (= (interpret-func $expr $type $ret-type $space)
-  (function (eval (if-decons $expr $op $args
+  (function (eval (if-decons-expr $expr $op $args
     (chain (eval (interpret $op $type $space)) $reduced-op
       (eval (return-on-error $reduced-op
-        (eval (if-decons $type $arrow $arg-types
+        (eval (if-decons-expr $type $arrow $arg-types
           (chain (eval (interpret-args $expr $args $arg-types $ret-type $space)) $reduced-args
             (eval (return-on-error $reduced-args
               (chain (cons $reduced-op $reduced-args) $r (return $r)))))
@@ -200,13 +191,13 @@
 
 (= (interpret-args $atom $args $arg-types $ret-type $space)
   (function (unify $args ()
-    (eval (if-decons $arg-types $actual-ret-type $_tail
+    (eval (if-decons-expr $arg-types $actual-ret-type $_tail
       (eval (match-types $actual-ret-type $ret-type
         (return ())
         (return (Error $atom BadType)) ))
       (return (Error (interpret-args $atom $args $arg-types $ret-type $space) "interpret-args expects a non-empty value for $arg-types argument")) ))
-    (eval (if-decons $args $head $tail
-      (eval (if-decons $arg-types $head-type $tail-types
+    (eval (if-decons-expr $args $head $tail
+      (eval (if-decons-expr $arg-types $head-type $tail-types
         (chain (eval (interpret $head $head-type $space)) $reduced-head
           ; check that head was changed otherwise Error or Empty in the head
           ; can be just an argument which is passed by intention
@@ -225,19 +216,19 @@
 (= (interpret-tuple $atom $space)
   (function (unify $atom ()
     (return $atom)
-    (eval (if-decons $atom $head $tail
+    (eval (if-decons-expr $atom $head $tail
       (chain (eval (interpret $head %Undefined% $space)) $rhead
-        (eval (if-empty $rhead (return Empty)
+        (eval (if-equal $rhead Empty (return Empty)
           (chain (eval (interpret-tuple $tail $space)) $rtail
-            (eval (if-empty $rtail (return Empty)
+            (eval (if-equal $rtail Empty (return Empty)
               (chain (cons $rhead $rtail) $ret (return $ret)) ))))))
       (return (Error (interpret-tuple $atom $space) "Non-empty expression atom is expected as an argument")) )))))
 
 (= (metta-call $atom $type $space)
   (function (eval (if-error $atom (return $atom)
     (chain (eval $atom) $result
-      (eval (if-not-reducible $result (return $atom)
-        (eval (if-empty $result (return Empty)
+      (eval (if-equal $result NotReducible (return $atom)
+        (eval (if-equal $result Empty (return Empty)
           (eval (if-error $result (return $result)
             (chain (eval (interpret $result $type $space)) $ret (return $ret)) )))))))))))
 
@@ -277,19 +268,19 @@
 
 (: let* (-> Expression Atom Atom))
 (= (let* $pairs $template)
-  (eval (if-decons $pairs ($pattern $atom) $tail
+  (eval (if-decons-expr $pairs ($pattern $atom) $tail
     (let $pattern $atom (let* $tail $template))
     $template )))
 
 (: car-atom (-> Expression Atom))
 (= (car-atom $atom)
-  (eval (if-decons $atom $head $_
+  (eval (if-decons-expr $atom $head $_
     $head
     (Error (car-atom $atom) "car-atom expects a non-empty expression as an argument") )))
 
 (: cdr-atom (-> Expression Expression))
 (= (cdr-atom $atom)
-  (eval (if-decons $atom $_ $tail
+  (eval (if-decons-expr $atom $_ $tail
     $tail
     (Error (cdr-atom $atom) "cdr-atom expects a non-empty expression as an argument") )))
 

--- a/lib/src/metta/runner/stdlib.metta
+++ b/lib/src/metta/runner/stdlib.metta
@@ -294,3 +294,6 @@
 ; arguments  and returns unit
 (= (nop) ())
 (= (nop $x) ())
+
+; TODO: MINIMAL added for compatibility, remove after migration
+(= (empty) Empty)


### PR DESCRIPTION
Use stack to represent state of the interpreter and eliminate atom deconstructing/constructing on each step. Make small performance related fixes in the interpreter written in MeTTa.