### PR TITLE
Return unit if none in Python grounded functions when unwrap=True

### DIFF
--- a/c/src/metta.rs
+++ b/c/src/metta.rs
@@ -557,14 +557,31 @@ pub extern "C" fn atom_error_message(atom: *const atom_ref_t, buf: *mut c_char, 
 ///
 #[no_mangle] pub extern "C" fn ATOM_TYPE_GROUNDED_SPACE() -> atom_t { rust_type_atom::<DynSpace>().into() }
 
+/// @brief Creates an atom used to indicate that an atom's type is a unit type.
+/// @ingroup metta_language_group
+/// @return  The `atom_t` representing the atom
+/// @note The returned `atom_t` must be freed with `atom_free()`
+///
+#[no_mangle] pub extern "C" fn ATOM_TYPE_UNIT() -> atom_t { hyperon::metta::UNIT_TYPE().into() }
+
 /// @brief Creates a Symbol atom for the special MeTTa symbol used to indicate empty results
 /// returned by function.
 /// @ingroup metta_language_group
-/// @return  The `atom_t` representing the Void atom
+/// @return  The `atom_t` representing the Empty atom
 /// @note The returned `atom_t` must be freed with `atom_free()`
 ///
-#[no_mangle] pub extern "C" fn EMPTY_SYMBOL() -> atom_t {
+#[no_mangle] pub extern "C" fn EMPTY_ATOM() -> atom_t {
     hyperon::metta::EMPTY_SYMBOL.into()
+}
+
+/// @brief Creates an atom used to return from functions which are not
+/// supposed to return results (print for example).
+/// @ingroup metta_language_group
+/// @return  The `atom_t` representing the Unit atom
+/// @note The returned `atom_t` must be freed with `atom_free()`
+///
+#[no_mangle] pub extern "C" fn UNIT_ATOM() -> atom_t {
+    hyperon::metta::UNIT_ATOM().into()
 }
 
 /// @brief Checks whether Atom `atom` has Type `typ` in context of `space`

--- a/python/hyperon/atoms.py
+++ b/python/hyperon/atoms.py
@@ -116,10 +116,12 @@ class AtomType:
     EXPRESSION = Atom._from_catom(hp.CAtomType.EXPRESSION)
     GROUNDED = Atom._from_catom(hp.CAtomType.GROUNDED)
     GROUNDED_SPACE = Atom._from_catom(hp.CAtomType.GROUNDED_SPACE)
+    UNIT = Atom._from_catom(hp.CAtomType.UNIT)
 
 class Atoms:
 
     EMPTY = Atom._from_catom(hp.CAtoms.EMPTY)
+    UNIT = Atom._from_catom(hp.CAtoms.UNIT)
 
 class GroundedAtom(Atom):
     """
@@ -324,7 +326,7 @@ class OperationObject(GroundedObject):
             args = [arg.get_object().content for arg in args]
             result = self.op(*args)
             if result is None:
-                return [E()]
+                return [Atoms.UNIT]
             return [G(ValueObject(result), res_typ)]
         else:
             result = self.op(*args)

--- a/python/hyperon/atoms.py
+++ b/python/hyperon/atoms.py
@@ -322,7 +322,10 @@ class OperationObject(GroundedObject):
                     # raise RuntimeError("Grounded operation " + self.name + " with unwrap=True expects only grounded arguments")
                     raise NoReduceError()
             args = [arg.get_object().content for arg in args]
-            return [G(ValueObject(self.op(*args)), res_typ)]
+            result = self.op(*args)
+            if result is None:
+                return [E()]
+            return [G(ValueObject(result), res_typ)]
         else:
             result = self.op(*args)
             if not isinstance(result, list):

--- a/python/hyperonpy.cpp
+++ b/python/hyperonpy.cpp
@@ -773,7 +773,8 @@ PYBIND11_MODULE(hyperonpy, m) {
         ADD_TYPE(VARIABLE, "Variable")
         ADD_TYPE(EXPRESSION, "Expression")
         ADD_TYPE(GROUNDED, "Grounded")
-        ADD_TYPE(GROUNDED_SPACE, "Space");
+        ADD_TYPE(GROUNDED_SPACE, "Space")
+        ADD_TYPE(UNIT, "Unit");
     m.def("check_type", [](CSpace space, CAtom& atom, CAtom& type) {
             return check_type(space.ptr(), atom.ptr(), type.ptr());
         }, "Check if atom is an instance of the passed type");
@@ -786,10 +787,11 @@ PYBIND11_MODULE(hyperonpy, m) {
             return atoms;
         }, "Get types of the given atom");
 
-#define ADD_SYMBOL(t, d) .def_property_readonly_static(#t, [](py::object) { return CAtom(t ## _SYMBOL()); }, d " atom type")
+#define ADD_ATOM(t, d) .def_property_readonly_static(#t, [](py::object) { return CAtom(t ## _ATOM()); }, d " atom type")
 
     py::class_<CAtoms>(m, "CAtoms")
-        ADD_SYMBOL(EMPTY, "Empty");
+        ADD_ATOM(EMPTY, "Empty")
+        ADD_ATOM(UNIT, "Unit");
 
     py::class_<CMetta>(m, "CMetta");
     m.def("metta_new", [](CSpace space, EnvBuilder env_builder) {

--- a/python/tests/test_atom.py
+++ b/python/tests/test_atom.py
@@ -105,6 +105,16 @@ class AtomTest(unittest.TestCase):
         self.assertEqual(interpret(space, expr),
                 [E(S('Error'), expr, S('Grounded operation which is defined using unwrap=False should return atom instead of Python type'))])
 
+    def test_grounded_no_return(self):
+        space = GroundingSpaceRef()
+        def print_op(input):
+            print(input)
+
+        printExpr = E(OperationAtom('print', print_op, type_names=["Atom", "->"], unwrap=False), S("test"))
+        self.assertTrue(atom_is_error(interpret(space, printExpr)[0]))
+        printExpr = E(OperationAtom('print', print_op, type_names=["Atom", "->"], unwrap=True), ValueAtom("test"))
+        self.assertEqual(interpret(space, printExpr), [E()])
+
     def test_plan(self):
         space = GroundingSpaceRef()
         interpreter = Interpreter(space, E(x2Atom, ValueAtom(1)))

--- a/python/tests/test_grounded_type.py
+++ b/python/tests/test_grounded_type.py
@@ -22,11 +22,8 @@ class GroundedTypeTest(unittest.TestCase):
         metta.register_atom("untyped", ValueAtom(None))
         metta.register_atom("untop", OperationAtom("untop", lambda: None))
         self.assertEqual(
-            metta.run("!(untop)")[0][0].get_grounded_type(),
-            metta.parse_single("untyped").get_grounded_type())
-        self.assertNotEqual(
-            metta.run("!(untop)")[0][0].get_grounded_type(),
-            metta.run("!(+ 1 1)")[0][0].get_grounded_type())
+            metta.run("!(untop)")[0][0],
+            metta.parse_single("()"))
         self.assertNotEqual(
             metta.run("!(> 1 1)")[0][0].get_grounded_type(),
             metta.run("!(+ 1 1)")[0][0].get_grounded_type())


### PR DESCRIPTION
It is useful for the case when function without result is wrapped to the `GroundedAtom` and exported to MeTTa. In such case MeTTa expects instance of the unit type is returned (which is represented by empty expression `()`).