### PR TITLE
Handle Python 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN sh /tmp/rustup.sh -y && rm /tmp/rustup.sh
 ENV PATH="${PATH}:/home/user/.cargo/bin"
 RUN cargo install cbindgen
 
-RUN python3 -m pip install conan==1.60.2 pip==23.1.2
+RUN python3 -m pip install conan==1.62 pip==23.1.2
 ENV PATH="${PATH}:/home/user/.local/bin"
 RUN conan profile new --detect default
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ cargo install --force cbindgen
 
 * Install Conan and make default Conan profile:
 ```
-python3 -m pip install conan==1.60.2
+python3 -m pip install conan==1.62
 conan profile new --detect default
 ```
 

--- a/python/install-hyperonc.sh
+++ b/python/install-hyperonc.sh
@@ -30,7 +30,7 @@ sh /tmp/rustup.sh -y && rm /tmp/rustup.sh
 export PATH="${PATH}:${HOME}/.cargo/bin"
 cargo install cbindgen
 
-python3 -m pip install conan==1.60.2 pip==23.1.2
+python3 -m pip install conan==1.62 pip==23.1.2
 PATH="${PATH}:${HOME}/.local/bin"
 conan profile new --detect default
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "hyperon"
 description = "Hyperon API in Python"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.7,<3.12"
 keywords = ["metta", "hyperon", "opencog"]
 license = {text = "MIT License"}
 classifiers = [

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools==65.6.3", "conan==1.60.2", "cmake==3.26.4", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools==65.6.3", "conan==1.62", "cmake==3.26.4", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
Conan version is upgraded to 1.62, Python 3.12 is excluded from supported versions because `subunit 1.4.0` dependency of `hyperonc` is incompatible with Python 3.12. This is hotfix to unblock Python packages release.