### PR TITLE
Fix for !(mod-space top)

### DIFF
--- a/lib/src/metta/runner/modules/mod.rs
+++ b/lib/src/metta/runner/modules/mod.rs
@@ -374,7 +374,8 @@ impl MettaMod {
 /// ModuleLoader can be used to define a module format or to supply programmatically defined modules
 pub trait ModuleLoader: std::fmt::Debug + Send + Sync {
     /// A function to load the module my making MeTTa API calls.  This function will be called by
-    /// [Metta::get_or_init_module]
+    /// as a downstream consequence of [Metta::load_module_at_path], [Metta::load_module_direct],
+    /// [RunContext::load_module], or any other method that leads to the loading of modules
     fn load(&self, context: &mut RunContext) -> Result<(), String>;
 }
 

--- a/lib/src/metta/runner/modules/mod_names.rs
+++ b/lib/src/metta/runner/modules/mod_names.rs
@@ -233,6 +233,9 @@ impl ModNameNode {
 
     /// Parses a module name path into a canonical representation
     pub fn normalize_name_path(name: &str) -> Result<String, String> {
+        if name == TOP_MOD_NAME {
+            return Ok(TOP_MOD_NAME.to_string());
+        }
         let mut new_name = TOP_MOD_NAME.to_string();
         let (_, _, last) = Self::parse_parent_generic(Self::top(), name, &OverlayMap::none(),
             |node, _| Some(node),


### PR DESCRIPTION
This PR addresses a degenerate case in `mod_name::normalize_name_path` that was preventing `!(mod-space top)` from resolving.

Not directly related, but a possible work-around for https://github.com/trueagi-io/hyperon-experimental/issues/354 for the doc-strings.
