### PR TITLE
%void% -> Empty

### DIFF
--- a/lib/src/metta/runner/stdlib.metta
+++ b/lib/src/metta/runner/stdlib.metta
@@ -50,7 +50,7 @@
 (: unify (-> Atom Atom Atom Atom %Undefined%))
 (= (unify $a $a $then $else) $then)
 (= (unify $a $b $then $else)
-  (case (unify-or-empty $a $b) ((%void%  $else))) )
+  (case (unify-or-empty $a $b) ((Empty $else))) )
 (: unify-or-empty (-> Atom Atom Atom))
 (= (unify-or-empty $a $a) unified)
 (= (unify-or-empty $a $b) (empty))

--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -18,8 +18,6 @@ use regex::Regex;
 use super::arithmetics::*;
 use super::string::*;
 
-pub const VOID_SYMBOL : Atom = sym!("%void%");
-
 fn unit_result() -> Result<Vec<Atom>, ExecError> {
     Ok(vec![UNIT_ATOM()])
 }
@@ -1187,7 +1185,7 @@ mod non_minimal_only_stdlib {
                 Ok(result) if result.is_empty() => {
                     cases.into_iter()
                         .find_map(|(pattern, template, _external_vars)| {
-                            if pattern == VOID_SYMBOL {
+                            if pattern == EMPTY_SYMBOL {
                                 Some(template)
                             } else {
                                 None
@@ -1864,10 +1862,10 @@ mod tests {
         let case_op = CaseOp::new(space.clone());
 
         assert_eq!(case_op.execute(&mut vec![expr!(("foo")),
-                expr!(((n "B") n) ("%void%" "D"))]),
+                expr!(((n "B") n) ("Empty" "D"))]),
             Ok(vec![Atom::sym("A")]));
         assert_eq!(case_op.execute(&mut vec![expr!({MatchOp{}} {space} ("B" "C") ("C" "B")),
-                expr!(((n "C") n) ("%void%" "D"))]),
+                expr!(((n "C") n) ("Empty" "D"))]),
             Ok(vec![Atom::sym("D")]));
     }
 

--- a/lib/src/metta/runner/stdlib_minimal.rs
+++ b/lib/src/metta/runner/stdlib_minimal.rs
@@ -408,8 +408,6 @@ impl Grounded for CaseOp {
         log::debug!("CaseOp::execute: atom results: {:?}", results);
         let results = match results {
             Ok(results) if results.is_empty() =>
-                // TODO: MINIMAL in minimal MeTTa we should use Empty in both
-                // places here and in (case ...) calls in code
                 vec![switch(EMPTY_SYMBOL)],
             Ok(results) =>
                 results.into_iter().map(|atom| switch(atom)).collect(),

--- a/lib/src/metta/runner/stdlib_minimal.rs
+++ b/lib/src/metta/runner/stdlib_minimal.rs
@@ -16,8 +16,6 @@ use std::convert::TryInto;
 use super::arithmetics::*;
 use super::string::*;
 
-pub const VOID_SYMBOL : Atom = sym!("%void%");
-
 fn unit_result() -> Result<Vec<Atom>, ExecError> {
     Ok(vec![UNIT_ATOM()])
 }
@@ -412,7 +410,7 @@ impl Grounded for CaseOp {
             Ok(results) if results.is_empty() =>
                 // TODO: MINIMAL in minimal MeTTa we should use Empty in both
                 // places here and in (case ...) calls in code
-                vec![switch(VOID_SYMBOL)],
+                vec![switch(EMPTY_SYMBOL)],
             Ok(results) =>
                 results.into_iter().map(|atom| switch(atom)).collect(),
             Err(err) => vec![Atom::expr([ERROR_SYMBOL, atom.clone(), Atom::sym(err)])],
@@ -633,13 +631,13 @@ mod tests {
 
     #[test]
     fn metta_case_empty() {
-        let result = run_program("!(case Empty ( (ok ok) (%void% nok) ))");
+        let result = run_program("!(case Empty ( (ok ok) (Empty nok) ))");
         assert_eq!(result, Ok(vec![vec![expr!("nok")]]));
-        let result = run_program("!(case (unify (C B) (C B) ok Empty) ( (ok ok) (%void% nok) ))");
+        let result = run_program("!(case (unify (C B) (C B) ok Empty) ( (ok ok) (Empty nok) ))");
         assert_eq!(result, Ok(vec![vec![expr!("ok")]]));
         let result = run_program("!(case (unify (B C) (C B) ok nok) ( (ok ok) (nok nok) ))");
         assert_eq!(result, Ok(vec![vec![expr!("nok")]]));
-        let result = run_program("!(case (unify (B C) (C B) ok Empty) ( (ok ok) (%void% nok) ))");
+        let result = run_program("!(case (unify (B C) (C B) ok Empty) ( (ok ok) (Empty nok) ))");
         assert_eq!(result, Ok(vec![vec![expr!("nok")]]));
     }
 

--- a/lib/tests/case.rs
+++ b/lib/tests/case.rs
@@ -49,11 +49,11 @@ fn test_case_operation() {
             (((Rel-P $y) (P $y))
             ((Rel-Q $y) (Q $y))))
 
-        ; %void% can be used to capture empty results
+        ; Empty can be used to capture empty results
         !(case (match &self ($rel B $x) ($rel $x))
             (((Rel-P $y) (P $y))
             ((Rel-Q $y) (Q $y))
-            (%void% no-match)))
+            (Empty no-match)))
 
         ; a functional example
         (= (maybe-inc $x)


### PR DESCRIPTION
I propose to get rid of `%void%` in `case` and replace it with `Empty`, since it is more consistent with minimal metta