### PR TITLE
Manually install compatible Python version

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -39,7 +39,6 @@ jobs:
         env:
           CIBW_BEFORE_ALL: sh -c "./python/install-hyperonc.sh -u https://github.com/${{github.repository}}.git -r ${{env.COMMIT_HEAD}}"
           CIBW_SKIP: "*musllinux*"
-          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.7,<3.12"
         with:
           package-dir: ./python
 

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -27,6 +27,11 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v3
 
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.8"
+
       - run: |
           echo "REF_NAME=${{github.ref_name}}" | tee -a $GITHUB_ENV
           echo "EVENT_NAME=${{github.event_name}}" | tee -a $GITHUB_ENV


### PR DESCRIPTION
Manually install compatible version of Python into macosx-11 image to build dependencies using Conan (see https://github.com/trueagi-io/hyperon-experimental/issues/584).