### PR TITLE
Set name for the built-in spaces

### DIFF
--- a/lib/src/metta/runner/mod.rs
+++ b/lib/src/metta/runner/mod.rs
@@ -93,7 +93,7 @@ impl Metta {
     {
         let space = match space {
             Some(space) => space,
-            None => DynSpace::new(GroundingSpace::new())
+            None => DynSpace::new(GroundingSpace::builder().set_name("runner".into()).build())
         };
 
         //Create the raw MeTTa runner
@@ -149,7 +149,7 @@ impl Metta {
 
     /// Returns a new MeTTa interpreter intended for use loading MeTTa modules during import
     fn new_loading_runner(metta: &Metta, path: &Path) -> Self {
-        let space = DynSpace::new(GroundingSpace::new());
+        let space = DynSpace::new(GroundingSpace::builder().set_name(format!("{path:?}")).build());
         let tokenizer = metta.tokenizer().clone_inner();
         let environment = metta.0.environment.clone();
         let settings = metta.0.settings.clone();

--- a/lib/src/space/grounding.rs
+++ b/lib/src/space/grounding.rs
@@ -75,6 +75,31 @@ fn atom_to_trie_key(atom: &Atom) -> TrieKey<SymbolAtom> {
     TrieKey::from(tokens)
 }
 
+/// Builder of the [GroundingSpace] instance.
+#[derive(Default)]
+pub struct Builder {
+    name: Option<String>,
+}
+
+impl Builder {
+    /// Sets the name property for the `GroundingSpace` which can be useful for debugging
+    pub fn set_name(mut self, name: String) -> Builder {
+        self.name = Some(name);
+        self
+    }
+
+    /// Return new GroundingSpace initialized
+    pub fn build(self) -> GroundingSpace {
+        GroundingSpace {
+            index: MultiTrie::new(),
+            content: Vec::new(),
+            free: BTreeSet::new(),
+            common: SpaceCommon::default(),
+            name: self.name,
+        }
+    }
+}
+
 /// In-memory space which can contain grounded atoms.
 // TODO: Clone is required by C API
 #[derive(Clone)]
@@ -90,13 +115,12 @@ impl GroundingSpace {
 
     /// Constructs new empty space.
     pub fn new() -> Self {
-        Self {
-            index: MultiTrie::new(),
-            content: Vec::new(),
-            free: BTreeSet::new(),
-            common: SpaceCommon::default(),
-            name: None,
-        }
+        Self::builder().build()
+    }
+
+    /// Returns builder of the space initialized with default values
+    pub fn builder() -> Builder {
+        Builder::default()
     }
 
     /// Constructs space from vector of atoms.
@@ -290,11 +314,6 @@ impl GroundingSpace {
     /// Returns the iterator over content of the space.
     pub fn iter(&self) -> SpaceIter {
         SpaceIter::new(GroundingSpaceIter::new(self))
-    }
-
-    /// Sets the name property for the `GroundingSpace` which can be useful for debugging
-    pub fn set_name(&mut self, name: String) {
-        self.name = Some(name);
     }
 
     /// Returns the name property for the `GroundingSpace`, if one has been set


### PR DESCRIPTION
Add GroundingSpace Builder to be able setting name in one line. It can be extended to add atoms as well.

@luketpeterson , this is a PR to discuss briefly if we need builder here. I added it because I wanted be able to construct `GroundingSpace` in one line instead of calling new. But if you don't like the style or have other objections please feel free to reject :-)