### PR TITLE
Enable MacOSX Apple Silicon release

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Rust stable
         uses: actions-rs/toolchain@v1.0.6
@@ -57,7 +57,7 @@ jobs:
           args: cbindgen
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python-version }}
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -9,8 +9,8 @@ jobs:
   deploy-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-versoin: 3.x
       - uses: actions/cache@v2

--- a/.github/workflows/minimal.yml
+++ b/.github/workflows/minimal.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Rust stable
         uses: actions-rs/toolchain@v1.0.6
@@ -47,7 +47,7 @@ jobs:
           args: cbindgen
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.7
 

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -43,7 +43,6 @@ jobs:
         uses: pypa/cibuildwheel@v2.17.0
         env:
           CIBW_BEFORE_ALL: sh -c "./python/install-hyperonc.sh -u https://github.com/${{github.repository}}.git -r ${{env.COMMIT_HEAD}}"
-          CIBW_SKIP: "*musllinux*"
         with:
           package-dir: ./python
 

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.10"
 
       - run: |
           echo "REF_NAME=${{github.ref_name}}" | tee -a $GITHUB_ENV

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-11]
+        os: [ubuntu-20.04, macos-13, macos-14]
       max-parallel: 3
 
     steps:

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -25,10 +25,10 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.8"
 
@@ -40,7 +40,7 @@ jobs:
           echo "COMMIT_HEAD=${{github.ref_name != '' && github.ref_name || env.GITHUB_SHA}}" | tee -a $GITHUB_ENV
 
       - name: Build wheels on ${{ matrix.os }}
-        uses: pypa/cibuildwheel@v2.13.1
+        uses: pypa/cibuildwheel@v2.17.0
         env:
           CIBW_BEFORE_ALL: sh -c "./python/install-hyperonc.sh -u https://github.com/${{github.repository}}.git -r ${{env.COMMIT_HEAD}}"
           CIBW_SKIP: "*musllinux*"
@@ -59,9 +59,9 @@ jobs:
           file_glob: true
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: python-wheels
+          name: python-wheels-${{ matrix.os }}
           path: ./wheelhouse/*.whl
 
   publish-test-pypi:
@@ -74,9 +74,10 @@ jobs:
     needs: [build-wheels]
     if: github.event.action == 'published'
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
-        name: python-wheels
+        pattern: python-wheels-*
+        merge-multiple: true
         path: dist
     - name: Publish package distributions to Test PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
@@ -93,9 +94,10 @@ jobs:
     needs: [build-wheels]
     if: github.event.action == 'published'
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
-        name: python-wheels
+        pattern: python-wheels-*
+        merge-multiple: true
         path: dist
     - name: Publish package distributions to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,6 +1,6 @@
 # Instructions for developers
 
-## How to check Python release procedure locally
+## How to release Python distribution packages locally
 
 Python packages are released using
 [cibuildwheel](https://pypi.org/project/cibuildwheel/). First step is to setup
@@ -8,8 +8,11 @@ it. Usually it means setup docker and install the package from PyPi (see [setup
 instructions](https://cibuildwheel.pypa.io/en/stable/setup/#local)).
 
 There are additional preparations to be made before running it. First of all
-`libhyperonc` library should be built and installed in a build environment. It
-is done by `install-hyperonc.sh` script which is called using
+`libhyperonc` library should be built and installed in a build environment. By
+default library downloads and install version from the `main` branch of the
+`trueagi-io/hyperon-experimental` repository. If one need to use the custom
+branch then it is done by passing custom parameters to the
+`install-hyperonc.sh` script which is called using
 [CIBW_BEFORE_ALL](https://cibuildwheel.pypa.io/en/stable/options/#before-all)
 environment variable:
 ```
@@ -23,13 +26,6 @@ the Python package is copied into container automatically. Code of the
 `libhyperonc` library should be downloaded from outside. It means one need to
 have the code in some repo accessible from the container before starting
 release. The simplest way is to push the changes in your GitHub repo fork.
-
-Some platform are not supported. Use
-[CIBW_SKIP](https://cibuildwheel.pypa.io/en/stable/options/#build-skip) to skip
-such platforms:
-```
-export CIBW_SKIP="*musllinux*"
-```
 
 Also one can start from building the only platform to quickly check whether
 release works. This can be done using

--- a/python/install-hyperonc.sh
+++ b/python/install-hyperonc.sh
@@ -19,8 +19,8 @@ while getopts 'u:r:' opt; do
     esac
 done
 
-echo "hyperonc repository URL $HYPERONC_URL"
-echo "hyperonc revision $HYPERONC_REV"
+echo "hyperonc repository URL: $HYPERONC_URL"
+echo "hyperonc revision: $HYPERONC_REV"
 
 # This is to build subunit from Conan on CentOS based manylinux images.
 if test "$AUDITWHEEL_POLICY" = "manylinux2014"; then
@@ -45,8 +45,13 @@ git reset --hard FETCH_HEAD
 
 mkdir -p ${HOME}/hyperonc/c/build
 cd ${HOME}/hyperonc/c/build
-# Rust doesn't support building shared libraries under musllinux environment
-cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release ..
+# Rust doesn't support building shared libraries under musllinux environment.
+CMAKE_ARGS="$CMAKE_ARGS -DBUILD_SHARED_LIBS=OFF"
+# Local prefix is used to support MacOSX Apple Silicon GitHub actions environment.
+CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${HOME}/.local"
+CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_BUILD_TYPE=Release"
+echo "hyperonc CMake arguments: $CMAKE_ARGS"
+cmake $CMAKE_ARGS ..
 make
 make check
 make install

--- a/python/install-hyperonc.sh
+++ b/python/install-hyperonc.sh
@@ -12,6 +12,8 @@ while getopts 'u:r:' opt; do
             ;;
         ?|h)
             echo "Usage: $(basename $0) [-u hyperonc_repo_url] [-r hyperonc_revision]"
+            echo "-u hyperonc_repo_url    Git repo URL to get hyperonc source code"
+            echo "-r hyperonc_revision    Revision of hyperonc to get from Git"
             exit 1
             ;;
     esac

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -36,7 +36,8 @@ package-dir = { "hyperon" = "hyperon" }
 
 [tool.cibuildwheel]
 before-all = "sh -c ./python/install-hyperonc.sh"
-# no Rust toolchain is available for musllinux-i686 environment
-skip = "*-musllinux_i686"
+# There is no Rust toolchain is available for musllinux-i686 environment.
+# Other musllinux platforms are opted out to decrease the build time.
+skip = "*musllinux*"
 test-requires = ["pytest==7.3.2"]
 test-command = "pytest {project}/python/tests"

--- a/python/setup.py
+++ b/python/setup.py
@@ -38,11 +38,13 @@ class CMakeBuild(build_ext):
         extdir = ext_fullpath.parent.resolve()
         debug = int(os.environ.get("DEBUG", 0)) if self.debug is None else self.debug
         cfg = "Debug" if debug else "Release"
+        local_prefix = os.path.join(os.environ["HOME"], ".local")
 
         cmake_args = [
             f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={extdir}{os.sep}",
             f"-DPython3_EXECUTABLE={sys.executable}",
-            f"-DCMAKE_BUILD_TYPE={cfg}"
+            f"-DCMAKE_BUILD_TYPE={cfg}",
+            f"-DCMAKE_PREFIX_PATH={local_prefix}"
         ]
         build_args = []
         # Adding CMake arguments set as environment variable


### PR DESCRIPTION
Fix deprecation warnings from release job, opt out `musllinux` by default in `pyproject.toml`, fix issue with insufficient permissions when building using `macos-14` GitHub runner.

To install Python package for MacOSX Apple Silicon from test PyPi:
```
python3 -m pip install --index-url https://test.pypi.org/simple/ hyperon
```
Version `0.1.8.1` should be installed.