### PR TITLE
Speedup in narrow_vars in situations where the number of variables in the interpreter state gets huge

### DIFF
--- a/lib/src/atom/matcher.rs
+++ b/lib/src/atom/matcher.rs
@@ -543,8 +543,10 @@ impl Bindings {
     /// ```
     pub fn narrow_vars<T: VariableSet>(&self, vars: &T) -> Bindings {
         let mut deps: HashSet<VariableAtom> = HashSet::new();
-        for var in vars.iter() {
-            self.find_deps(var, &mut deps);
+        for var in self.id_by_var.keys() {
+            if vars.contains(var) {
+                self.find_deps(var, &mut deps);
+            }
         }
 
         let dep_ids: HashSet<u32> = deps.iter()


### PR DESCRIPTION
Observation: the `vars` HashSet that gets passed into `narrow_vars` starts to grow truly massive (1000 atoms for large recursive evaluations in minimal MeTTa), and a lot of time is wasted hashing and evaluating dependencies for each one.

This fix improves performance by ~5% for the test case here:
```
(= (TupleCount $tuple) (if (== $tuple ()) 0 (+ 1 (TupleCount (cdr-atom $tuple)))))
!(TupleCount (1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32))
```

This is not a silver bullet by any measure, but I believe it never makes the situation worse.