### PR TITLE
Squishing warnings that popped up with Rust 1.76.0

### DIFF
--- a/c/src/atom.rs
+++ b/c/src/atom.rs
@@ -8,9 +8,7 @@ use crate::space::*;
 
 use std::os::raw::*;
 use std::fmt::Display;
-use std::convert::TryInto;
 use std::collections::HashSet;
-use std::iter::FromIterator;
 use std::sync::atomic::{AtomicPtr, Ordering};
 
 use hyperon::matcher::{Bindings, BindingsSet};

--- a/c/src/metta.rs
+++ b/c/src/metta.rs
@@ -8,7 +8,6 @@ use hyperon::metta::interpreter::InterpreterState;
 use hyperon::metta::runner::{Metta, RunContext, ModId, RunnerState, Environment, EnvBuilder};
 use hyperon::metta::runner::modules::ModuleLoader;
 use hyperon::metta::runner::modules::catalog::{FsModuleFormat, ModuleDescriptor};
-use hyperon::rust_type_atom;
 use hyperon::atom::*;
 use hyperon::metta::runner::arithmetics::*;
 
@@ -1203,10 +1202,10 @@ impl From<&mut RunContext<'_, '_, '_>> for run_context_t {
 
 impl run_context_t {
     fn borrow(&self) -> &RunContext<'static, 'static, 'static> {
-        unsafe{ &*self.context.cast::<RunContext<'static, 'static, 'static>>() }
+        &unsafe{ &*self.context.cast::<RustRunContext>() }.0
     }
     fn borrow_mut(&mut self) -> &mut RunContext<'static, 'static, 'static> {
-        unsafe{ &mut *self.context.cast::<RunContext<'static, 'static, 'static>>() }
+        &mut unsafe{ &mut *self.context.cast::<RustRunContext>() }.0
     }
 }
 
@@ -1662,6 +1661,7 @@ pub struct module_descriptor_t {
 }
 
 #[derive(Clone)]
+#[allow(dead_code)] //LP-TODO-NEXT.  Currently we don't do much with module_descriptor_t, but that will change when I make C bindings for the catalog API
 enum RustModuleDescriptor {
     Descriptor(ModuleDescriptor),
     Err(String)

--- a/lib/src/atom/matcher.rs
+++ b/lib/src/atom/matcher.rs
@@ -63,7 +63,6 @@ macro_rules! bind_set {
 }
 
 use std::collections::{HashMap, HashSet};
-use core::iter::FromIterator;
 
 use super::*;
 use crate::common::reformove::RefOrMove;

--- a/lib/src/metta/runner/arithmetics.rs
+++ b/lib/src/metta/runner/arithmetics.rs
@@ -196,7 +196,6 @@ def_binary_bool_op!(OrOp, or, ||);
 // NOTE: xor and flip are absent in Python intentionally for conversion testing
 def_binary_bool_op!(XorOp, xor, ^);
 
-use rand;
 #[derive(Clone, PartialEq, Debug)]
 pub struct FlipOp{}
 

--- a/lib/src/metta/runner/modules/mod.rs
+++ b/lib/src/metta/runner/modules/mod.rs
@@ -1,19 +1,12 @@
 
 use std::path::{Path, PathBuf};
 use std::collections::HashMap;
-use std::sync::Mutex;
 
-use crate::space::{Space, DynSpace};
 use crate::metta::*;
 use crate::metta::runner::*;
-use crate::metta::types::validate_atom;
-use crate::metta::text::{SExprParser, Tokenizer};
-use crate::common::shared::Shared;
 
 use regex::Regex;
 
-#[cfg(not(feature = "minimal"))]
-use super::interpreter::interpret;
 #[cfg(not(feature = "minimal"))]
 use super::stdlib::*;
 

--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -8,7 +8,6 @@ use crate::metta::runner::{Metta, RunContext, ModuleLoader};
 use crate::metta::types::{get_atom_types, get_meta_type};
 use crate::common::shared::Shared;
 
-use std::convert::TryFrom;
 use std::rc::Rc;
 use std::cell::RefCell;
 use std::fmt::Display;
@@ -687,7 +686,6 @@ mod non_minimal_only_stdlib {
     use crate::metta::interpreter::interpret;
     use crate::common::assert::vec_eq_no_order;
     use crate::common::ReplacingMapper;
-    use std::iter::FromIterator;
 
     // TODO: move it into hyperon::atom module?
     pub(crate) fn atom_as_expr(atom: &Atom) -> Option<&ExpressionAtom> {
@@ -1341,11 +1339,11 @@ use crate::metta::runner::METTA_CODE;
 /// NOTE: the corelib will be loaded automatically if the runner is initialized with one of the high-level
 /// init functions such as [Metta::new] and [Metta::new_with_stdlib_loader]
 #[derive(Debug)]
-pub(crate) struct CoreLibLoader(String);
+pub(crate) struct CoreLibLoader;
 
 impl Default for CoreLibLoader {
     fn default() -> Self {
-        CoreLibLoader("corelib".to_string())
+        CoreLibLoader
     }
 }
 
@@ -1368,7 +1366,7 @@ mod tests {
     use super::*;
     use crate::atom::matcher::atoms_are_equivalent;
     use crate::metta::text::*;
-    use crate::metta::runner::{Metta, EnvBuilder};
+    use crate::metta::runner::EnvBuilder;
     use crate::metta::types::validate_atom;
     use crate::common::test_utils::*;
 

--- a/lib/src/metta/types.rs
+++ b/lib/src/metta/types.rs
@@ -18,8 +18,6 @@
 //! When atom has no type assigned by user it has type `%Undefined%`. The value
 //! of `%Undefined%` type can be matched with any type required.
 
-use std::convert::TryInto;
-
 use super::*;
 use crate::atom::matcher::{Bindings, BindingsSet, apply_bindings_to_atom};
 use crate::space::Space;

--- a/lib/src/space/grounding.rs
+++ b/lib/src/space/grounding.rs
@@ -4,11 +4,11 @@
 use crate::*;
 use super::*;
 use crate::atom::*;
-use crate::atom::matcher::{BindingsSet, MatchResultIter, match_atoms};
+use crate::atom::matcher::{MatchResultIter, match_atoms};
 use crate::atom::subexpr::split_expr;
 use crate::common::multitrie::{MultiTrie, TrieKey, TrieToken};
 
-use std::fmt::{Display, Debug};
+use std::fmt::Debug;
 use std::collections::BTreeSet;
 use std::collections::HashSet;
 


### PR DESCRIPTION
Squishing warnings that popped up with Rust 1.76.0

Mostly redundant imports on account of the language prelude including more traits