### PR TITLE
Add pragma to turn off library interpreter written in minimal MeTTa

### DIFF
--- a/lib/src/metta/runner/stdlib2.rs
+++ b/lib/src/metta/runner/stdlib2.rs
@@ -946,4 +946,22 @@ mod tests {
         assert_eq!(metta.run(SExprParser::new(program2)),
             Ok(vec![vec![expr!("Error" "myAtom" "BadType")]]));
     }
+
+    #[test]
+    fn test_pragma_interpreter_bare_minimal() {
+        let program = "
+            (= (bar) baz)
+            (= (foo) (bar))
+            !(eval (foo))
+            !(pragma! interpreter bare-minimal)
+            !(eval (foo))
+        ";
+
+        assert_eq_metta_results!(run_program(program),
+            Ok(vec![
+                vec![expr!("baz")],
+                vec![UNIT_ATOM()],
+                vec![expr!(("bar"))],
+            ]));
+    }
 }


### PR DESCRIPTION
Executing `!(pragma! interpreter bare-minimal)` turns off interpreter written in minimal MeTTa and only minimal MeTTa interpreter is used.

I used "interpreter" keyword because I would like to try implementing switchable interpreter.