### PR TITLE
Flowing errors in tokenizer atom-constructor functions through to parser

### DIFF
--- a/lib/src/metta/runner/arithmetics.rs
+++ b/lib/src/metta/runner/arithmetics.rs
@@ -56,14 +56,14 @@ impl Into<f64> for Number {
 }
 
 impl Number {
-    pub fn from_int_str(num: &str) -> Self {
-        let n = num.parse::<i64>().expect("Could not parse integer");
-        Self::Integer(n)
+    pub fn from_int_str(num: &str) -> Result<Self, String> {
+        let n = num.parse::<i64>().map_err(|e| format!("Could not parse integer: '{num}', {e}"))?;
+        Ok(Self::Integer(n))
     }
 
-    pub fn from_float_str(num: &str) -> Self {
-        let n = num.parse::<f64>().expect("Could not parse float");
-        Self::Float(n)
+    pub fn from_float_str(num: &str) -> Result<Self, String> {
+        let n = num.parse::<f64>().map_err(|e| format!("Could not parse float: '{num}', {e}"))?;
+        Ok(Self::Float(n))
     }
 
     pub fn promote(a: Number, b: Number) -> (Number, Number) {
@@ -406,10 +406,10 @@ mod tests {
 
     #[test]
     fn number() {
-        assert_eq!(Number::from_int_str("12345"), Number::Integer(12345i64));
-        assert_eq!(Number::from_float_str("123.45"), Number::Float(123.45f64));
-        assert_eq!(Number::from_float_str("12345e-02"), Number::Float(123.45f64));
-        assert_eq!(Number::from_float_str("1.2345e+2"), Number::Float(123.45f64));
+        assert_eq!(Number::from_int_str("12345").unwrap(), Number::Integer(12345i64));
+        assert_eq!(Number::from_float_str("123.45").unwrap(), Number::Float(123.45f64));
+        assert_eq!(Number::from_float_str("12345e-02").unwrap(), Number::Float(123.45f64));
+        assert_eq!(Number::from_float_str("1.2345e+2").unwrap(), Number::Float(123.45f64));
         assert_eq!(format!("{}", Number::Integer(12345i64)), "12345");
         assert_eq!(format!("{}", Number::Float(123.45f64)), "123.45");
     }

--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -1415,12 +1415,12 @@ mod non_minimal_only_stdlib {
         let mut rust_tokens = Tokenizer::new();
         let tref = &mut rust_tokens;
 
-        tref.register_token(regex(r"[\-\+]?\d+"),
-            |token| { Atom::gnd(Number::from_int_str(token)) });
-        tref.register_token(regex(r"[\-\+]?\d+\.\d+"),
-            |token| { Atom::gnd(Number::from_float_str(token)) });
-        tref.register_token(regex(r"[\-\+]?\d+(\.\d+)?[eE][\-\+]?\d+"),
-            |token| { Atom::gnd(Number::from_float_str(token)) });
+        tref.register_fallible_token(regex(r"[\-\+]?\d+"),
+            |token| { Ok(Atom::gnd(Number::from_int_str(token)?)) });
+        tref.register_fallible_token(regex(r"[\-\+]?\d+\.\d+"),
+            |token| { Ok(Atom::gnd(Number::from_float_str(token)?)) });
+        tref.register_fallible_token(regex(r"[\-\+]?\d+(\.\d+)?[eE][\-\+]?\d+"),
+            |token| { Ok(Atom::gnd(Number::from_float_str(token)?)) });
         tref.register_token(regex(r"True|False"),
             |token| { Atom::gnd(Bool::from_str(token)) });
         let sum_op = Atom::gnd(SumOp{});

--- a/lib/src/metta/runner/stdlib_minimal.rs
+++ b/lib/src/metta/runner/stdlib_minimal.rs
@@ -428,12 +428,12 @@ pub fn register_rust_stdlib_tokens(target: &mut Tokenizer) {
     let mut rust_tokens = Tokenizer::new();
     let tref = &mut rust_tokens;
 
-    tref.register_token(regex(r"[\-\+]?\d+"),
-        |token| { Atom::gnd(Number::from_int_str(token)) });
-    tref.register_token(regex(r"[\-\+]?\d+\.\d+"),
-        |token| { Atom::gnd(Number::from_float_str(token)) });
-    tref.register_token(regex(r"[\-\+]?\d+(\.\d+)?[eE][\-\+]?\d+"),
-        |token| { Atom::gnd(Number::from_float_str(token)) });
+    tref.register_fallible_token(regex(r"[\-\+]?\d+"),
+        |token| { Ok(Atom::gnd(Number::from_int_str(token)?)) });
+    tref.register_fallible_token(regex(r"[\-\+]?\d+\.\d+"),
+        |token| { Ok(Atom::gnd(Number::from_float_str(token)?)) });
+    tref.register_fallible_token(regex(r"[\-\+]?\d+(\.\d+)?[eE][\-\+]?\d+"),
+        |token| { Ok(Atom::gnd(Number::from_float_str(token)?)) });
     tref.register_token(regex(r"True|False"),
         |token| { Atom::gnd(Bool::from_str(token)) });
     let sum_op = Atom::gnd(SumOp{});


### PR DESCRIPTION
The rest of the fix for https://github.com/trueagi-io/hyperon-experimental/issues/634