### PR TITLE
Separate custom matched grounded atoms and grounded atoms matched by equality

### DIFF
--- a/c/src/atom.rs
+++ b/c/src/atom.rs
@@ -618,14 +618,10 @@ impl Grounded for CGrounded {
         }
     }
 
-    fn match_(&self, other: &Atom) -> matcher::MatchResultIter {
+    fn as_match(&self) -> Option<&dyn CustomMatch> {
         match self.api().match_ {
-            Some(func) => {
-                let other: atom_ref_t = other.into();
-                let set = func(self.get_ptr(), &other);
-                Box::new(set.into_inner().into_iter())
-            },
-            None => match_by_equality(self, other)
+            None => None,
+            Some(_) => Some(self),
         }
     }
 
@@ -638,6 +634,20 @@ impl Grounded for CGrounded {
             None => Err(serial::Error::NotSupported),
         }
     }
+}
+
+impl CustomMatch for CGrounded {
+    fn match_(&self, other: &Atom) -> matcher::MatchResultIter {
+        match self.api().match_ {
+            Some(func) => {
+                let other: atom_ref_t = other.into();
+                let set = func(self.get_ptr(), &other);
+                Box::new(set.into_inner().into_iter())
+            },
+            None => match_by_equality(self, other)
+        }
+    }
+
 }
 
 impl PartialEq for CGrounded {

--- a/lib/examples/custom_match.rs
+++ b/lib/examples/custom_match.rs
@@ -31,7 +31,13 @@ impl Grounded for TestDict {
     fn execute(&self, _args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
         execute_not_executable(self)
     }
-    fn match_(&self, other: &Atom) -> matcher::MatchResultIter {
+    fn as_match(&self) -> Option<&dyn CustomMatch> {
+        Some(self)
+    }
+}
+
+impl CustomMatch for TestDict {
+    fn match_(&self, other: &Atom) -> MatchResultIter {
         if let Some(other) = other.as_gnd::<TestDict>() {
             other.0.iter().map(|(ko, vo)| {
                 self.0.iter().map(|(k, v)| {

--- a/lib/src/atom/matcher.rs
+++ b/lib/src/atom/matcher.rs
@@ -1441,6 +1441,12 @@ mod test {
         fn execute(&self, _args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
             execute_not_executable(self)
         }
+        fn as_match(&self) -> Option<&dyn CustomMatch> {
+            Some(self)
+        }
+    }
+
+    impl CustomMatch for Rand {
         fn match_(&self, other: &Atom) -> matcher::MatchResultIter {
             match other {
                 Atom::Expression(expr) if expr.children().len() == 1 =>
@@ -1485,6 +1491,12 @@ mod test {
         fn execute(&self, _args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
             execute_not_executable(self)
         }
+        fn as_match(&self) -> Option<&dyn CustomMatch> {
+            Some(self)
+        }
+    }
+
+    impl CustomMatch for ReturnPairInX {
         fn match_(&self, _other: &Atom) -> matcher::MatchResultIter {
             let result = vec![ bind!{ x: expr!("B") }, bind!{ x: expr!("C") } ];
             Box::new(result.into_iter())
@@ -1723,6 +1735,12 @@ mod test {
             fn execute(&self, _args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
                 execute_not_executable(self)
             }
+            fn as_match(&self) -> Option<&dyn CustomMatch> {
+                Some(self)
+            }
+        }
+
+        impl CustomMatch for Assigner {
             fn match_(&self, other: &Atom) -> matcher::MatchResultIter {
                 match other.iter().collect::<Vec<&Atom>>().as_slice() {
                     [ Atom::Variable(var), values @ .. ] => {

--- a/lib/src/atom/mod.rs
+++ b/lib/src/atom/mod.rs
@@ -303,10 +303,10 @@ pub fn make_variables_unique(mut atom: Atom) -> Atom {
 // values:
 // - type_() to return MeTTa type of the atom;
 // - execute() to represent functions as atoms;
-// - match_() to implement custom matching behaviour.
+// - as_match() to return optional custom matching behaviour API.
 
-// match_by_equality() method allows reusing default match_() implementation in
-// 3rd party code when it is not required to be customized.
+// By default Grounded::as_match() returns None which makes GroundedAtom's
+// implementation match atom by equality.
 
 /// Grounded function execution error.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -351,7 +351,21 @@ pub trait GroundedAtom : Any + Debug + Display {
         self.as_grounded().execute(args)
     }
     fn match_(&self, other: &Atom) -> matcher::MatchResultIter {
-        self.as_grounded().match_(other)
+        match self.as_grounded().as_match() {
+            Some(match_) => match_.match_(other),
+            None => {
+                let equal = match other {
+                    Atom::Grounded(other) => self.eq_gnd(other.as_ref()),
+                    _ => false,
+                };
+                let result = if equal {
+                    matcher::BindingsSet::single()
+                } else {
+                    matcher::BindingsSet::empty()
+                };
+                Box::new(result.into_iter())
+            },
+        }
     }
     // A mutable reference is used here instead of a type parameter because
     // the type parameter makes impossible using GroundedAtom reference in the
@@ -373,17 +387,16 @@ impl dyn GroundedAtom {
     }
 }
 
-/// Trait allows implementing grounded atom with custom behaviour.
-/// [rust_type_atom], [match_by_equality] and [execute_not_executable]
-/// functions can be used to implement default behavior if requried.
-/// If no custom behavior is needed then simpler way is using [Atom::value]
-/// function for automatic grounding.
+/// Trait allows implementing grounded atom with custom behavior.
+/// [rust_type_atom] and [execute_not_executable] functions can be used to
+/// implement default behavior if required. If no custom behavior is needed
+/// then simpler way is using [Atom::value] function for automatic grounding.
 ///
 /// # Examples
 ///
 /// ```
 /// use hyperon::*;
-/// use hyperon::matcher::{Bindings, MatchResultIter, match_atoms};
+/// use hyperon::matcher::{Bindings, match_atoms};
 /// use std::fmt::{Display, Formatter};
 /// use std::iter::once;
 ///
@@ -397,10 +410,6 @@ impl dyn GroundedAtom {
 ///
 ///     fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
 ///         execute_not_executable(self)
-///     }
-///
-///     fn match_(&self, other: &Atom) -> MatchResultIter {
-///         match_by_equality(self, other)
 ///     }
 /// }
 ///
@@ -428,15 +437,17 @@ pub trait Grounded : Display {
     /// it is called.
     fn type_(&self) -> Atom;
 
+    // TODO: move `Grounded::execute` into a separate trait similarly to `CustomMatch`
     /// Executes grounded function on passed `args` and returns list of
     /// results as `Vec<Atom>` or [ExecError].
     fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError>;
 
-    /// Implements custom matching logic of the grounded atom.
-    /// Gets `other` atom as input, returns the iterator of the
-    /// [matcher::Bindings] for the variables of the `other` atom.
-    /// See [matcher] for detailed explanation.
-    fn match_(&self, other: &Atom) -> matcher::MatchResultIter;
+    /// Returns reference to the custom matching API implementation. If `None`
+    /// is returned then atom is matched by equality.
+    /// See [CustomMatch] for details.
+    fn as_match(&self) -> Option<&dyn CustomMatch> {
+        None
+    }
 
     /// Implements serialization logic of the grounded atom. The logic is
     /// implemented in terms of the Rust native types.
@@ -446,6 +457,62 @@ pub trait Grounded : Display {
     }
 }
 
+/// Trait for implementing custom matching logic. In order to make it work
+/// one should also implement [Grounded::as_match] method.
+///
+/// # Examples
+///
+/// ```
+/// use hyperon::*;
+/// use hyperon::matcher::{BindingsSet, Bindings, MatchResultIter, match_atoms};
+/// use std::fmt::{Display, Formatter};
+/// use std::iter::once;
+///
+/// #[derive(Debug, PartialEq, Clone)]
+/// struct MyGrounded {}
+///
+/// impl Grounded for MyGrounded {
+///     fn type_(&self) -> Atom {
+///         rust_type_atom::<MyGrounded>()
+///     }
+///
+///     fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+///         execute_not_executable(self)
+///     }
+///
+///     fn as_match(&self) -> Option<&dyn CustomMatch> {
+///         Some(self)
+///     }
+/// }
+///
+/// impl CustomMatch for MyGrounded {
+///     fn match_(&self, other: &Atom) -> MatchResultIter {
+///         // Doesn't match with anything even with itself
+///         Box::new(BindingsSet::empty().into_iter())
+///     }
+/// }
+///
+/// impl Display for MyGrounded {
+///     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+///         write!(f, "MyGrounded")
+///     }
+/// }
+///
+/// let atom = Atom::gnd(MyGrounded{});
+/// let same = Atom::gnd(MyGrounded{});
+///
+/// assert_eq!(atom, same);
+/// assert_eq!(match_atoms(&atom, &same).collect::<Vec<Bindings>>(), vec![]);
+/// ```
+///
+pub trait CustomMatch {
+    /// Implements custom matching logic of the grounded atom.
+    /// Gets `other` atom as input, returns the iterator of the
+    /// [matcher::Bindings] for the variables of the `other` atom.
+    /// See [matcher] for detailed explanation.
+    fn match_(&self, other: &Atom) -> matcher::MatchResultIter;
+}
+
 /// Returns the name of the Rust type wrapped into [Atom::Symbol]. This is a
 /// default implementation of `type_()` for the grounded types wrapped
 /// automatically.
@@ -453,7 +520,7 @@ pub fn rust_type_atom<T>() -> Atom {
     Atom::sym(std::any::type_name::<T>())
 }
 
-/// Returns either single emtpy [matcher::Bindings] instance if `self` and
+/// Returns either single empty [matcher::Bindings] instance if `self` and
 /// `other` are equal or empty iterator if not. This is a default
 /// implementation of `match_()` for the grounded types wrapped automatically.
 pub fn match_by_equality<T: 'static + PartialEq + Debug>(this: &T, other: &Atom) -> matcher::MatchResultIter {
@@ -464,7 +531,7 @@ pub fn match_by_equality<T: 'static + PartialEq + Debug>(this: &T, other: &Atom)
     }
 }
 
-/// Returns either single emtpy [matcher::Bindings] instance if the string representing `self` and
+/// Returns either single empty [matcher::Bindings] instance if the string representing `self` and
 /// `other` render are identical strings, or an empty iterator if not.
 pub fn match_by_string_equality(this: &str, other: &Atom) -> matcher::MatchResultIter {
     let other_string = other.to_string();
@@ -521,10 +588,6 @@ impl<T: AutoGroundedType> Grounded for AutoGroundedAtom<T> {
 
     fn execute(&self, _args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
         execute_not_executable(self)
-    }
-
-    fn match_(&self, other: &Atom) -> matcher::MatchResultIter {
-        match_by_equality(&self.0, other)
     }
 }
 
@@ -1000,9 +1063,6 @@ mod test {
         fn execute(&self, _args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
             execute_not_executable(self)
         }
-        fn match_(&self, other: &Atom) -> matcher::MatchResultIter {
-            match_by_equality(self, other)
-        }
     }
 
     impl Display for TestInteger {
@@ -1020,9 +1080,6 @@ mod test {
         }
         fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
             Ok(vec![Atom::value(self.0 * args.get(0).unwrap().as_gnd::<i32>().unwrap())])
-        }
-        fn match_(&self, other: &Atom) -> matcher::MatchResultIter {
-            match_by_equality(self, other)
         }
     }
 

--- a/lib/src/common/mod.rs
+++ b/lib/src/common/mod.rs
@@ -44,10 +44,6 @@ impl Grounded for &'static Operation {
     fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
         (self.execute)(self, args)
     }
-
-    fn match_(&self, other: &Atom) -> matcher::MatchResultIter {
-        match_by_equality(self, other)
-    }
 }
 
 impl PartialEq for Operation {

--- a/lib/src/common/shared.rs
+++ b/lib/src/common/shared.rs
@@ -4,7 +4,6 @@ use std::rc::Rc;
 use std::cell::RefCell;
 use std::fmt::{Debug, Display};
 use crate::atom::*;
-use crate::matcher::MatchResultIter;
 
 pub trait LockBorrow<T: ?Sized> {
     fn borrow(&self) -> Box<dyn Deref<Target=T> + '_>;
@@ -164,12 +163,23 @@ impl<T: Grounded> Grounded for Shared<T> {
         rust_type_atom::<Self>()
     }
 
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        self.0.borrow().match_(other)
+    fn as_match(&self) -> Option<&dyn CustomMatch> {
+        match self.0.borrow().as_match() {
+            None => None,
+            Some(_) => Some(self),
+        }
     }
 
     fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
         self.0.borrow().execute(args)
+    }
+}
+
+impl<T: Grounded> CustomMatch for Shared<T> {
+    fn match_(&self, other: &Atom) -> matcher::MatchResultIter {
+        self.0.borrow().as_match()
+            .expect("Custom match procedure is not expected to be changed in runtime")
+            .match_(other)
     }
 }
 
@@ -203,13 +213,8 @@ mod tests {
         fn type_(&self) -> Atom {
             Atom::sym("IgnoredType")
         }
-        fn match_(&self, other: &Atom) -> MatchResultIter {
-            let vec = if *other == Atom::sym("matchable") {
-                vec![bind!{ x: Atom::sym("match") }]
-            } else {
-                Vec::new()
-            };
-            Box::new(vec.into_iter())
+        fn as_match(&self) -> Option<&dyn CustomMatch> {
+            Some(self)
         }
         fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
             let mut result = vec![Atom::sym("executed")];
@@ -218,12 +223,23 @@ mod tests {
         }
     }
 
+    impl CustomMatch for SharedGrounded {
+        fn match_(&self, other: &Atom) -> matcher::MatchResultIter {
+            let vec = if *other == Atom::sym("matchable") {
+                vec![bind!{ x: Atom::sym("match") }]
+            } else {
+                Vec::new()
+            };
+            Box::new(vec.into_iter())
+        }
+    }
+
     #[test]
     fn grounded_for_shared() {
         let shared = Shared::new(SharedGrounded{});
 
         assert_eq!(shared.type_(), Atom::sym("hyperon::common::shared::Shared<hyperon::common::shared::tests::SharedGrounded>"));
-        assert_eq!(shared.match_(&Atom::sym("matchable")).collect::<Vec<Bindings>>(), 
+        assert_eq!(shared.as_match().unwrap().match_(&Atom::sym("matchable")).collect::<Vec<Bindings>>(),
             vec![bind!{ x: Atom::sym("match") }]);
         assert_eq!(shared.execute(&mut vec![Atom::sym("arg")]), Ok(vec![Atom::sym("executed"), Atom::sym("arg")]));
     }

--- a/lib/src/metta/interpreter.rs
+++ b/lib/src/metta/interpreter.rs
@@ -907,9 +907,6 @@ mod tests {
         fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
             Err((*args[0].as_gnd::<&str>().unwrap()).into())
         }
-        fn match_(&self, other: &Atom) -> matcher::MatchResultIter {
-            match_by_equality(self, other)
-        }
     }
 
     impl Display for ThrowError {
@@ -936,9 +933,6 @@ mod tests {
         }
         fn execute(&self, _args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
             Err(ExecError::NoReduce)
-        }
-        fn match_(&self, other: &Atom) -> matcher::MatchResultIter {
-            match_by_equality(self, other)
         }
     }
 
@@ -981,9 +975,6 @@ mod tests {
         }
         fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
             Ok(vec![Atom::value(self.0 * args.get(0).unwrap().as_gnd::<i32>().unwrap())])
-        }
-        fn match_(&self, other: &Atom) -> matcher::MatchResultIter {
-            match_by_equality(self, other)
         }
     }
 

--- a/lib/src/metta/interpreter_minimal.rs
+++ b/lib/src/metta/interpreter_minimal.rs
@@ -1150,9 +1150,6 @@ mod tests {
         fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
             Err((*args[0].as_gnd::<&str>().unwrap()).into())
         }
-        fn match_(&self, other: &Atom) -> matcher::MatchResultIter {
-            match_by_equality(self, other)
-        }
     }
 
     impl Display for ThrowError {
@@ -1170,9 +1167,6 @@ mod tests {
         }
         fn execute(&self, _args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
             Err(ExecError::NoReduce)
-        }
-        fn match_(&self, other: &Atom) -> matcher::MatchResultIter {
-            match_by_equality(self, other)
         }
     }
 
@@ -1192,9 +1186,6 @@ mod tests {
         fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
             Ok(vec![Atom::value(self.0 * args.get(0).unwrap().as_gnd::<i32>().unwrap())])
         }
-        fn match_(&self, other: &Atom) -> matcher::MatchResultIter {
-            match_by_equality(self, other)
-        }
     }
 
     impl Display for MulXUndefinedType {
@@ -1212,9 +1203,6 @@ mod tests {
         }
         fn execute(&self, _args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
             Ok(vec![])
-        }
-        fn match_(&self, other: &Atom) -> matcher::MatchResultIter {
-            match_by_equality(self, other)
         }
     }
 

--- a/lib/src/metta/runner/arithmetics.rs
+++ b/lib/src/metta/runner/arithmetics.rs
@@ -1,6 +1,5 @@
 use crate::*;
 use crate::metta::*;
-use crate::matcher::MatchResultIter;
 use crate::atom::serial;
 
 use std::fmt::Display;
@@ -121,10 +120,6 @@ impl Grounded for Number {
         execute_not_executable(self)
     }
 
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
-    }
-
     fn serialize(&self, serializer: &mut dyn serial::Serializer) -> serial::Result {
         match self {
             &Self::Integer(n) => serializer.serialize_i64(n),
@@ -170,12 +165,18 @@ impl Grounded for Bool {
         execute_not_executable(self)
     }
 
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_bidirectional_equality(self, other)
+    fn as_match(&self) -> Option<&dyn CustomMatch> {
+        Some(self)
     }
 
     fn serialize(&self, serializer: &mut dyn serial::Serializer) -> serial::Result {
         serializer.serialize_bool(self.0)
+    }
+}
+
+impl CustomMatch for Bool {
+    fn match_(&self, other: &Atom) -> matcher::MatchResultIter {
+        match_by_bidirectional_equality(self, other)
     }
 }
 
@@ -208,10 +209,6 @@ macro_rules! def_binary_number_op {
                 };
 
                 Ok(vec![Atom::gnd(res)])
-            }
-
-            fn match_(&self, other: &Atom) -> MatchResultIter {
-                match_by_equality(self, other)
             }
         }
     }
@@ -250,10 +247,6 @@ macro_rules! def_binary_bool_op {
 
                 Ok(vec![Atom::gnd(Bool(a $op b))])
             }
-
-            fn match_(&self, other: &Atom) -> MatchResultIter {
-                match_by_equality(self, other)
-            }
         }
     }
 }
@@ -281,10 +274,6 @@ impl Grounded for FlipOp {
     fn execute(&self, _args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
         Ok(vec![Atom::gnd(Bool(rand::random()))])
     }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
-    }
 }
 
 
@@ -307,10 +296,6 @@ impl Grounded for NotOp {
         let &Bool(a) = args.get(0).ok_or_else(arg_error)?.as_gnd::<Bool>().ok_or_else(arg_error)?;
 
         Ok(vec![Atom::gnd(Bool(!a))])
-    }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
     }
 }
 

--- a/lib/src/metta/runner/mod.rs
+++ b/lib/src/metta/runner/mod.rs
@@ -1245,9 +1245,6 @@ mod tests {
             Ok(vec![expr!("Error" ("error") "TestError")])
             //Err("TestError".into())
         }
-        fn match_(&self, other: &Atom) -> crate::matcher::MatchResultIter {
-            match_by_equality(self, other)
-        }
     }
 
     #[test]
@@ -1297,9 +1294,6 @@ mod tests {
         }
         fn execute(&self, _args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
             Ok(vec![self.0.clone()])
-        }
-        fn match_(&self, other: &Atom) -> crate::matcher::MatchResultIter {
-            match_by_equality(self, other)
         }
     }
 

--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -1,5 +1,4 @@
 use crate::*;
-use crate::matcher::MatchResultIter;
 use crate::space::*;
 use crate::metta::*;
 use crate::metta::text::Tokenizer;
@@ -136,10 +135,6 @@ impl Grounded for ImportOp {
 
         unit_result()
     }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
-    }
 }
 
 /// A utility function to return the part of a string in between starting and ending quotes
@@ -218,10 +213,6 @@ impl Grounded for IncludeOp {
         // different from the way "eval-type" APIs work when called from host code, e.g. Rust
         Ok(eval_result.into_iter().last().unwrap_or_else(|| vec![]))
     }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
-    }
 }
 
 /// mod-space! returns the space of a specified module, loading the module if it's not loaded already
@@ -276,10 +267,6 @@ impl Grounded for ModSpaceOp {
         let space = Atom::gnd(context.metta().module_space(mod_id));
         Ok(vec![space])
     }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
-    }
 }
 
 /// Provides a way to access [Metta::load_module_at_path] from within MeTTa code
@@ -330,10 +317,6 @@ impl Grounded for RegisterModuleOp {
 
         unit_result()
     }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
-    }
 }
 
 /// This operation prints the modules loaded from the top of the runner
@@ -371,10 +354,6 @@ impl Grounded for PrintModsOp {
         self.metta.display_loaded_modules();
         unit_result()
     }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
-    }
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -408,10 +387,6 @@ impl Grounded for BindOp {
         self.tokenizer.borrow_mut().register_token(token_regex, move |_| { atom.clone() });
         unit_result()
     }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
-    }
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -435,10 +410,6 @@ impl Grounded for NewSpaceOp {
         } else {
             Err("new-space doesn't expect arguments".into())
         }
-    }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
     }
 }
 
@@ -464,10 +435,6 @@ impl Grounded for AddAtomOp {
         let space = Atom::as_gnd::<DynSpace>(space).ok_or("add-atom expects a space as the first argument")?;
         space.borrow_mut().add(atom.clone());
         unit_result()
-    }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
     }
 }
 
@@ -495,10 +462,6 @@ impl Grounded for RemoveAtomOp {
         // TODO? Is it necessary to distinguish whether the atom was removed or not?
         unit_result()
     }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
-    }
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -523,10 +486,6 @@ impl Grounded for GetAtomsOp {
         space.borrow().as_space().atom_iter()
             .map(|iter| iter.cloned().map(|a| make_variables_unique(a)).collect())
             .ok_or(ExecError::Runtime("Unsupported Operation. Can't traverse atoms in this space".to_string()))
-    }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
     }
 }
 
@@ -559,10 +518,6 @@ impl Grounded for PragmaOp {
         self.settings.borrow_mut().insert(key.into(), value.clone());
         unit_result()
     }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
-    }
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -593,10 +548,6 @@ impl Grounded for GetTypeOp {
 
         Ok(get_atom_types(self.space.borrow().as_space(), atom))
     }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
-    }
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -622,10 +573,6 @@ impl Grounded for GetTypeSpaceOp {
 
         Ok(get_atom_types(space, atom))
     }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
-    }
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -647,10 +594,6 @@ impl Grounded for GetMetaTypeOp {
         let atom = args.get(0).ok_or_else(arg_error)?;
 
         Ok(vec![get_meta_type(&atom)])
-    }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
     }
 }
 
@@ -674,10 +617,6 @@ impl Grounded for PrintlnOp {
         let atom = args.get(0).ok_or_else(arg_error)?;
         println!("{}", atom_to_string(atom));
         unit_result()
-    }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
     }
 }
 
@@ -706,10 +645,6 @@ impl Grounded for FormatArgsOp {
             .collect();
         let res = format.format(args.as_slice());
         Ok(vec![Atom::gnd(Str::from_string(res))])
-    }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
     }
 }
 
@@ -779,10 +714,6 @@ impl Grounded for TraceOp {
         eprintln!("{}", msg);
         Ok(vec![val.clone()])
     }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
-    }
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -801,10 +732,6 @@ impl Grounded for NopOp {
 
     fn execute(&self, _args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
         unit_result()
-    }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
     }
 }
 
@@ -842,11 +769,6 @@ impl Grounded for StateAtom {
     fn execute(&self, _args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
         execute_not_executable(self)
     }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        // Different state atoms with equal states are equal
-        match_by_equality(self, other)
-    }
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -868,10 +790,6 @@ impl Grounded for NewStateOp {
         let atom = args.get(0).ok_or(arg_error)?;
         Ok(vec![Atom::gnd(StateAtom::new(atom.clone()))])
     }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
-    }
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -887,10 +805,6 @@ impl Grounded for GetStateOp {
         let state = args.get(0).ok_or(arg_error)?;
         let atom = Atom::as_gnd::<StateAtom>(state).ok_or(arg_error)?;
         Ok(vec![atom.state.borrow().clone()])
-    }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
     }
 }
 
@@ -921,10 +835,6 @@ impl Grounded for ChangeStateOp {
         let new_value = args.get(1).ok_or(arg_error)?;
         *state.state.borrow_mut() = new_value.clone();
         Ok(vec![atom.clone()])
-    }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
     }
 }
 
@@ -964,10 +874,6 @@ impl Grounded for SealedOp {
 
         Ok(result)
     }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
-    }
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -990,10 +896,6 @@ impl Grounded for EqualOp {
         let b = args.get(1).ok_or_else(arg_error)?;
 
         Ok(vec![Atom::gnd(Bool(a == b))])
-    }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
     }
 }
 
@@ -1019,10 +921,6 @@ impl Grounded for MatchOp {
         log::debug!("MatchOp::execute: space: {:?}, pattern: {:?}, template: {:?}", space, pattern, template);
         let space = Atom::as_gnd::<DynSpace>(space).ok_or("match expects a space as the first argument")?;
         Ok(space.borrow().subst(&pattern, &template))
-    }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
     }
 }
 
@@ -1063,10 +961,6 @@ impl Grounded for UniqueOp {
         });
         Ok(result)
     }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
-    }
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -1103,10 +997,6 @@ impl Grounded for UnionOp {
         lhs_result.extend(rhs_result);
 
         Ok(lhs_result)
-    }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
     }
 }
 
@@ -1184,10 +1074,6 @@ impl Grounded for IntersectionOp {
 
         Ok(lhs_result)
     }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
-    }
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -1264,10 +1150,6 @@ impl Grounded for SubtractionOp {
 
         Ok(lhs_result)
     }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
-    }
 }
 
 /// The internal `non_minimal_only_stdlib` module contains code that is never used by the minimal stdlib
@@ -1306,10 +1188,6 @@ mod non_minimal_only_stdlib {
             let car = chld.get(0).ok_or("car-atom expects non-empty expression")?;
             Ok(vec![car.clone()])
         }
-
-        fn match_(&self, other: &Atom) -> MatchResultIter {
-            match_by_equality(self, other)
-        }
     }
 
     #[derive(Clone, PartialEq, Debug)]
@@ -1337,10 +1215,6 @@ mod non_minimal_only_stdlib {
                 Ok(vec![Atom::expr(cdr)])
             }
         }
-
-        fn match_(&self, other: &Atom) -> MatchResultIter {
-            match_by_equality(self, other)
-        }
     }
 
     #[derive(Clone, PartialEq, Debug)]
@@ -1365,10 +1239,6 @@ mod non_minimal_only_stdlib {
             let mut res = vec![atom.clone()];
             res.extend(chld.clone());
             Ok(vec![Atom::expr(res)])
-        }
-
-        fn match_(&self, other: &Atom) -> MatchResultIter {
-            match_by_equality(self, other)
         }
     }
 
@@ -1398,10 +1268,6 @@ mod non_minimal_only_stdlib {
             let arg_error = || ExecError::from("capture expects one argument");
             let atom = args.get(0).ok_or_else(arg_error)?;
             interpret_no_error(self.space.clone(), &atom).map_err(|e| ExecError::from(e))
-        }
-
-        fn match_(&self, other: &Atom) -> MatchResultIter {
-            match_by_equality(self, other)
         }
     }
 
@@ -1502,10 +1368,6 @@ mod non_minimal_only_stdlib {
         fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
             CaseOp::execute(self, args)
         }
-
-        fn match_(&self, other: &Atom) -> MatchResultIter {
-            match_by_equality(self, other)
-        }
     }
 
     fn assert_results_equal(actual: &Vec<Atom>, expected: &Vec<Atom>, atom: &Atom) -> Result<Vec<Atom>, ExecError> {
@@ -1549,10 +1411,6 @@ mod non_minimal_only_stdlib {
 
             assert_results_equal(&actual, &expected, actual_atom)
         }
-
-        fn match_(&self, other: &Atom) -> MatchResultIter {
-            match_by_equality(self, other)
-        }
     }
 
     #[derive(Clone, PartialEq, Debug)]
@@ -1588,10 +1446,6 @@ mod non_minimal_only_stdlib {
 
             assert_results_equal(&actual, expected, actual_atom)
         }
-
-        fn match_(&self, other: &Atom) -> MatchResultIter {
-            match_by_equality(self, other)
-        }
     }
 
     #[derive(Clone, PartialEq, Debug)]
@@ -1625,10 +1479,6 @@ mod non_minimal_only_stdlib {
             let result = interpret_no_error(self.space.clone(), atom)?;
 
             Ok(vec![Atom::expr(result)])
-        }
-
-        fn match_(&self, other: &Atom) -> MatchResultIter {
-            match_by_equality(self, other)
         }
     }
 
@@ -1668,10 +1518,6 @@ mod non_minimal_only_stdlib {
             }
             Ok(superposed)
         }
-
-        fn match_(&self, other: &Atom) -> MatchResultIter {
-            match_by_equality(self, other)
-        }
     }
 
     #[derive(Clone, PartialEq, Debug)]
@@ -1702,10 +1548,6 @@ mod non_minimal_only_stdlib {
             let result = bindings.map(|b| { matcher::apply_bindings_to_atom_move(template.clone(), &b) }).collect();
             log::debug!("LetOp::execute: pattern: {}, atom: {}, template: {}, result: {:?}", pattern, atom, template, result);
             Ok(result)
-        }
-
-        fn match_(&self, other: &Atom) -> MatchResultIter {
-            match_by_equality(self, other)
         }
     }
 
@@ -1773,10 +1615,6 @@ mod non_minimal_only_stdlib {
                         Atom::expr([Atom::gnd(LetVarOp{}), Atom::expr(tail), template])])])
                 },
             }
-        }
-
-        fn match_(&self, other: &Atom) -> MatchResultIter {
-            match_by_equality(self, other)
         }
     }
 
@@ -2585,10 +2423,6 @@ mod tests {
 
         fn execute(&self, _args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
             execute_not_executable(self)
-        }
-
-        fn match_(&self, other: &Atom) -> MatchResultIter {
-            match_by_equality(self, other)
         }
     }
 

--- a/lib/src/metta/runner/stdlib_minimal.rs
+++ b/lib/src/metta/runner/stdlib_minimal.rs
@@ -1,5 +1,4 @@
 use crate::*;
-use crate::matcher::MatchResultIter;
 use crate::space::*;
 use crate::metta::*;
 use crate::metta::text::Tokenizer;
@@ -44,10 +43,6 @@ impl Grounded for PrintAlternativesOp {
         println!("{} {}:", args.len(), atom);
         args.iter().for_each(|arg| println!("    {}", arg));
         Ok(vec![UNIT_ATOM()])
-    }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
     }
 }
 
@@ -101,10 +96,6 @@ impl Grounded for GetTypeOp {
             Ok(types)
         }
     }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
-    }
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -133,10 +124,6 @@ impl Grounded for IfEqualOp {
         } else {
             Ok(vec![else_.clone()])
         }
-    }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
     }
 }
 
@@ -198,10 +185,6 @@ impl Grounded for AssertEqualOp {
 
         assert_results_equal(&actual, &expected, actual_atom)
     }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
-    }
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -237,10 +220,6 @@ impl Grounded for AssertEqualToResultOp {
         let actual = interpret_no_error(self.space.clone(), actual_atom)?;
 
         assert_results_equal(&actual, expected, actual_atom)
-    }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
     }
 }
 
@@ -284,10 +263,6 @@ impl Grounded for SuperposeOp {
             Ok(superposed)
         }
     }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
-    }
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -322,10 +297,6 @@ impl Grounded for CollapseOp {
 
         Ok(vec![Atom::expr(result)])
     }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
-    }
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -354,10 +325,6 @@ impl Grounded for CaptureOp {
         let arg_error = || ExecError::from("capture expects one argument");
         let atom = args.get(0).ok_or_else(arg_error)?;
         interpret(self.space.clone(), &atom).map_err(|e| ExecError::from(e))
-    }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
     }
 }
 
@@ -414,10 +381,6 @@ impl Grounded for CaseOp {
             Err(err) => vec![Atom::expr([ERROR_SYMBOL, atom.clone(), Atom::sym(err)])],
         };
         Ok(results)
-    }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
     }
 }
 
@@ -1112,10 +1075,6 @@ mod tests {
 
         fn execute(&self, _args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
             execute_not_executable(self)
-        }
-
-        fn match_(&self, other: &Atom) -> MatchResultIter {
-            match_by_equality(self, other)
         }
     }
 

--- a/lib/src/metta/runner/string.rs
+++ b/lib/src/metta/runner/string.rs
@@ -1,6 +1,5 @@
 use crate::*;
 use crate::common::collections::ImmutableString;
-use crate::matcher::MatchResultIter;
 use crate::serial;
 
 pub const ATOM_TYPE_STRING : Atom = sym!("String");
@@ -27,10 +26,6 @@ impl Grounded for Str {
 
     fn execute(&self, _args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
         execute_not_executable(self)
-    }
-
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        match_by_equality(self, other)
     }
 
     fn serialize(&self, serializer: &mut dyn serial::Serializer) -> serial::Result {

--- a/lib/src/metta/types.rs
+++ b/lib/src/metta/types.rs
@@ -312,12 +312,18 @@ impl Grounded for UndefinedTypeMatch {
         ATOM_TYPE_TYPE
     }
 
-    fn match_(&self, _other: &Atom) -> crate::matcher::MatchResultIter {
-        Box::new(std::iter::once(crate::matcher::Bindings::new()))
+    fn as_match(&self) -> Option<&dyn CustomMatch> {
+        Some(self)
     }
 
     fn execute(&self, _args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
         execute_not_executable(self)
+    }
+}
+
+impl CustomMatch for UndefinedTypeMatch {
+    fn match_(&self, _other: &Atom) -> matcher::MatchResultIter {
+        Box::new(std::iter::once(crate::matcher::Bindings::new()))
     }
 }
 
@@ -795,9 +801,6 @@ mod tests {
 
         fn execute(&self, _args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
             execute_not_executable(self)
-        }
-        fn match_(&self, other: &Atom) -> matcher::MatchResultIter {
-            match_by_equality(self, other)
         }
     }
 

--- a/lib/src/space/grounding.rs
+++ b/lib/src/space/grounding.rs
@@ -4,7 +4,7 @@
 use crate::*;
 use super::*;
 use crate::atom::*;
-use crate::atom::matcher::{MatchResultIter, match_atoms};
+use crate::atom::matcher::match_atoms;
 use crate::atom::subexpr::split_expr;
 use crate::common::multitrie::{MultiTrie, TrieKey, TrieToken};
 
@@ -378,12 +378,18 @@ impl Grounded for GroundingSpace {
         rust_type_atom::<GroundingSpace>()
     }
 
-    fn match_(&self, other: &Atom) -> MatchResultIter {
-        Box::new(self.query(other).into_iter())
+    fn as_match(&self) -> Option<&dyn CustomMatch> {
+        Some(self)
     }
 
     fn execute(&self, _args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
         execute_not_executable(self)
+    }
+}
+
+impl CustomMatch for GroundingSpace {
+    fn match_(&self, other: &Atom) -> matcher::MatchResultIter {
+        Box::new(self.query(other).into_iter())
     }
 }
 

--- a/lib/src/space/mod.rs
+++ b/lib/src/space/mod.rs
@@ -360,12 +360,18 @@ impl crate::atom::Grounded for DynSpace {
         rust_type_atom::<DynSpace>()
     }
 
-    fn match_(&self, other: &Atom) -> matcher::MatchResultIter {
-        Box::new(self.query(other).into_iter())
+    fn as_match(&self) -> Option<&dyn CustomMatch> {
+        Some(self)
     }
 
     fn execute(&self, _args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
         execute_not_executable(self)
+    }
+}
+
+impl CustomMatch for DynSpace {
+    fn match_(&self, other: &Atom) -> matcher::MatchResultIter {
+        Box::new(self.query(other).into_iter())
     }
 }
 


### PR DESCRIPTION
Separate custom matched grounded atoms and grounded atoms matched by equality to address https://github.com/trueagi-io/hyperon-experimental/pull/698/files#r1623809472

We cannot understand whether custom matching is implemented on a grounded atom because of lack of the specialization feature in stable Rust, so I compared two approaches:
- returning optional matching procedure `fn Grounded::get_match(&self) -> Option<Box<dyn Fn(&Atom) -> MatchResultsIter>>`
- and adding separate `fn Grounded::as_match(&self) -> Option<&dyn CustomMatch>`
- having separate flag `Grounded::has_custom_matching`

I chosen last one because:
- it seems more clean and logical to me having each separate customization aspect as a separate trait
- if specialization is available in a stable Rust we can automatize it
- returning closures from `get_match` requires additional boxing and looks more surprising than implementing a trait

I like this approach finally and I think we could reuse it to implement `Hash` on value-like grounded atoms and to move `execute` into a separate trait.

Despite change is big most interesting files are:
- `lib/src/atom/mod.rs`
- `lib/src/common/shared.rs`
- `c/src/atom.rs`

Other files contains removed default `match_by_equality` logic and rearranging custom matching logic to match new API.

@Adam-Vandervorst FYI (cannot add you as a reviewer).