### PR TITLE
remove _version.py to prevent setuptools from failing

### DIFF
--- a/python/hyperon/__init__.py
+++ b/python/hyperon/__init__.py
@@ -1,12 +1,12 @@
 from .atoms import *
 from .base import *
 from .runner import *
-from ._version import __version__ as _ver
 
-if _ver is None:
+try:
+    from ._version import __version__ as _ver
+    __version__ = _ver
+except Exception:
     from pathlib import Path
     path = Path(__file__).parent / "../VERSION"
     with path.open() as f: ver = f.read().splitlines()[0].split("'")[1]
     __version__ = ver + "+localbuild"
-else:
-    __version__ = _ver

--- a/python/hyperon/_version.py
+++ b/python/hyperon/_version.py
@@ -1,1 +1,0 @@
-__version__ = None


### PR DESCRIPTION
So, after recent changes to versioning, it seems that every time we're installing the hyperon file _version.py is being changed and adding it to gitignore won't change a thing since it is already in the repository. So, I've bypassed this problem and deleted the _version.py file. Please check.