### PR TITLE
Import hotfix

### DIFF
--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -306,7 +306,9 @@ impl Grounded for GetAtomsOp {
         let arg_error = || ExecError::from("get-atoms expects one argument: space");
         let space = args.get(0).ok_or_else(arg_error)?;
         let space = Atom::as_gnd::<DynSpace>(space).ok_or("get-atoms expects a space as its argument")?;
-        space.borrow().as_space().atom_iter().map(|iter| iter.cloned().collect()).ok_or(ExecError::Runtime("Unsupported Operation. Can't traverse atoms in this space".to_string()))
+        space.borrow().as_space().atom_iter()
+            .map(|iter| iter.cloned().map(|a| make_variables_unique(a)).collect())
+            .ok_or(ExecError::Runtime("Unsupported Operation. Can't traverse atoms in this space".to_string()))
     }
 
     fn match_(&self, other: &Atom) -> MatchResultIter {

--- a/lib/src/metta/runner/stdlib2.rs
+++ b/lib/src/metta/runner/stdlib2.rs
@@ -405,6 +405,8 @@ pub fn register_runner_tokens(metta: &Metta) {
     tref.register_token(regex(r"bind!"), move |_| { bind_op.clone() });
     let trace_op = Atom::gnd(stdlib::TraceOp{});
     tref.register_token(regex(r"trace!"), move |_| { trace_op.clone() });
+    let println_op = Atom::gnd(stdlib::PrintlnOp{});
+    tref.register_token(regex(r"println!"), move |_| { println_op.clone() });
     // &self should be updated
     // TODO: adding &self might be done not by stdlib, but by MeTTa itself.
     // TODO: adding &self introduces self referencing and thus prevents space

--- a/python/tests/scripts/f1_imports.metta
+++ b/python/tests/scripts/f1_imports.metta
@@ -37,7 +37,7 @@
 
 ; It's first atom is a space
 !(assertEqual
-  (let $xx (collapse (get-atoms &m)) (contains $xx is-space))
+  (let $x (collapse (get-atoms &m)) (contains $x is-space))
   True)
 
 ; FIXME? Now, it is moduleC space.
@@ -82,7 +82,7 @@
 ; because we load modules only once, and we collect atoms-spaces to
 ; prevent duplication
 !(assertEqual
-  (let $xx (collapse (get-atoms &m)) (contains $xx is-space))
+  (let $x (collapse (get-atoms &m)) (contains $x is-space))
   False)
 
 ; Let's check that `if` from stdlib is not duplicated and gives only one result

--- a/python/tests/scripts/f1_imports.metta
+++ b/python/tests/scripts/f1_imports.metta
@@ -22,12 +22,23 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 !(import! &m f1_moduleA.metta)
 
+; Check whether passed expression contains atom for which condition is True
+(: contains (-> Expression (-> Atom Bool) Bool))
+(= (contains $list $condition)
+  (if (== $list ()) False
+    (let $head (car-atom $list)
+      (if ($condition $head) True
+        (let $tail (cdr-atom $list) (contains $tail $condition)) ))))
+
+; Check whether atom is space comparing its type with type of the &self atom
+(: is-space (-> Atom Bool))
+(= (is-space $atom)
+   (let* (($type (get-type $atom)) ($space (get-type &self))) (== $type $space)))
+
 ; It's first atom is a space
 !(assertEqual
-  (let* (($x (collapse (get-atoms &m)))
-         ($y (car-atom $x)))
-        (get-type $y))
-  (get-type &self))
+  (let $xx (collapse (get-atoms &m)) (contains $xx is-space))
+  True)
 
 ; FIXME? Now, it is moduleC space.
 ;        Should it be `stdlib` atom for a separately imported space
@@ -55,25 +66,24 @@
 !(assertEqual (g 2) 102)
 !(assertEqual (f 2) 103)
 
+; Check whether atom is &m
+(: is-m (-> Atom Bool))
+(= (is-m $atom) (== $atom &m))
+
 ; `&self` contains 3 atoms-spaces now:
 ; - stdlib
 ; - moduleC imported by moduleA and removed from A after its import to &self
 ; - moduleA itself, which is the same as &m
-!(assertEqual &m
-  (let* (($a (collapse (get-atoms &self)))
-          ($x (cdr-atom $a))
-          ($y (cdr-atom $x)))
-         (car-atom $y)))
+!(assertEqual
+  (let $a (collapse (get-atoms &self)) (contains $a is-m))
+  True)
 
 ; NOTE: now the first atom, which was a space, is removed from `&m`,
 ; because we load modules only once, and we collect atoms-spaces to
 ; prevent duplication
 !(assertEqual
-  (== (let* (($x (collapse (get-atoms &m)))
-             ($y (car-atom $x)))
-            (get-type $y))
-        (get-type &self))
-   False)
+  (let $xx (collapse (get-atoms &m)) (contains $xx is-space))
+  False)
 
 ; Let's check that `if` from stdlib is not duplicated and gives only one result
 !(assertEqual


### PR DESCRIPTION
Hotfix for the #572 which can be used before modules system refactoring is merged and unblocks minimal MeTTa.

The idea of the fix is to add a temporal instance of atomspace which contains stdlib into an imported space and remove it after running imported code. Also needed to fix a test to not rely on an order of atoms returned. Last thing I have found that `get-atoms` returns non-unique instances of the variables and thus unification of `$x` and `(get-atoms $m)` is not possible when `&m` contains instances of `$x`.