### PR TITLE
Addition to simple python import

### DIFF
--- a/python/sandbox/simple_import/example_04_numpy_simple_import.metta
+++ b/python/sandbox/simple_import/example_04_numpy_simple_import.metta
@@ -1,0 +1,11 @@
+!(import! &self simple_import)
+
+!(import numpy)
+!(import numpy)
+!(import numpy.linalg)
+
+
+!(bind! m1 (call_dot2 numpy random rand 3 3 ))
+!(bind! m1_inv (call_dot2 numpy linalg inv m1))
+
+!(__unwrap (call_dot numpy matmul m1 m1_inv))


### PR DESCRIPTION
Small Addition to the sandbox simple_import example
It adds "import" without as or from, see `example_04_numpy_simple_import.metta`

- With such import it is more common that we could call import twice, but since we work on the level of tokenizer it does not cause any problem (see `example_04_numpy_simple_import.metta`).
- For calls like "numpy.random.rand" it adds a "dirty" call_dot2 operator
