### PR TITLE
Tweaking test in stdlib2, so it passes with new module import behavior

### DIFF
--- a/lib/src/metta/runner/stdlib2.rs
+++ b/lib/src/metta/runner/stdlib2.rs
@@ -843,11 +843,11 @@ mod tests {
     }
 
     #[test]
-    fn test_variable_defined_via_variabe() {
+    fn test_variable_defined_via_variable() {
         let program = "
             (= (myif T $y) $y)
-            (= (not F) T)
-            (= (a $z) (not (b $z)))
+            (= (mynot F) T)
+            (= (a $z) (mynot (b $z)))
             (= (b d) F)
 
             !(eval (interpret (myif (a $x) $x) %Undefined% &self))


### PR DESCRIPTION
The test `stdlib2::test_variable_defined_via_variabe` contains this code:
```
            (= (myif T $y) $y)
            (= (not F) T)
            (= (a $z) (not (b $z)))
            (= (b d) F)

            !(eval (interpret (myif (a $x) $x) %Undefined% &self))
```
The problem is that the `not` operation is imported from stdlib/corelib in the modules branch.  So we get this error: `(Error (not F) not expects one boolean arguments)`

 Would you be ok to change the test to be:
```
            (= (myif T $y) $y)
            (= (mynot F) T)
            (= (a $z) (mynot (b $z)))
            (= (b d) F)

            !(eval (interpret (myif (a $x) $x) %Undefined% &self))
```
Or do you think the `not` operation shouldn't be imported?

Feel free to reject this PR if I've misunderstood the purpose of the test.

