### PR TITLE
Add Cargo workspace configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,17 @@
+[workspace]
+members = [
+    "lib",
+    "c",
+    "repl",
+]
+resolver = "2"
+
+[workspace.package]
+version = "0.1.6"
+edition = "2021"
+
+[workspace.dependencies]
+hyperon = { path = "./lib", version = "0.1.6" }
+regex = "1.5.4"
+log = "0.4.0"
+env_logger = "0.8.4"

--- a/README.md
+++ b/README.md
@@ -70,12 +70,10 @@ python3 -m pip install pip==23.1.2
 
 # Build and run
 
-## Hyperon library
+## Rust library and REPL
 
-Build and test the library:
+Build and test the Rust binaries:
 ```
-cd ./lib
-cargo build
 cargo test
 ```
 
@@ -90,6 +88,12 @@ Run examples:
 cargo run --example sorted_list
 ```
 
+Run REPL:
+```
+cargo run --bin metta
+```
+You can also find executable at `./target/debug/metta`.
+
 To enable logging during running tests or examples export `RUST_LOG`
 environment variable:
 ```
@@ -103,10 +107,9 @@ cargo +nightly bench
 
 Generate docs:
 ```
-cd ./lib
 cargo doc --no-deps
 ```
-Docs can be found at `./lib/target/doc/hyperon/index.html`.
+Docs can be found at `./target/doc/hyperon/index.html`.
 
 ## C and Python API
 

--- a/c/Cargo.toml
+++ b/c/Cargo.toml
@@ -1,14 +1,13 @@
 [package]
 name = "hyperonc"
-version = "0.1.6"
-authors = ["Vitaly Bogdanov <vsbogd@gmail.com>"]
-edition = "2018"
+version.workspace = true
+edition.workspace = true
 
 [dependencies]
-hyperon = { path = "../lib/" }
-regex = "1.5.4"
-log = "0.4.0"
-env_logger = "0.8.4"
+hyperon = { workspace = true }
+regex = { workspace = true }
+log = { workspace = true }
+env_logger = { workspace = true }
 
 [lib]
 name = "hyperonc"

--- a/c/src/metta.rs
+++ b/c/src/metta.rs
@@ -126,6 +126,7 @@ pub extern "C" fn tokenizer_register_token(tokenizer: *mut tokenizer_t,
     let regex = Regex::new(cstr_as_str(regex)).unwrap();
     let c_token = CToken{ context, api };
     tokenizer.register_token(regex, move |token| {
+        let c_token = &c_token; //Be explicit we're capturing c_token, and not the pointers it contains
         let constr = unsafe{ (&*c_token.api).construct_atom };
         let atom = constr(str_as_cstr(token).as_ptr(), c_token.context);
         atom.into_inner()

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,14 +1,13 @@
 [package]
 name = "hyperon"
-version = "0.1.6"
-authors = ["Vitaly Bogdanov <vsbogd@gmail.com>"]
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [dependencies]
 mopa = "0.2.2"
-regex = "1.5.4"
-log = "0.4.0"
-env_logger = "0.8.4"
+regex = { workspace = true }
+log = { workspace = true }
+env_logger = { workspace = true }
 directories = "5.0.1" # For Environment to find platform-specific config location
 smallvec = "1.10.0"
 im = "15.1.0"

--- a/repl/Cargo.toml
+++ b/repl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "metta-repl"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 description = "A shell to execute MeTTa"
 
 [dependencies]
@@ -11,7 +11,7 @@ clap = { version = "4.4.0", features = ["derive"] }
 signal-hook = "0.3.17"
 pyo3 = { version = "0.19.2", features = ["auto-initialize"], optional = true }
 pep440_rs = { version = "0.3.11", optional = true }
-hyperon = { path = "../lib/", optional = true } #TODO: We can only link Hyperon directly or through Python, but not both at the same time.  The right fix is to allow HyperonPy to be built within Hyperon, See https://github.com/trueagi-io/hyperon-experimental/issues/283
+hyperon = { workspace = true, optional = true } #TODO: We can only link Hyperon directly or through Python, but not both at the same time.  The right fix is to allow HyperonPy to be built within Hyperon, See https://github.com/trueagi-io/hyperon-experimental/issues/283
 
 [[bin]]
 name = "metta"


### PR DESCRIPTION
Introducing virtual workspace Cargo.toml file allows reusing workspace configuration (version, dependencies) in all Rust subprojects.