### PR TITLE
Changing module loading logic so modules aren't merged into runner until loading is complete

### DIFF
--- a/c/src/metta.rs
+++ b/c/src/metta.rs
@@ -5,8 +5,8 @@ use hyperon::space::DynSpace;
 use hyperon::metta::text::*;
 use hyperon::metta::interpreter;
 use hyperon::metta::interpreter::InterpreterState;
-use hyperon::metta::runner::{Metta, RunContext, ModId, RunnerState, Environment, EnvBuilder};
-use hyperon::metta::runner::modules::ModuleLoader;
+use hyperon::metta::runner::{Metta, RunContext, RunnerState, Environment, EnvBuilder};
+use hyperon::metta::runner::modules::{ModuleLoader, ModId};
 use hyperon::metta::runner::modules::catalog::{FsModuleFormat, ModuleDescriptor};
 use hyperon::atom::*;
 

--- a/c/src/metta.rs
+++ b/c/src/metta.rs
@@ -1187,21 +1187,21 @@ pub struct run_context_t {
 // layer because it's harder to exercise lifecycle discipline in Python and a bug in Python shouldn't lead
 // to invlid memory access
 
-struct RustRunContext(RunContext<'static, 'static, 'static, 'static>);
+struct RustRunContext(RunContext<'static, 'static, 'static>);
 
-impl From<&mut RunContext<'_, '_, '_, '_>> for run_context_t {
-    fn from(context_ref: &mut RunContext<'_, '_, '_, '_>) -> Self {
+impl From<&mut RunContext<'_, '_, '_>> for run_context_t {
+    fn from(context_ref: &mut RunContext<'_, '_, '_>) -> Self {
         Self {
-            context: (context_ref as *mut RunContext<'_, '_, '_, '_>).cast()
+            context: (context_ref as *mut RunContext<'_, '_, '_>).cast()
         }
     }
 }
 
 impl run_context_t {
-    fn borrow(&self) -> &RunContext<'static, 'static, 'static, 'static> {
+    fn borrow(&self) -> &RunContext<'static, 'static, 'static> {
         &unsafe{ &*self.context.cast::<RustRunContext>() }.0
     }
-    fn borrow_mut(&mut self) -> &mut RunContext<'static, 'static, 'static, 'static> {
+    fn borrow_mut(&mut self) -> &mut RunContext<'static, 'static, 'static> {
         &mut unsafe{ &mut *self.context.cast::<RustRunContext>() }.0
     }
 }

--- a/c/src/metta.rs
+++ b/c/src/metta.rs
@@ -2000,5 +2000,5 @@ pub extern "C" fn run_context_load_module(run_context: *mut run_context_t, name:
 pub extern "C" fn run_context_import_dependency(run_context: *mut run_context_t, mod_id: module_id_t) {
     let context = unsafe{ &mut *run_context }.borrow_mut();
 
-    context.module().import_all_from_dependency(context.metta(), mod_id.into_inner()).unwrap();
+    context.import_all_from_dependency(mod_id.into_inner()).unwrap();
 }

--- a/c/tests/check_runner.c
+++ b/c/tests/check_runner.c
@@ -187,7 +187,7 @@ void custom_stdlib_loader(run_context_t *run_context, void* callback_context) {
     space_free(space);
 
     //"import * from corelib" (This is optional, and some implementations might not want it)
-    module_id_t corelib_mod_id = run_context_load_module(run_context, "corelib");
+    module_id_t corelib_mod_id = run_context_load_module(run_context, "top:corelib");
     run_context_import_dependency(run_context, corelib_mod_id);
 
     //Load a custom atom using the MeTTa syntax

--- a/c/tests/check_runner.c
+++ b/c/tests/check_runner.c
@@ -35,6 +35,9 @@ bool run_metta_and_compare_result(metta_t* runner, const char* metta_src, const 
             size_t len = atom_to_str(&result_atom, atom_str_buf, 256);
 
             result = strcmp(atom_str_buf, expected_result) == 0;
+            if (!result) {
+                fprintf(stderr, "Expected: \"%s\"\nFound:    \"%s\"\n", expected_result, atom_str_buf);
+            }
         }
         atom_vec_free(*results);
         free(results);
@@ -173,7 +176,7 @@ START_TEST (test_custom_module_format)
     ck_assert(run_metta_and_compare_result(&runner, "!(match &loaded-test test-atom found!)", "found!"));
 
     //Try and load a module that our format will reject, and validate we get an error
-    ck_assert(run_metta_and_compare_result(&runner, "!(import! &new-space bogus-mod)", "(Error (import! &new-space bogus-mod) Failed to resolve module bogus-mod)"));
+    ck_assert(run_metta_and_compare_result(&runner, "!(import! &new-space bogus-mod)", "(Error (import! &new-space bogus-mod) Failed to resolve module top:bogus-mod)"));
 
     metta_free(runner);
 }

--- a/lib/src/metta/runner/mod.rs
+++ b/lib/src/metta/runner/mod.rs
@@ -343,6 +343,11 @@ impl Metta {
                 main_mod_id = new_mod_id;
             }
         }
+
+        // //TODO-NOW, delete this
+        // let wrapper = ModNameNodeDisplayWrapper::new(TOP_MOD_NAME, &*module_names, |mod_id: ModId, f: &mut std::fmt::Formatter| write!(f, "{}", mod_id.0));
+        // println!("{wrapper}");
+
         Ok(main_mod_id)
     }
 
@@ -726,7 +731,8 @@ impl<'input> RunContext<'_, '_, '_, 'input> {
     /// NOTE: If this method is called during module load, and the module load fails, the
     /// added name will not become part of the runner's module namespace
     fn add_module_to_name_tree(&mut self, mod_name: &str, mod_id: ModId) -> Result<(), String>  {
-        self.init_state.add_module_to_name_tree(&self.metta, self.mod_id, mod_name, mod_id)
+        let normalized_mod_name = normalize_relative_module_name(self.module().path(), mod_name)?;
+        self.init_state.add_module_to_name_tree(&self.metta, self.mod_id, &normalized_mod_name, mod_id)
     }
 
     /// Normalize a module name into a canonical name-path form, and expanding a relative module-path
@@ -783,7 +789,6 @@ impl<'input> RunContext<'_, '_, '_, 'input> {
         if self.get_module_by_name(&mod_name).is_ok() {
             return Err(format!("Attempt to create module alias with name that conflicts with existing module: {mod_name}"));
         }
-        let mod_name = self.normalize_module_name(mod_name)?;
         self.add_module_to_name_tree(&mod_name, mod_id)?;
         Ok(mod_id)
     }

--- a/lib/src/metta/runner/mod.rs
+++ b/lib/src/metta/runner/mod.rs
@@ -864,23 +864,12 @@ impl<'input> RunContext<'_, '_, '_, 'input> {
     fn load_module_internal(&mut self, mod_path: &str, parent_mod_id: ModId) -> Result<ModId, String> {
         let mut state = RunnerState::new_with_module(&self.metta, parent_mod_id);
         state.run_in_context(|context| {
-<<<<<<< Updated upstream
-            let new_mod_id = match context.module().pkg_info().resolve_module(context, mod_path)? {
+            match context.module().pkg_info().resolve_module(context, mod_path)? {
                 Some((loader, descriptor)) => {
-                    self.metta.get_or_init_module_with_descriptor(mod_path, descriptor, loader)?
+                    self.get_or_init_module_with_descriptor(mod_path, descriptor, loader)
                 },
                 None => {return Err(format!("Failed to resolve module {mod_path}"))}
-            };
-            self.add_module_to_name_tree(&mod_path, new_mod_id)?;
-            Ok(new_mod_id)
-=======
-            match context.module().pkg_info().resolve_module(context, &normalized_mod_path)? {
-                Some((loader, descriptor)) => {
-                    self.get_or_init_module_with_descriptor(&normalized_mod_path, descriptor, loader)
-                },
-                None => {return Err(format!("Failed to resolve module {mod_name}"))}
             }
->>>>>>> Stashed changes
         })
     }
 

--- a/lib/src/metta/runner/mod.rs
+++ b/lib/src/metta/runner/mod.rs
@@ -514,7 +514,7 @@ impl<'m, 'input> RunnerState<'m, 'input> {
     pub(crate) fn new_for_loading(metta: &'m Metta, new_mod_name: &str, init_state: &mut ModuleInitState) -> Self {
         let normalized_name = normalize_relative_module_name("top", &new_mod_name).unwrap();
         let mod_id = init_state.push(normalized_name);
-        Self::new_internal(metta, mod_id, init_state.clone())
+        Self::new_internal(metta, mod_id, init_state.new_child())
     }
 
     /// Creates a new RunnerState to be used in the process of loading a new module
@@ -725,7 +725,7 @@ impl<'input> RunContext<'_, '_, 'input> {
         if mod_id == self.mod_id {
             f(self)
         } else {
-            let mut state = RunnerState::new_with_module_and_init_state(&self.metta, mod_id, self.init_state.clone());
+            let mut state = RunnerState::new_with_module_and_init_state(&self.metta, mod_id, self.init_state.new_child());
             state.run_in_context(f)
         }
     }

--- a/lib/src/metta/runner/modules/mod.rs
+++ b/lib/src/metta/runner/modules/mod.rs
@@ -22,7 +22,7 @@ pub mod catalog;
 use catalog::*;
 
 mod mod_names;
-pub(crate) use mod_names::{ModNameNode, mod_name_from_path, normalize_relative_module_name, module_name_is_legal, get_module_sub_path, decompose_name_path, compose_name_path, ModNameNodeDisplayWrapper};
+pub(crate) use mod_names::{ModNameNode, mod_name_from_path, normalize_relative_module_name, module_name_is_legal, mod_name_remove_prefix, decompose_name_path, compose_name_path, ModNameNodeDisplayWrapper};
 pub use mod_names::{TOP_MOD_NAME, SELF_MOD_NAME, MOD_NAME_SEPARATOR};
 
 /// A reference to a [MettaMod] that is loaded into a [Metta] runner
@@ -583,7 +583,7 @@ impl ModuleInitFrame {
     // name-space gets a lot trickier if modules are allowed to add sub-modules outside themselves
     pub(crate) fn add_module_to_name_tree(&mut self, mod_name: &str, mod_id: ModId) -> Result<(), String> {
         let self_mod_path = &self.new_mod_name.as_ref().unwrap();
-        match get_module_sub_path(mod_name, &self_mod_path) {
+        match mod_name_remove_prefix(mod_name, &self_mod_path) {
             Some(sub_mod_name) => {
                 if sub_mod_name.len() == 0 {
                     return Err(format!("Attempt to load {mod_name} recursively from within its own loader"));

--- a/lib/src/metta/runner/modules/mod.rs
+++ b/lib/src/metta/runner/modules/mod.rs
@@ -342,7 +342,8 @@ impl MettaMod {
 
 }
 
-/// ModuleInitState is a smart-pointer to a vec of [ModuleInitFrame]
+/// ModuleInitState is a smart-pointer to a state that contains some objects to be merged
+/// into the runner after module initialization has completed sucessfully
 pub(crate) enum ModuleInitState {
     /// Meaning: The RunnerState holding this pointer is not initializing modules
     None,
@@ -357,16 +358,6 @@ pub(crate) enum ModuleInitState {
 pub(crate) struct ModuleInitStateInsides {
     frames: Vec<ModuleInitFrame>,
     module_descriptors: HashMap<ModuleDescriptor, ModId>,
-}
-
-impl Clone for ModuleInitState {
-    fn clone(&self) -> Self {
-        match self {
-            Self::None => Self::None,
-            Self::Root(rc) |
-            Self::Child(rc) => Self::Child(rc.clone())
-        }
-    }
 }
 
 impl ModuleInitState {
@@ -395,6 +386,13 @@ impl ModuleInitState {
                 insides_ref.frames.push(ModuleInitFrame::new_with_name(mod_name));
                 ModId::new_relative(new_idx)
             }
+        }
+    }
+    pub fn new_child(&self) -> Self {
+        match self {
+            Self::None => Self::None,
+            Self::Root(rc) |
+            Self::Child(rc) => Self::Child(rc.clone())
         }
     }
     pub fn is_root(&self) -> bool {

--- a/lib/src/metta/runner/modules/mod.rs
+++ b/lib/src/metta/runner/modules/mod.rs
@@ -52,20 +52,6 @@ impl ModId {
     pub(crate) const fn get_idx_from_relative(self) -> usize {
         self.0 & (usize::MAX >> 1)
     }
-    //TODO-NOW: Actually I might not need this if I don't allow InitFrames to collapse
-    // pub(crate) const fn new_relative(frame_idx: usize, mod_idx: usize) -> Self {
-    //     //Set the highest bit to 1 to indicate a relative ID,
-    //     //The low 16 bits are a mod_idx, and the 15 bits above that are the frame_idx
-    //     assert!(frame_idx < 1<<16);
-    //     assert!(mod_idx < 1<<17);
-    //     Self((!(usize::MAX>>1)) | (frame_idx<<16) | mod_idx)
-    // }
-    // /// Returns (frame_idx, mod_idx)
-    // pub(crate) const fn get_idx_from_relative(self) -> (usize, usize) {
-    //     let frame_idx = (self.0 & 0xFFFF0000) >> 16;
-    //     let mod_idx = self.0 & 0xFFFF;
-    //     (frame_idx, mod_idx)
-    // }
     pub(crate) const fn is_relative(self) -> bool {
         self.0 & (!(usize::MAX >> 1)) > 0
     }

--- a/lib/src/metta/runner/modules/mod.rs
+++ b/lib/src/metta/runner/modules/mod.rs
@@ -258,6 +258,21 @@ impl MettaMod {
         Ok(())
     }
 
+    /// Private method to iterate a module's imported_deps and replace a reference to one ModId
+    /// with another from a map.
+    pub(crate) fn remap_imported_deps(&self, mapping: &HashMap<ModId, ModId>) {
+        let mut deps = self.imported_deps.lock().unwrap();
+        let mut temp = HashMap::with_capacity(deps.len());
+        core::mem::swap(&mut temp, &mut *deps);
+        for (dep_mod_id, space) in temp.into_iter() {
+            let new_mod_id = match mapping.get(&dep_mod_id) {
+                Some(mapped_id) => *mapped_id,
+                None => dep_mod_id,
+            };
+            deps.insert(new_mod_id, space);
+        }
+    }
+
     /// Private function that returns a deep copy of a module's space, with the module's dependency
     /// sub-spaces stripped out and returned separately
     //

--- a/lib/src/metta/runner/modules/mod_names.rs
+++ b/lib/src/metta/runner/modules/mod_names.rs
@@ -48,27 +48,28 @@ pub(crate) fn mod_name_remove_prefix<'a>(name: &'a str, prefix: &str) -> Option<
     }
 }
 
-/// Returns the portion of `name` that does not match the beginning of `other`, starting
-/// at the point where the strings diverge.  For example, is `name == "top:mod_a:hello"`
-/// and `other == "top:mod_a:goodbye"`, then this function would return "hello".
-pub(crate) fn remove_common_prefix<'a>(name: &'a str, other: &str) -> &'a str {
-    let mut start = 0;
-    let mut other_iter = other.chars();
-    for (idx, c_name) in name.char_indices() {
-        if c_name == MOD_NAME_SEPARATOR {
-            start = idx+1;
-        }
-        match other_iter.next() {
-            Some(c_other) => {
-                if c_name != c_other {
-                    return &name[start..]
-                }
-            },
-            None => return &name[start..]
-        }
-    }
-    ""
-}
+//TODO-NEXT: This function is likely unneeded, and can be removed
+// /// Returns the portion of `name` that does not match the beginning of `other`, starting
+// /// at the point where the strings diverge.  For example, is `name == "top:mod_a:hello"`
+// /// and `other == "top:mod_a:goodbye"`, then this function would return "hello".
+// pub(crate) fn remove_common_prefix<'a>(name: &'a str, other: &str) -> &'a str {
+//     let mut start = 0;
+//     let mut other_iter = other.chars();
+//     for (idx, c_name) in name.char_indices() {
+//         if c_name == MOD_NAME_SEPARATOR {
+//             start = idx+1;
+//         }
+//         match other_iter.next() {
+//             Some(c_other) => {
+//                 if c_name != c_other {
+//                     return &name[start..]
+//                 }
+//             },
+//             None => return &name[start..]
+//         }
+//     }
+//     ""
+// }
 
 /// Returns the part of a module name path after the last separator, or the entire path if it does not
 /// contain a separator.  May panic if the mod-name-path is invalid
@@ -594,10 +595,6 @@ fn module_name_parse_test() {
     assert_eq!(top.resolve("top:sub2:suba:subA").unwrap(), ModId(4));
     assert!(top.resolve("sub2:suba:subA:").is_none());
     assert!(top.resolve("sub1:suba").is_none());
-
-    //TODO-NOW, figure out if we want to keep these tests
-    // assert_eq!(ModNameNode::normalize_name_path("").unwrap(), "top");
-    // assert_eq!(ModNameNode::normalize_name_path("sub2:suba:subA").unwrap(), "top:sub2:suba:subA");
 
 // //NOTE: HashMap internals make the order unpredictable so this is hard to test
 // assert_eq!(format!("\n{top}"), r#"

--- a/lib/src/metta/runner/modules/mod_names.rs
+++ b/lib/src/metta/runner/modules/mod_names.rs
@@ -353,25 +353,6 @@ impl ModNameNode {
             |_, _| {}).map(|(node, _subtree_idx, remaining)| (node, remaining))
     }
 
-    // //TODO-NOW This function is probably not needed
-    // /// Parses a module name path into a canonical representation beginning with `top`
-    // ///
-    // /// Does not handle paths beginning with `self`
-    // pub fn normalize_name_path(name: &str) -> Result<String, String> {
-    //     if name == TOP_MOD_NAME {
-    //         return Ok(TOP_MOD_NAME.to_string());
-    //     }
-    //     let mut new_name = TOP_MOD_NAME.to_string();
-    //     let (_, _, last) = Self::parse_parent_generic(Self::top(), name, &OverlayMap::none(),
-    //         |node, _| Some(node),
-    //         |_, component| {new_name.push_str(":"); new_name.push_str(component)})?;
-    //     if last.len() > 0 {
-    //         new_name.push_str(":");
-    //         new_name.push_str(last);
-    //     }
-    //     Ok(new_name)
-    // }
-
     /// Internal generic `parse_parent` that can expand to mutable and const versions.
     /// Return valus is (parent_node, subtree_idx, remaining_name_path)
     /// If subtree_idx is None, the path was parsed to the end.  If it is Some, then the overlay_map

--- a/lib/src/metta/runner/modules/mod_names.rs
+++ b/lib/src/metta/runner/modules/mod_names.rs
@@ -50,29 +50,6 @@ pub(crate) fn mod_name_remove_prefix<'a>(name: &'a str, prefix: &str) -> Option<
     }
 }
 
-//TODO-NEXT: This function is likely unneeded, and can be removed
-// /// Returns the portion of `name` that does not match the beginning of `other`, starting
-// /// at the point where the strings diverge.  For example, is `name == "top:mod_a:hello"`
-// /// and `other == "top:mod_a:goodbye"`, then this function would return "hello".
-// pub(crate) fn remove_common_prefix<'a>(name: &'a str, other: &str) -> &'a str {
-//     let mut start = 0;
-//     let mut other_iter = other.chars();
-//     for (idx, c_name) in name.char_indices() {
-//         if c_name == MOD_NAME_SEPARATOR {
-//             start = idx+1;
-//         }
-//         match other_iter.next() {
-//             Some(c_other) => {
-//                 if c_name != c_other {
-//                     return &name[start..]
-//                 }
-//             },
-//             None => return &name[start..]
-//         }
-//     }
-//     ""
-// }
-
 /// Returns the part of a module name path after the last separator, or the entire path if it does not
 /// contain a separator.  May panic if the mod-name-path is invalid
 pub(crate) fn mod_name_from_path(path: &str) -> &str {

--- a/lib/src/metta/runner/modules/mod_names.rs
+++ b/lib/src/metta/runner/modules/mod_names.rs
@@ -48,6 +48,28 @@ pub(crate) fn mod_name_remove_prefix<'a>(name: &'a str, prefix: &str) -> Option<
     }
 }
 
+/// Returns the portion of `name` that does not match the beginning of `other`, starting
+/// at the point where the strings diverge.  For example, is `name == "top:mod_a:hello"`
+/// and `other == "top:mod_a:goodbye"`, then this function would return "hello".
+pub(crate) fn remove_common_prefix<'a>(name: &'a str, other: &str) -> &'a str {
+    let mut start = 0;
+    let mut other_iter = other.chars();
+    for (idx, c_name) in name.char_indices() {
+        if c_name == MOD_NAME_SEPARATOR {
+            start = idx+1;
+        }
+        match other_iter.next() {
+            Some(c_other) => {
+                if c_name != c_other {
+                    return &name[start..]
+                }
+            },
+            None => return &name[start..]
+        }
+    }
+    ""
+}
+
 /// Returns the part of a module name path after the last separator, or the entire path if it does not
 /// contain a separator.  May panic if the mod-name-path is invalid
 pub(crate) fn mod_name_from_path(path: &str) -> &str {
@@ -297,7 +319,7 @@ impl ModNameNode {
             new_name.push_str(component);
         }
         Ok(new_name)
-    } 
+    }
 
     /// Internal generic `parse_parent` that can expand to mutable and const versions.
     /// Return valus is (parent_node, subtree_idx, remaining_name_path)

--- a/lib/src/metta/runner/modules/mod_names.rs
+++ b/lib/src/metta/runner/modules/mod_names.rs
@@ -92,6 +92,20 @@ pub(crate) fn concat_relative_module_path(base_path: &str, relative_path: &str) 
     }
 }
 
+/// Returns the portion of `mod_path` that is a sub-path on top of `base_path`.  The reverse
+/// of `concat_relative_module_path`
+pub(crate) fn get_module_sub_path<'a>(mod_path: &'a str, base_path: &str) -> Option<&'a str> {
+    if mod_path.starts_with(base_path) {
+        if (&mod_path[base_path.len()..]).starts_with(':') {
+            Some(&mod_path[base_path.len()+1..])
+        } else {
+            None
+        }
+    } else {
+        None
+    }
+}
+
 /// Normalize a module name into a canonical name-path form, and expanding a relative module-path
 ///
 /// On input, module names that don't begin with either `top` nor `self` will be assumed to be
@@ -207,6 +221,7 @@ impl ModNameNode {
     }
 
     /// Adds a single new node to a layered tree.  See [Self::resolve_layered] for details
+    #[allow(dead_code)] //NOTE: This function "feels" like it belongs in a complete API, and might be used in the future.  See discussion on [ModuleInitFrame::add_module_to_name_tree]
     pub fn add_to_layered(&mut self, subtrees: &mut[(&str, &mut Self)], name: &str, mod_id: ModId) -> Result<(), String> {
         self.merge_subtree_into_layered(subtrees, name, Self::new(mod_id))
     }

--- a/lib/src/metta/runner/modules/mod_names.rs
+++ b/lib/src/metta/runner/modules/mod_names.rs
@@ -22,7 +22,7 @@ pub const MOD_NAME_SEPARATOR: char = ':';
 ///
 #[derive(Clone, Debug, Default)]
 pub(crate) struct ModNameNode {
-    mod_id: ModId,
+    pub mod_id: ModId,
     children: Option<HashMap<String, ModNameNode>>
 }
 
@@ -263,6 +263,20 @@ impl ModNameNode {
             self.children = Some(HashMap::new());
         }
         self.children.as_mut().unwrap().insert(child_name, child_node);
+    }
+
+    /// Walks a tree running the provided function on each node, including the root
+    pub fn visit_mut<F: FnMut(&str, &mut Self)>(&mut self, root_node_name: &str, mut f: F) {
+        self.visit_mut_internal(root_node_name, &mut f);
+    }
+
+    fn visit_mut_internal<F: FnMut(&str, &mut Self)>(&mut self, root_node_name: &str, f: &mut F) {
+        f(root_node_name, self);
+        if let Some(children) = &mut self.children {
+            for (child_name, child_node) in children.iter_mut() {
+                child_node.visit_mut_internal(child_name, f);
+            }
+        }
     }
 
     /// Returns the [ModId] of a module name/path within `&self`, or None if it can't be resolved

--- a/lib/src/metta/runner/modules/mod_names.rs
+++ b/lib/src/metta/runner/modules/mod_names.rs
@@ -20,7 +20,7 @@ pub const MOD_NAME_SEPARATOR: char = ':';
 /// `self` is an alias for the current module
 /// `self.some_mod` is a private sub-module of the current module
 ///
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub(crate) struct ModNameNode {
     mod_id: ModId,
     children: Option<HashMap<String, ModNameNode>>

--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -102,12 +102,12 @@ impl Grounded for ImportOp {
         // Import the module, as per the behavior described above
         match dest_arg {
             Atom::Symbol(dest_sym) => {
-                context.module().import_dependency_as(&context.metta, mod_id, Some(dest_sym.name().to_string()))?;
+                context.import_dependency_as(mod_id, Some(dest_sym.name().to_string()))?;
             }
             other_atom => {
                 match &other_atom {
                     Atom::Grounded(_) if Atom::as_gnd::<DynSpace>(other_atom) == Some(context.module().space()) => {
-                        context.module().import_all_from_dependency(&context.metta, mod_id)?;
+                        context.import_all_from_dependency(mod_id)?;
                     },
                     _ => {
                         return Err(format!("import! destination argument must be a symbol atom naming a new space, or &self.  Found: {other_atom:?}").into());

--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -26,7 +26,7 @@ fn unit_result() -> Result<Vec<Atom>, ExecError> {
 #[derive(Clone, Debug)]
 pub struct ImportOp {
     //TODO-HACK: This is a terrible horrible ugly hack that should be fixed ASAP
-    context: std::sync::Arc<std::sync::Mutex<Vec<std::sync::Arc<std::sync::Mutex<&'static mut RunContext<'static, 'static, 'static, 'static>>>>>>,
+    context: std::sync::Arc<std::sync::Mutex<Vec<std::sync::Arc<std::sync::Mutex<&'static mut RunContext<'static, 'static, 'static>>>>>>,
 }
 
 impl PartialEq for ImportOp {
@@ -150,7 +150,7 @@ fn strip_quotes(src: &str) -> &str {
 #[derive(Clone, Debug)]
 pub struct IncludeOp {
     //TODO-HACK: This is a terrible horrible ugly hack that should be fixed ASAP
-    context: std::sync::Arc<std::sync::Mutex<Vec<std::sync::Arc<std::sync::Mutex<&'static mut RunContext<'static, 'static, 'static, 'static>>>>>>,
+    context: std::sync::Arc<std::sync::Mutex<Vec<std::sync::Arc<std::sync::Mutex<&'static mut RunContext<'static, 'static, 'static>>>>>>,
 }
 
 impl PartialEq for IncludeOp {
@@ -216,7 +216,7 @@ impl Grounded for IncludeOp {
 #[derive(Clone, Debug)]
 pub struct ModSpaceOp {
     //TODO-HACK: This is a terrible horrible ugly hack that should be fixed ASAP
-    context: std::sync::Arc<std::sync::Mutex<Vec<std::sync::Arc<std::sync::Mutex<&'static mut RunContext<'static, 'static, 'static, 'static>>>>>>,
+    context: std::sync::Arc<std::sync::Mutex<Vec<std::sync::Arc<std::sync::Mutex<&'static mut RunContext<'static, 'static, 'static>>>>>>,
 }
 
 impl PartialEq for ModSpaceOp {

--- a/python/hyperon/runner.py
+++ b/python/hyperon/runner.py
@@ -338,7 +338,7 @@ def _priv_make_module_loader_func_for_pymod(pymod_name, load_corelib=False, reso
 
             #Load and import the corelib using "import *" behavior, if that flag was specified
             if load_corelib:
-                corelib_id = run_context.load_module("corelib")
+                corelib_id = run_context.load_module("top:corelib")
                 run_context.import_dependency(corelib_id)
 
             for n in dir(mod):

--- a/python/tests/scripts/f1_imports.metta
+++ b/python/tests/scripts/f1_imports.metta
@@ -90,7 +90,7 @@
 
 ; Check that the &self space contains the corelib child space
 ; Note: corelib doesn't import any modules into itself, so no space copy is needed
-!(import! &corelib corelib)
+!(import! &corelib top:corelib)
 (: is-corelib (-> Atom Bool))
 (= (is-corelib $atom) (== $atom &corelib))
 !(assertEqual


### PR DESCRIPTION
This PR is a blocker for fixing the `relative_submodule_import_test`, and resolving several other issues.

It's a fairly substantial internal refactor to the module-loading process, but the only outward-facing change should be that modules are loaded as child modules of the module loading them, as opposed to loading at the top-level of the module namespace.