### PR TITLE
Make type of the EqualOp compatible with one from Python stdlib

### DIFF
--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -1123,7 +1123,7 @@ impl Display for EqualOp {
 
 impl Grounded for EqualOp {
     fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_ATOM, ATOM_TYPE_ATOM, ATOM_TYPE_BOOL])
+        Atom::expr([ARROW_SYMBOL, expr!(t), expr!(t), ATOM_TYPE_BOOL])
     }
 
     fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {


### PR DESCRIPTION
In Python stdlib `==` has type `(-> $t $t Bool)` which makes interpreter to evaluate each argument before passing them to `==`. In Rust stdlib it was `(-> Atom Atom Bool)` which causes different behaviour.

This PR is to discuss and unify the behaviour.