### PR TITLE
Adding module resource API and `include` operation

### DIFF
--- a/c/src/atom.rs
+++ b/c/src/atom.rs
@@ -882,7 +882,7 @@ pub unsafe extern "C" fn atom_vec_from_array(atoms: *mut atom_t, size: usize) ->
         if size == 0 {
             return vec![].into()
         } else {
-            panic!();
+            panic!("Null pointer is passed to the constructor of the vector with non-zero size");
         }
     }
     let c_arr = std::slice::from_raw_parts_mut(atoms, size);

--- a/c/src/atom.rs
+++ b/c/src/atom.rs
@@ -213,7 +213,7 @@ pub unsafe extern "C" fn atom_expr(children: *mut atom_t, size: usize) -> atom_t
         if size == 0 {
             return Atom::expr(vec![]).into()
         } else {
-            panic!();
+            panic!("Null pointer is passed to the constructor of the expression with non-zero size");
         }
     }
     let c_arr = std::slice::from_raw_parts_mut(children, size);

--- a/c/src/atom.rs
+++ b/c/src/atom.rs
@@ -209,6 +209,13 @@ pub unsafe extern "C" fn atom_sym(name: *const c_char) -> atom_t {
 ///
 #[no_mangle]
 pub unsafe extern "C" fn atom_expr(children: *mut atom_t, size: usize) -> atom_t {
+    if children == core::ptr::null_mut() {
+        if size == 0 {
+            return Atom::expr(vec![]).into()
+        } else {
+            panic!();
+        }
+    }
     let c_arr = std::slice::from_raw_parts_mut(children, size);
     let children: Vec<Atom> = c_arr.into_iter().map(|atom| {
         core::mem::replace(atom, atom_t::null()).into_inner()
@@ -871,6 +878,13 @@ pub extern "C" fn atom_vec_clone(vec: *const atom_vec_t) -> atom_vec_t {
 ///
 #[no_mangle]
 pub unsafe extern "C" fn atom_vec_from_array(atoms: *mut atom_t, size: usize) -> atom_vec_t {
+    if atoms == core::ptr::null_mut() {
+        if size == 0 {
+            return vec![].into()
+        } else {
+            panic!();
+        }
+    }
     let c_arr = std::slice::from_raw_parts_mut(atoms, size);
     let atoms: Vec<Atom> = c_arr.into_iter().map(|atom| {
         core::mem::replace(atom, atom_t::null()).into_inner()

--- a/c/src/metta.rs
+++ b/c/src/metta.rs
@@ -1187,21 +1187,21 @@ pub struct run_context_t {
 // layer because it's harder to exercise lifecycle discipline in Python and a bug in Python shouldn't lead
 // to invlid memory access
 
-struct RustRunContext(RunContext<'static, 'static, 'static>);
+struct RustRunContext(RunContext<'static, 'static, 'static, 'static>);
 
-impl From<&mut RunContext<'_, '_, '_>> for run_context_t {
-    fn from(context_ref: &mut RunContext<'_, '_, '_>) -> Self {
+impl From<&mut RunContext<'_, '_, '_, '_>> for run_context_t {
+    fn from(context_ref: &mut RunContext<'_, '_, '_, '_>) -> Self {
         Self {
-            context: (context_ref as *mut RunContext<'_, '_, '_>).cast()
+            context: (context_ref as *mut RunContext<'_, '_, '_, '_>).cast()
         }
     }
 }
 
 impl run_context_t {
-    fn borrow(&self) -> &RunContext<'static, 'static, 'static> {
+    fn borrow(&self) -> &RunContext<'static, 'static, 'static, 'static> {
         &unsafe{ &*self.context.cast::<RustRunContext>() }.0
     }
-    fn borrow_mut(&mut self) -> &mut RunContext<'static, 'static, 'static> {
+    fn borrow_mut(&mut self) -> &mut RunContext<'static, 'static, 'static, 'static> {
         &mut unsafe{ &mut *self.context.cast::<RustRunContext>() }.0
     }
 }

--- a/c/src/metta.rs
+++ b/c/src/metta.rs
@@ -6,7 +6,7 @@ use hyperon::metta::text::*;
 use hyperon::metta::interpreter;
 use hyperon::metta::interpreter::InterpreterState;
 use hyperon::metta::runner::{Metta, RunContext, ModId, RunnerState, Environment, EnvBuilder};
-use hyperon::metta::runner::modules::ModuleLoader;
+use hyperon::metta::runner::modules::{ModuleLoader, ResourceKey};
 use hyperon::metta::runner::modules::catalog::{FsModuleFormat, ModuleDescriptor};
 use hyperon::atom::*;
 
@@ -1926,7 +1926,8 @@ impl ModuleLoader for CFsModFmtLoader {
 
         Ok(())
     }
-    fn get_resource(&self, _res_key: &str) -> Result<Vec<u8>, String> {
+    fn get_resource(&self, _res_key: ResourceKey) -> Result<Vec<u8>, String> {
+        //TODO, add C API for providing resources
         Err("resource not found".to_string())
     }
 }

--- a/lib/src/metta/runner/mod.rs
+++ b/lib/src/metta/runner/mod.rs
@@ -400,7 +400,7 @@ impl Metta {
     /// Returns a buffer containing the specified resource, if it is available from a loaded module
     pub fn get_module_resource(&self, mod_id: ModId, res_key: &str) -> Result<Vec<u8>, String> {
         let modules = self.0.modules.lock().unwrap();
-        modules.get(mod_id.0).unwrap().get_resource(res_key).clone()
+        modules.get(mod_id.0).unwrap().get_resource(res_key)
     }
 
     /// Returns a reference to the Tokenizer associated with the runner's top module

--- a/lib/src/metta/runner/mod.rs
+++ b/lib/src/metta/runner/mod.rs
@@ -65,7 +65,7 @@ use super::text::{Tokenizer, Parser, SExprParser};
 use super::types::validate_atom;
 
 pub mod modules;
-use modules::{MettaMod, ModNameNode, ModuleLoader, TOP_MOD_NAME, ModNameNodeDisplayWrapper};
+use modules::{MettaMod, ModNameNode, ModuleLoader, ResourceKey, TOP_MOD_NAME, ModNameNodeDisplayWrapper};
 #[cfg(feature = "pkg_mgmt")]
 use modules::catalog::{ModuleDescriptor, loader_for_module_at_path};
 
@@ -398,7 +398,7 @@ impl Metta {
     }
 
     /// Returns a buffer containing the specified resource, if it is available from a loaded module
-    pub fn get_module_resource(&self, mod_id: ModId, res_key: &str) -> Result<Vec<u8>, String> {
+    pub fn get_module_resource(&self, mod_id: ModId, res_key: ResourceKey) -> Result<Vec<u8>, String> {
         let modules = self.0.modules.lock().unwrap();
         modules.get(mod_id.0).unwrap().get_resource(res_key)
     }
@@ -923,7 +923,7 @@ impl<'input> RunContext<'_, '_, '_, 'input> {
     /// and loads the specified resource from the module, without loading the module itself
     ///
     /// NOTE: Although this method won't load the module itself, it will load parent modules if necessary
-    pub fn load_resource_from_module(&mut self, mod_name: &str, res_key: &str) -> Result<Vec<u8>, String> {
+    pub fn load_resource_from_module(&mut self, mod_name: &str, res_key: ResourceKey) -> Result<Vec<u8>, String> {
 
         // LP-TODO-NOW!, We should assume mod_name is relative by default, not absolute
 

--- a/lib/src/metta/runner/modules/catalog.rs
+++ b/lib/src/metta/runner/modules/catalog.rs
@@ -267,10 +267,10 @@ impl ModuleLoader for SingleFileModule {
 
         Ok(())
     }
-    fn get_resource(&self, res_key: &str) -> Result<Vec<u8>, String> {
+    fn get_resource(&self, res_key: ResourceKey) -> Result<Vec<u8>, String> {
         match res_key {
-            "module.metta" => self.read_contents(),
-            _ => Err("unrecognized resoruce key".to_string())
+            ResourceKey::MainMettaSrc => self.read_contents(),
+            _ => Err("unsupported resoruce key".to_string())
         }
     }
 }
@@ -314,10 +314,10 @@ impl ModuleLoader for DirModule {
 
         Ok(())
     }
-    fn get_resource(&self, res_key: &str) -> Result<Vec<u8>, String> {
+    fn get_resource(&self, res_key: ResourceKey) -> Result<Vec<u8>, String> {
         match res_key {
-            "module.metta" => self.read_module_metta().ok_or_else(|| format!("no module.metta file found in {} dir module", self.path.display())),
-            _ => Err("unrecognized resoruce key".to_string())
+            ResourceKey::MainMettaSrc => self.read_module_metta().ok_or_else(|| format!("no module.metta file found in {} dir module", self.path.display())),
+            _ => Err("unsupported resoruce key".to_string())
         }
     }
 }

--- a/lib/src/metta/runner/modules/mod.rs
+++ b/lib/src/metta/runner/modules/mod.rs
@@ -365,7 +365,7 @@ impl MettaMod {
         self.resource_dir.as_deref()
     }
 
-    pub fn get_resource(&self, res_key: &str) -> Result<Vec<u8>, String> {
+    pub fn get_resource(&self, res_key: ResourceKey) -> Result<Vec<u8>, String> {
         if let Some(loader) = &self.loader {
             loader.get_resource(res_key)
         } else {
@@ -395,20 +395,27 @@ pub trait ModuleLoader: std::fmt::Debug + Send + Sync {
     fn load(&self, context: &mut RunContext) -> Result<(), String>;
 
     /// Returns a data blob containing a given named resource belonging to a module
-    ///
-    /// The following values for `res_key` are commonly accepted:
-    /// * `module.metta`: The MeTTa code for the module in S-Expression format, if the module is
-    ///    implemented as MeTTa code.  
-    ///    NOTE: there is no guarantee the code in the `module.metta` resource will work outside
-    ///    the module's context.  This use case must be supported by each module individually.
-    /// * `authors`: A list of people or organizations responsible for the module **TODO**
-    /// * `description`: A short description of the module **TODO**
-    /// * TODO: Losts more we'll want to add...
-    ///
-    /// NOTE: Some resources may not be available from some modules or ModuleLoaders
-    fn get_resource(&self, _res_key: &str) -> Result<Vec<u8>, String> {
+    fn get_resource(&self, _res_key: ResourceKey) -> Result<Vec<u8>, String> {
         Err("resource not found".to_string())
     }
+}
+
+/// Identifies a resource to retrieve from a [ModuleLoader]
+///
+/// NOTE: Some resources may not be available from some modules or ModuleLoaders
+pub enum ResourceKey<'a> {
+    /// The MeTTa code for the module in S-Expression format, if the module is
+    /// implemented as MeTTa code.
+    ///
+    /// NOTE: there is no guarantee the code in the `module.metta` resource will work outside
+    /// the module's context.  This use case must be supported by each module individually.
+    MainMettaSrc,
+    /// A list of people or organizations responsible for the module **TODO**
+    Authors,
+    /// A short description of the module **TODO**
+    Description,
+    /// A custom identifier, to be interpreted by the [ModuleLoader] implementation
+    Custom(&'a str)
 }
 
 //-=-+-=-=-+-=-=-+-=-=-+-=-=-+-=-=-+-=-=-+-=-=-+-=-=-+-=-=-+-=-=-+-=-=-+-=-=-+-=-=-+-=-=-+-=-=-+-

--- a/lib/src/metta/runner/modules/mod.rs
+++ b/lib/src/metta/runner/modules/mod.rs
@@ -33,6 +33,7 @@ pub struct MettaMod {
     tokenizer: Shared<Tokenizer>,
     imported_deps: Mutex<HashMap<ModId, DynSpace>>,
     sub_module_names: Option<ModNameNode>,
+    loader: Option<Box<dyn ModuleLoader>>,
     #[cfg(feature = "pkg_mgmt")]
     pkg_info: PkgInfo,
 }
@@ -58,6 +59,7 @@ impl MettaMod {
             imported_deps: Mutex::new(HashMap::new()),
             resource_dir,
             sub_module_names: Some(ModNameNode::new(ModId::INVALID)),
+            loader: None,
             #[cfg(feature = "pkg_mgmt")]
             pkg_info: PkgInfo::default(),
         };
@@ -123,9 +125,15 @@ impl MettaMod {
         }
     }
 
-    // Internal method as part of the loading process, for loading a MettaMod into a runner
+    /// Internal method as part of the loading process, caller takes ownership of sub-module hierarchiy
+    /// to merge it into the runner's name hierarchy as part of loading a MettaMod into a runner
     pub(crate) fn take_sub_module_names(&mut self) -> Option<ModNameNode> {
         core::mem::take(&mut self.sub_module_names)
+    }
+
+    /// Internal method to store the loader with its module, for resource access later on
+    pub(crate) fn set_loader(&mut self, loader: Box<dyn ModuleLoader>) {
+        self.loader = Some(loader);
     }
 
     /// Adds a loaded module as a dependency of the `&self` [MettaMod], and adds a [Tokenizer] entry to access
@@ -330,7 +338,7 @@ impl MettaMod {
         }
     }
 
-    /// Returns the full path of a loaded module.  For example: "top.parent_mod.this_mod"
+    /// Returns the full path of a loaded module.  For example: "top:parent_mod:this_mod"
     pub fn path(&self) -> &str {
         &self.mod_path
     }
@@ -357,6 +365,14 @@ impl MettaMod {
         self.resource_dir.as_deref()
     }
 
+    pub fn get_resource(&self, res_key: &str) -> Result<Vec<u8>, String> {
+        if let Some(loader) = &self.loader {
+            loader.get_resource(res_key)
+        } else {
+            Err(format!("module resource loader not available"))
+        }
+    }
+
     /// A convenience to add an an atom to a module's Space, if it passes type-checking
     pub(crate) fn add_atom(&self, atom: Atom, type_check: bool) -> Result<(), Atom> {
         if type_check && !validate_atom(self.space.borrow().as_space(), &atom) {
@@ -373,10 +389,26 @@ impl MettaMod {
 /// A ModuleLoader is responsible for loading a MeTTa module through the API.  Implementations of
 /// ModuleLoader can be used to define a module format or to supply programmatically defined modules
 pub trait ModuleLoader: std::fmt::Debug + Send + Sync {
-    /// A function to load the module my making MeTTa API calls.  This function will be called by
+    /// A function to load the module my making MeTTa API calls.  This function will be called
     /// as a downstream consequence of [Metta::load_module_at_path], [Metta::load_module_direct],
     /// [RunContext::load_module], or any other method that leads to the loading of modules
     fn load(&self, context: &mut RunContext) -> Result<(), String>;
+
+    /// Returns a data blob containing a given named resource belonging to a module
+    ///
+    /// The following values for `res_key` are commonly accepted:
+    /// * `module.metta`: The MeTTa code for the module in S-Expression format, if the module is
+    ///    implemented as MeTTa code.  
+    ///    NOTE: there is no guarantee the code in the `module.metta` resource will work outside
+    ///    the module's context.  This use case must be supported by each module individually.
+    /// * `authors`: A list of people or organizations responsible for the module **TODO**
+    /// * `description`: A short description of the module **TODO**
+    /// * TODO: Losts more we'll want to add...
+    ///
+    /// NOTE: Some resources may not be available from some modules or ModuleLoaders
+    fn get_resource(&self, _res_key: &str) -> Result<Vec<u8>, String> {
+        Err("resource not found".to_string())
+    }
 }
 
 //-=-+-=-=-+-=-=-+-=-=-+-=-=-+-=-=-+-=-=-+-=-=-+-=-=-+-=-=-+-=-=-+-=-=-+-=-=-+-=-=-+-=-=-+-=-=-+-
@@ -420,12 +452,12 @@ fn hierarchical_module_import_test() {
     let runner = Metta::new(Some(EnvBuilder::test_env()));
 
     //Make sure we get a reasonable error, if we try to load a sub-module to a module that doesn't exist
-    let result = runner.load_module_direct(&InnerLoader, "outer:inner");
+    let result = runner.load_module_direct(Box::new(InnerLoader), "outer:inner");
     assert!(result.is_err());
 
     //Make sure we can load sub-modules sucessfully
-    let _outer_mod_id = runner.load_module_direct(&OuterLoader, "outer").unwrap();
-    let _inner_mod_id = runner.load_module_direct(&InnerLoader, "outer:inner").unwrap();
+    let _outer_mod_id = runner.load_module_direct(Box::new(OuterLoader), "outer").unwrap();
+    let _inner_mod_id = runner.load_module_direct(Box::new(InnerLoader), "outer:inner").unwrap();
 
     //Make sure we load the outer module sucessfully and can match the outer module's atom, but not
     // the inner module's
@@ -452,7 +484,7 @@ impl ModuleLoader for RelativeOuterLoader {
         let space = DynSpace::new(GroundingSpace::new());
         context.init_self_module(space, None);
 
-        let _inner_mod_id = context.load_module_direct(&InnerLoader, "self:inner").unwrap();
+        let _inner_mod_id = context.load_module_direct(Box::new(InnerLoader), "self:inner").unwrap();
 
         let parser = SExprParser::new("outer-module-test-atom");
         context.push_parser(Box::new(parser));

--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -26,7 +26,7 @@ fn unit_result() -> Result<Vec<Atom>, ExecError> {
 #[derive(Clone, Debug)]
 pub struct ImportOp {
     //TODO-HACK: This is a terrible horrible ugly hack that should be fixed ASAP
-    context: std::sync::Arc<std::sync::Mutex<Vec<std::sync::Arc<std::sync::Mutex<&'static mut RunContext<'static, 'static, 'static>>>>>>,
+    context: std::sync::Arc<std::sync::Mutex<Vec<std::sync::Arc<std::sync::Mutex<&'static mut RunContext<'static, 'static, 'static, 'static>>>>>>,
 }
 
 impl PartialEq for ImportOp {
@@ -150,7 +150,7 @@ fn strip_quotes(src: &str) -> &str {
 #[derive(Clone, Debug)]
 pub struct IncludeOp {
     //TODO-HACK: This is a terrible horrible ugly hack that should be fixed ASAP
-    context: std::sync::Arc<std::sync::Mutex<Vec<std::sync::Arc<std::sync::Mutex<&'static mut RunContext<'static, 'static, 'static>>>>>>,
+    context: std::sync::Arc<std::sync::Mutex<Vec<std::sync::Arc<std::sync::Mutex<&'static mut RunContext<'static, 'static, 'static, 'static>>>>>>,
 }
 
 impl PartialEq for IncludeOp {
@@ -194,7 +194,11 @@ impl Grounded for IncludeOp {
         let program_text = String::from_utf8(program_buf)
             .map_err(|e| e.to_string())?;
         let parser = crate::metta::text::OwnedSExprParser::new(program_text);
-        context.push_parser(Box::new(parser));
+        //QUESTION: do we want to do anything with the result from the `include` operation?
+        let _eval_result = context.run_inline(|context| {
+            context.push_parser(Box::new(parser));
+            Ok(())
+        })?;
 
         unit_result()
     }
@@ -212,7 +216,7 @@ impl Grounded for IncludeOp {
 #[derive(Clone, Debug)]
 pub struct ModSpaceOp {
     //TODO-HACK: This is a terrible horrible ugly hack that should be fixed ASAP
-    context: std::sync::Arc<std::sync::Mutex<Vec<std::sync::Arc<std::sync::Mutex<&'static mut RunContext<'static, 'static, 'static>>>>>>,
+    context: std::sync::Arc<std::sync::Mutex<Vec<std::sync::Arc<std::sync::Mutex<&'static mut RunContext<'static, 'static, 'static, 'static>>>>>>,
 }
 
 impl PartialEq for ModSpaceOp {

--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -4,7 +4,7 @@ use crate::space::*;
 use crate::metta::*;
 use crate::metta::text::Tokenizer;
 use crate::metta::text::SExprParser;
-use crate::metta::runner::{Metta, RunContext, ModuleLoader};
+use crate::metta::runner::{Metta, RunContext, ModuleLoader, ResourceKey};
 use crate::metta::types::{get_atom_types, get_meta_type};
 use crate::common::shared::Shared;
 use crate::common::CachingMapper;
@@ -188,7 +188,7 @@ impl Grounded for IncludeOp {
         //TODO: Remove this hack to access the RunContext, when it's part of the arguments to `execute`
         let ctx_ref = self.context.lock().unwrap().last().unwrap().clone();
         let mut context = ctx_ref.lock().unwrap();
-        let program_buf = context.load_resource_from_module(mod_name, "module.metta")?;
+        let program_buf = context.load_resource_from_module(mod_name, ResourceKey::MainMettaSrc)?;
 
         // Interpret the loaded MeTTa S-Expression text
         let program_text = String::from_utf8(program_buf)

--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -147,6 +147,63 @@ fn strip_quotes(src: &str) -> &str {
     src
 }
 
+#[derive(Clone, Debug)]
+pub struct IncludeOp {
+    //TODO-HACK: This is a terrible horrible ugly hack that should be fixed ASAP
+    context: std::sync::Arc<std::sync::Mutex<Vec<std::sync::Arc<std::sync::Mutex<&'static mut RunContext<'static, 'static, 'static>>>>>>,
+}
+
+impl PartialEq for IncludeOp {
+    fn eq(&self, _other: &Self) -> bool { true }
+}
+
+impl IncludeOp {
+    pub fn new(metta: Metta) -> Self {
+        Self{ context: metta.0.context.clone() }
+    }
+}
+
+impl Display for IncludeOp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "include")
+    }
+}
+
+impl Grounded for IncludeOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_ATOM, UNIT_TYPE()])
+    }
+
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        let arg_error = || ExecError::from("include expects a module name argument");
+        let mod_name_atom = args.get(0).ok_or_else(arg_error)?;
+
+        // TODO: replace Symbol by grounded String?
+        let mod_name = match mod_name_atom {
+            Atom::Symbol(mod_name) => mod_name.name(),
+            _ => return Err(arg_error())
+        };
+        let mod_name = strip_quotes(mod_name);
+
+        //TODO: Remove this hack to access the RunContext, when it's part of the arguments to `execute`
+        let ctx_ref = self.context.lock().unwrap().last().unwrap().clone();
+        let mut context = ctx_ref.lock().unwrap();
+        let program_buf = context.load_resource_from_module(mod_name, "module.metta")?;
+
+        // Interpret the loaded MeTTa S-Expression text
+        let program_text = String::from_utf8(program_buf)
+            .map_err(|e| e.to_string())?;
+        let parser = crate::metta::text::OwnedSExprParser::new(program_text);
+        context.push_parser(Box::new(parser));
+
+        unit_result()
+    }
+
+    fn match_(&self, other: &Atom) -> MatchResultIter {
+        match_by_equality(self, other)
+    }
+}
+
 /// mod-space! returns the space of a specified module, loading the module if it's not loaded already
 //NOTE: The "impure" '!' denoted in the op atom name is due to the side effect of loading the module.  If
 // we want a side-effect-free version, it could be implemented by calling `RunContext::get_module_by_name`
@@ -1440,6 +1497,8 @@ mod non_minimal_only_stdlib {
         tref.register_token(regex(r"get-type"), move |_| { get_type_op.clone() });
         let import_op = Atom::gnd(ImportOp::new(metta.clone()));
         tref.register_token(regex(r"import!"), move |_| { import_op.clone() });
+        let include_op = Atom::gnd(IncludeOp::new(metta.clone()));
+        tref.register_token(regex(r"include"), move |_| { include_op.clone() });
         let pragma_op = Atom::gnd(PragmaOp::new(metta.settings().clone()));
         tref.register_token(regex(r"pragma!"), move |_| { pragma_op.clone() });
 

--- a/lib/src/metta/runner/stdlib_minimal.rs
+++ b/lib/src/metta/runner/stdlib_minimal.rs
@@ -407,6 +407,8 @@ pub fn register_runner_tokens(tref: &mut Tokenizer, tokenizer: Shared<Tokenizer>
     tref.register_token(regex(r"pragma!"), move |_| { pragma_op.clone() });
     let import_op = Atom::gnd(stdlib::ImportOp::new(metta.clone()));
     tref.register_token(regex(r"import!"), move |_| { import_op.clone() });
+    let include_op = Atom::gnd(stdlib::IncludeOp::new(metta.clone()));
+    tref.register_token(regex(r"include"), move |_| { include_op.clone() });
     let bind_op = Atom::gnd(stdlib::BindOp::new(tokenizer.clone()));
     tref.register_token(regex(r"bind!"), move |_| { bind_op.clone() });
     let trace_op = Atom::gnd(stdlib::TraceOp{});

--- a/python/tests/test_include.metta
+++ b/python/tests/test_include.metta
@@ -1,0 +1,3 @@
+(five isprime)
+(seven isprime)
+!(add-atom &self (six notprime))

--- a/python/tests/test_modules.py
+++ b/python/tests/test_modules.py
@@ -25,10 +25,12 @@ class ModulesTest(HyperonTestCase):
 
     def test_include(self):
         metta = MeTTa(env_builder=Environment.custom_env(working_dir=os.getcwd(), disable_config=True, is_test=True))
-        metta.run("!(include test_include)")
-
-        result = metta.run("!(match &self ($x isprime) $x)")
-        self.assertEqualMettaRunnerResults(result, [[S("five"), S("seven")]])
+        result = metta.run("""
+            (three isprime)
+            !(include test_include)
+            !(match &self ($x isprime) $x)
+        """)
+        self.assertTrue(areEqualNoOrder(result[1], [S("three"), S("five"), S("seven")]))
 
         result = metta.run("!(match &self ($x notprime) $x)")
         self.assertEqual(result[0], [S("six")])

--- a/python/tests/test_modules.py
+++ b/python/tests/test_modules.py
@@ -27,10 +27,12 @@ class ModulesTest(HyperonTestCase):
         metta = MeTTa(env_builder=Environment.custom_env(working_dir=os.getcwd(), disable_config=True, is_test=True))
         result = metta.run("""
             (three isprime)
+            !(match &self ($x isprime) $x)
             !(include test_include)
             !(match &self ($x isprime) $x)
         """)
-        self.assertTrue(areEqualNoOrder(result[1], [S("three"), S("five"), S("seven")]))
+        self.assertTrue(areEqualNoOrder(result[0], [S("three")]))
+        self.assertTrue(areEqualNoOrder(result[2], [S("three"), S("five"), S("seven")]))
 
         result = metta.run("!(match &self ($x notprime) $x)")
         self.assertEqual(result[0], [S("six")])

--- a/python/tests/test_modules.py
+++ b/python/tests/test_modules.py
@@ -1,8 +1,9 @@
 import unittest
+from test_common import *
 
 from hyperon import *
 
-class ModulesTest(unittest.TestCase):
+class ModulesTest(HyperonTestCase):
 
     def test_python_file_mod_format(self):
         """
@@ -21,3 +22,13 @@ class ModulesTest(unittest.TestCase):
         #Validate that we can access an atom from the module, and it's the atom we expect
         result = runner.parse_all("pi_test")
         self.assertEqual(result[0].get_object().content, 3.14159)
+
+    def test_include(self):
+        metta = MeTTa(env_builder=Environment.custom_env(working_dir=os.getcwd(), disable_config=True, is_test=True))
+        metta.run("!(include test_include)")
+
+        result = metta.run("!(match &self ($x isprime) $x)")
+        self.assertEqualMettaRunnerResults(result, [[S("five"), S("seven")]])
+
+        result = metta.run("!(match &self ($x notprime) $x)")
+        self.assertEqual(result[0], [S("six")])


### PR DESCRIPTION
This PR adds the `include` operation and associated changes so module loaders can make additional named resources available through a resource API.

I also included a fix for an occasional panic caused by the C API being misused, passing a NULL ptr to a function taking an array ptr, when a zero-sized array is desired.