### PR TITLE
Updating include op's type to match new behavior from prior PR

### DIFF
--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -172,7 +172,7 @@ impl Display for IncludeOp {
 
 impl Grounded for IncludeOp {
     fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_ATOM, UNIT_TYPE()])
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_ATOM, ATOM_TYPE_ATOM])
     }
 
     fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {


### PR DESCRIPTION
In [PR](https://github.com/trueagi-io/hyperon-experimental/pull/684) the behavior of the `include` stdlib op was changed to potentially return an atom rather than the unit type.  I forgot to update the type signature, so that's what this PR does.