### PR TITLE
Fixing build warning, on account of Rust 1.76 being more strict about pointer comparisons

### DIFF
--- a/lib/src/space/mod.rs
+++ b/lib/src/space/mod.rs
@@ -351,7 +351,7 @@ impl Space for DynSpace {
 
 impl PartialEq for DynSpace {
     fn eq(&self, other: &Self) -> bool {
-        RefCell::as_ptr(&self.0) == RefCell::as_ptr(&other.0)
+        std::ptr::addr_eq(RefCell::as_ptr(&self.0), RefCell::as_ptr(&other.0))
     }
 }
 


### PR DESCRIPTION
Fixing build warning, on account of Rust 1.76 being more strict about pointer comparisons