### PR TITLE
Create OperationAtom if object is callable

### DIFF
--- a/python/hyperon/atoms.py
+++ b/python/hyperon/atoms.py
@@ -399,7 +399,9 @@ class OperationObject(GroundedObject):
             result = self.op(*args, **kwargs)
             if result is None:
                 return [Atoms.UNIT]
-            return [G(ValueObject(result), res_typ)]
+            if callable(result):
+                return [OperationAtom(repr(result), result, unwrap=True)]
+            return [ValueAtom(result, res_typ)]
         else:
             result = self.op(*atoms)
             if not isinstance(result, list):


### PR DESCRIPTION
Works similar to `py-atom`. If the object returned by Python code is callable, wrap it into `OperationAtom` instead of `ValueAtom`.