### PR TITLE
Fix return operation type in minimal MeTTa stdlib

### DIFF
--- a/lib/src/metta/runner/stdlib_minimal.metta
+++ b/lib/src/metta/runner/stdlib_minimal.metta
@@ -1,8 +1,7 @@
 (@doc ErrorType (@desc "Type of the atom which contains error"))
 (: ErrorType Type)
 (: Error (-> Atom Atom ErrorType))
-(: ReturnType Type)
-(: return (-> Atom ReturnType))
+(: return (-> $t $t))
 
 (: function (-> Atom Atom))
 (: eval (-> Atom Atom))

--- a/python/tests/scripts/d4_type_prop.metta
+++ b/python/tests/scripts/d4_type_prop.metta
@@ -118,7 +118,12 @@
 ; But we can add 'reasoning'
 (= (= $type T)
    (match &self (: $impl (-> $cause $type))
-      (= $cause T)))
+      ; This kind of rule interferes with common types like
+      ; `(: return (-> $t $t))`. Presence of such type in a codebase triggers the
+      ; rule and as result goes into an infinite loop:
+      ; ((Mortal Plato) T) -> (: return (-> $t $t)) -> ((Mortal Plato) T).
+      ; == check is added to prevent the loop.
+      (if (== $cause $type) (empty) (= $cause T))))
 !(assertEqual
   (= (Mortal Plato) T)
   T)


### PR DESCRIPTION
Fix integration test d4_... to work after the change.