### PR TITLE
Adding `mod-space!` Op Atom, to access the space of a module, loading it if necessary

### DIFF
--- a/lib/src/metta/runner/stdlib2.rs
+++ b/lib/src/metta/runner/stdlib2.rs
@@ -383,6 +383,8 @@ pub fn register_common_tokens(tref: &mut Tokenizer, _tokenizer: Shared<Tokenizer
     tref.register_token(regex(r"match"), move |_| { match_op.clone() });
     let register_module_op = Atom::gnd(stdlib::RegisterModuleOp::new(metta.clone()));
     tref.register_token(regex(r"register-module!"), move |_| { register_module_op.clone() });
+    let mod_space_op = Atom::gnd(stdlib::ModSpaceOp::new(metta.clone()));
+    tref.register_token(regex(r"mod-space!"), move |_| { mod_space_op.clone() });
     let print_mods_op = Atom::gnd(stdlib::PrintModsOp::new(metta.clone()));
     tref.register_token(regex(r"print-mods!"), move |_| { print_mods_op.clone() });
 }


### PR DESCRIPTION
Adding `mod-space!` Op Atom, to access the space of a module, loading it if necessary
See https://github.com/trueagi-io/hyperon-experimental/issues/592

It's now possible to do this: `!(add-atom &new_space (mod-space! mod_name))`

Therefore, `!(add-atom &self (mod-space! stdlib))` adds the same atom(s) as `!(import! &self stdlib)`, but does not add any tokens.

For me the remaining question is whether we want to enshrine the "nested-sub-space" behavior into MeTTa semantics?  We could add a `merge-atoms` or similar operation, to make it clear we're bringing in all atoms from the source space, but the implementation in the present code would be identical to `add-atom`