### PR TITLE
Adding `add-reduct` operation, to merge atoms from a src space into a dst

### DIFF
--- a/lib/src/metta/runner/stdlib.metta
+++ b/lib/src/metta/runner/stdlib.metta
@@ -268,7 +268,7 @@
     (let $pattern $atom (let* $tail $template))
     $template )))
 
-(: add-reduct (-> Grounded %Undefined% ()))
+(: add-reduct (-> Grounded %Undefined% (->)))
 (= (add-reduct $dst $atom)  (add-atom $dst $atom))
 
 (: car-atom (-> Expression Atom))

--- a/lib/src/metta/runner/stdlib.metta
+++ b/lib/src/metta/runner/stdlib.metta
@@ -268,9 +268,8 @@
     (let $pattern $atom (let* $tail $template))
     $template )))
 
-(: merge-space (-> Atom %Undefined% Atom))
-(= (merge-space $dst $space)
-  (let $x $space (add-atom $dst $x)))
+(: add-reduct (-> Grounded %Undefined% ()))
+(= (add-reduct $dst $atom)  (add-atom $dst $atom))
 
 (: car-atom (-> Expression Atom))
 (= (car-atom $atom)

--- a/lib/src/metta/runner/stdlib.metta
+++ b/lib/src/metta/runner/stdlib.metta
@@ -268,6 +268,10 @@
     (let $pattern $atom (let* $tail $template))
     $template )))
 
+(: merge-space (-> Atom %Undefined% Atom))
+(= (merge-space $dst $space)
+  (let $x $space (add-atom $dst $x)))
+
 (: car-atom (-> Expression Atom))
 (= (car-atom $atom)
   (eval (if-decons-expr $atom $head $_

--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -1466,6 +1466,7 @@ mod non_minimal_only_stdlib {
         (= (if False $then $else) $else)
         (: Error (-> Atom Atom ErrorType))
 
+        (= (merge-space $dst $space)  (let $x $space (add-atom $dst $x)))
 
         ; quote prevents atom from being reduced
         (: quote (-> Atom Atom))

--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -1466,7 +1466,8 @@ mod non_minimal_only_stdlib {
         (= (if False $then $else) $else)
         (: Error (-> Atom Atom ErrorType))
 
-        (= (merge-space $dst $space)  (add-atom $dst $space))
+        (: add-reduct (-> Grounded %Undefined% ()))
+        (= (add-reduct $dst $atom)  (add-atom $dst $atom))
 
         ; quote prevents atom from being reduced
         (: quote (-> Atom Atom))

--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -1466,7 +1466,7 @@ mod non_minimal_only_stdlib {
         (= (if False $then $else) $else)
         (: Error (-> Atom Atom ErrorType))
 
-        (: add-reduct (-> Grounded %Undefined% ()))
+        (: add-reduct (-> Grounded %Undefined% (->)))
         (= (add-reduct $dst $atom)  (add-atom $dst $atom))
 
         ; quote prevents atom from being reduced

--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -1466,7 +1466,7 @@ mod non_minimal_only_stdlib {
         (= (if False $then $else) $else)
         (: Error (-> Atom Atom ErrorType))
 
-        (= (merge-space $dst $space)  (let $x $space (add-atom $dst $x)))
+        (= (merge-space $dst $space)  (add-atom $dst $space))
 
         ; quote prevents atom from being reduced
         (: quote (-> Atom Atom))


### PR DESCRIPTION
This provides a friendlier way to accomplish the requirements of https://github.com/trueagi-io/hyperon-experimental/issues/592, getting the space access op for the src space to reduce before adding it to the dst space