### PR TITLE
Replace match implemented via unify by the grounded version

### DIFF
--- a/lib/src/metta/runner/stdlib.metta
+++ b/lib/src/metta/runner/stdlib.metta
@@ -258,10 +258,6 @@
 (= (not True) False)
 (= (not False) True)
 
-(: match (-> Atom Atom Atom %Undefined%))
-(= (match $space $pattern $template)
-  (unify $pattern $space $template Empty))
-
 (: let (-> Atom %Undefined% Atom Atom))
 (= (let $pattern $atom $template)
   (unify $atom $pattern $template Empty))

--- a/lib/src/metta/runner/stdlib2.rs
+++ b/lib/src/metta/runner/stdlib2.rs
@@ -379,6 +379,8 @@ pub fn register_common_tokens(tref: &mut Tokenizer, _tokenizer: Shared<Tokenizer
     tref.register_token(regex(r"get-state"), move |_| { get_state_op.clone() });
     let nop_op = Atom::gnd(stdlib::NopOp{});
     tref.register_token(regex(r"nop"), move |_| { nop_op.clone() });
+    let match_op = Atom::gnd(stdlib::MatchOp{});
+    tref.register_token(regex(r"match"), move |_| { match_op.clone() });
 }
 
 //TODO: The additional arguments are a temporary hack on account of the way the operation atoms store references
@@ -531,7 +533,7 @@ mod tests {
         assert_eq!(result, Ok(vec![vec![expr!("ok")]]));
         let result = run_program("!(case (unify (B C) (C B) ok nok) ( (ok ok) (nok nok) ))");
         assert_eq!(result, Ok(vec![vec![expr!("nok")]]));
-        let result = run_program("!(case (match (B C) (C B) ok) ( (ok ok) (%void% nok) ))");
+        let result = run_program("!(case (unify (B C) (C B) ok Empty) ( (ok ok) (%void% nok) ))");
         assert_eq!(result, Ok(vec![vec![expr!("nok")]]));
     }
 


### PR DESCRIPTION
`unify` doesn't behave as `match` in a case when space is matched with variable. `match` returns atoms from the space. `unify` assigns the space as a value for the variable.