### PR TITLE
Adding support for parsing escape sequences in s-expression parser

### DIFF
--- a/lib/src/metta/text.rs
+++ b/lib/src/metta/text.rs
@@ -458,16 +458,6 @@ impl<'a> SExprParser<'a> {
                                                     }
                                                 }
                                             }
-                                            //QUESTION: the below code works fine and uncommenting it will re-enable single-digit codes.
-                                            // However, I realize why some languages disable single-digit codes because of the ambiguity it creates.
-                                            // For example, is "\xFF" an illegal code (codes are limited to 0x7F so we can't create invalid utf-8)
-                                            // of does it mean "\xf", followed by the ordinary 'f'?
-                                            //
-                                            // // Otherwise treat it as a single-digit code
-                                            // if code.is_none() {
-                                            //     let digits_buf = &[digit1_byte];
-                                            //     code = Some(u8::from_str_radix(core::str::from_utf8(digits_buf).unwrap(), 16).unwrap());
-                                            // }
                                         }
                                     }
                                 }

--- a/lib/src/metta/text.rs
+++ b/lib/src/metta/text.rs
@@ -433,6 +433,8 @@ impl<'a> SExprParser<'a> {
                 return string_node;
             }
             if c == '\\' {
+                let escape_err = |cur_idx| { SyntaxNode::incomplete_with_message(SyntaxNodeType::StringToken, char_idx..cur_idx, vec![], "Invalid escape sequence".to_string()) };
+
                 match self.it.next() {
                     Some((_idx, c)) => {
                         let val = match c {
@@ -463,11 +465,11 @@ impl<'a> SExprParser<'a> {
                                 }
                                 match code {
                                     Some(code) => code.into(),
-                                    None => { return SyntaxNode::incomplete_with_message(SyntaxNodeType::StringToken, char_idx..self.cur_idx(), vec![], "Invalid escape sequence".to_string()); }
+                                    None => { return escape_err(self.cur_idx()); }
                                 }
                             },
                             _ => {
-                                return SyntaxNode::incomplete_with_message(SyntaxNodeType::StringToken, char_idx..self.cur_idx(), vec![], "Invalid escape sequence".to_string());
+                                return escape_err(self.cur_idx());
                             }
                         };
                         token.push(val);

--- a/lib/src/metta/text.rs
+++ b/lib/src/metta/text.rs
@@ -593,9 +593,6 @@ mod tests {
         assert_eq!(vec![expr!("\"test\"quote\"")], parse_atoms(r#""test\"quote""#));
         // Two-digit hex code
         assert_eq!(vec![expr!("\"test\x7Fmax\"")], parse_atoms(r#""test\x7fmax""#));
-        // // Single-digit hex code (Disabled because usage is ambiguous)
-        //TODO: Delete this sub-test if we decide we don't want single-digit hex codes
-        // assert_eq!(vec![expr!("\"test\x0f fifteen\"")], parse_atoms(r#""test\xF fifteen""#));
         // Parse failure, code out of range
         assert!(parse_atoms(r#""test\xFF""#).len() == 0);
     }

--- a/repl/src/config_params.rs
+++ b/repl/src/config_params.rs
@@ -63,7 +63,8 @@ pub fn builtin_init_metta_code() -> String {
     format!(r#"
         ; !(bind! {CFG_HISTORY_MAX_LEN} (new-state 500)) ; TODO, enable this when value-bridging is implemented
         !(bind! {CFG_PROMPT} (new-state "> "))
-        ; !(bind! {CFG_STYLED_PROMPT} (new-state (concat "\x1b[1;32m" (get-state {CFG_PROMPT}) "\x1b[0m"))) ;TODO, two things before this works.  Escape parsing in string literals, and string stdlib type with concat operation
+        ; !(bind! {CFG_STYLED_PROMPT} (new-state (concat "\x1b[1;32m" (get-state {CFG_PROMPT}) "\x1b[0m"))) ;TODO, Need string stdlib type with concat operation
+        !(bind! {CFG_STYLED_PROMPT} (new-state "\x1b[1;32m> \x1b[0m")) 
         !(bind! {CFG_BRACKET_STYLES} (new-state ("94" "93" "95" "96")))
         !(bind! {CFG_COMMENT_STYLE} (new-state "32"))
         !(bind! {CFG_VARIABLE_STYLE} (new-state "33"))

--- a/repl/src/repl.default.metta
+++ b/repl/src/repl.default.metta
@@ -2,7 +2,7 @@
 ; !(change-state! &ReplHistoryMaxLen 500) ; TODO: enable this when I have value bridging implemented.
 
 !(change-state! &ReplPrompt "> ")
-; !(change-state! &ReplStyledPrompt "\x1b[1;32m> \x1b[0m") ; TODO: currently the MeTTa string parser doesn't resolve escape chars, although perhaps it should
+!(change-state! &ReplStyledPrompt "\x1b[1;32m> \x1b[0m") ;
 
 ; TODO: somebody with better design sense should tweak these, and also provide dark-mode setings
 ; ANSI escape codes to configure the syntax highlighter


### PR DESCRIPTION
Intended to address https://github.com/trueagi-io/hyperon-experimental/issues/619