### PR TITLE
Fixing erroneous error in Python module format loader, when explicit path is specified

### DIFF
--- a/python/hyperon/runner.py
+++ b/python/hyperon/runner.py
@@ -257,6 +257,7 @@ class _PyFileMeTTaModFmt:
         """Load the file as a Python module if it exists"""
 
         #See if we have a ".py" file first, and if not, check for a directory-based python mod
+        path = path if path.endswith(".py") else os.path.splitext(path)[0] + ".py"
         if not os.path.exists(path):
             dir_path = os.path.join(os.path.splitext(path)[0], "__init__.py")
             if os.path.exists(dir_path):


### PR DESCRIPTION
When I designed the FsModuleFormat trait, I imagined it would always generate its own filesystem paths, so I didn't validate them in the `try_path` method.  However I later changed it so the user can supply explicit paths, e.g. through the `register-module!` operation.

So I added the necessary validation code so that the python format loader doesn't try (and fail) to load a non-python module.