### PR TITLE
fix stringToChars

### DIFF
--- a/python/hyperon/stdlib.py
+++ b/python/hyperon/stdlib.py
@@ -110,7 +110,7 @@ def text_ops():
                              ['Atom', 'String'], unwrap=False)
     parseAtom = OperationAtom('parse', lambda s: [ValueAtom(SExprParser(str(s)[1:-1]).parse(Tokenizer()))],
                               ['String', 'Atom'], unwrap=False)
-    stringToCharsAtom = OperationAtom('stringToChars', lambda s: [ValueAtom(E(*[ValueAtom(Char(c)) for c in str(s)[1:-1]]))],
+    stringToCharsAtom = OperationAtom('stringToChars', lambda s: [E(*[ValueAtom(Char(c)) for c in str(s)[1:-1]])],
                                       ['String', 'Atom'], unwrap=False)
     charsToStringAtom = OperationAtom('charsToString', lambda a: [ValueAtom("".join([str(c)[1:-1] for c in a.get_children()]))],
                                       ['Atom', 'String'], unwrap=False)

--- a/python/tests/test_stdlib.py
+++ b/python/tests/test_stdlib.py
@@ -17,7 +17,7 @@ class StdlibTest(HyperonTestCase):
 
         # Check that (stringToChars "ABC") == ('A' 'B' 'C')
         self.assertEqualMettaRunnerResults(metta.run("!(stringToChars \"ABC\")"),
-                                           [[ValueAtom(E(ValueAtom(Char("A")), ValueAtom(Char("B")), ValueAtom(Char("C"))))]])
+                                           [[E(ValueAtom(Char("A")), ValueAtom(Char("B")), ValueAtom(Char("C")))]])
 
         # Check that (charsToString ('A' 'B' 'C')) == "ABC"
         self.assertEqualMettaRunnerResults(metta.run("!(charsToString ('A' 'B' 'C'))"),


### PR DESCRIPTION
As per #621 , `stringToChars` is expected to produce `Expression`, but it result was wrapped into `ValueAtom` even in the unit test. While this could be done for some reason, it is most likely a bug, and `stringToChars` should really return `Expression`