### PR TITLE
Fix returning values through variables as actual parameters

### DIFF
--- a/lib/src/atom/matcher.rs
+++ b/lib/src/atom/matcher.rs
@@ -617,22 +617,6 @@ impl Bindings {
         self
     }
 
-    /// Keep only variables passed in vars
-    pub fn retain<F>(&mut self, f: F) where F: Fn(&VariableAtom) -> bool {
-        let to_remove: Vec<VariableAtom> = self.binding_by_var.keys()
-            .filter_map(|var| {
-                if !f(var) {
-                    Some(var.clone())
-                } else {
-                    None
-                }
-            }).collect();
-
-        for var in &to_remove {
-            self.remove_var_from_binding(var);
-        }
-    }
-
     pub fn has_loops(&self) -> bool {
         for binding in &self.bindings {
             let mut used_bindings = bitset::BitSet::with_capacity(self.bindings.index_upper_bound());
@@ -1777,31 +1761,37 @@ mod test {
 
     #[test]
     fn bindings_retain() -> Result<(), &'static str> {
+        let mut atom = expr!(a b);
         let mut bindings = Bindings::new()
             .add_var_equality(&VariableAtom::new("a"), &VariableAtom::new("b"))?;
-        bindings.retain(|v| *v == VariableAtom::new("a") || *v == VariableAtom::new("b"));
+        bindings.apply_and_retain(&mut atom, |v| *v == VariableAtom::new("a") || *v == VariableAtom::new("b"));
         assert_eq!(bindings, bind!{ a: expr!(b) });
+        assert_eq!(atom, expr!(a b));
 
+        let mut atom = expr!(a b c d e);
         let mut bindings = Bindings::new()
             .add_var_equality(&VariableAtom::new("a"), &VariableAtom::new("b"))?
             .add_var_binding_v2(VariableAtom::new("b"), expr!("B" d))?
-            .add_var_binding_v2(VariableAtom::new("c"), expr!("c"))?
+            .add_var_binding_v2(VariableAtom::new("c"), expr!("C"))?
             .add_var_binding_v2(VariableAtom::new("d"), expr!("D"))?
             .with_var_no_value(&VariableAtom::new("e"));
-        bindings.retain(|v| *v == VariableAtom::new("b") || *v == VariableAtom::new("e"));
+        bindings.apply_and_retain(&mut atom, |v| *v == VariableAtom::new("b") || *v == VariableAtom::new("e"));
         let expected = Bindings::new()
             .add_var_binding_v2(VariableAtom::new("b"), expr!("B" d))?
             .with_var_no_value(&VariableAtom::new("e"));
         assert_eq!(bindings, expected);
+        assert_eq!(atom, expr!(("B" "D") b "C" "D" e));
         Ok(())
     }
 
     #[test]
     fn bindings_retain_all() -> Result<(), &'static str> {
+        let mut atom = expr!(a b);
         let mut bindings = Bindings::new()
             .add_var_equality(&VariableAtom::new("a"), &VariableAtom::new("b"))?;
-        bindings.retain(|_| false);
+        bindings.apply_and_retain(&mut atom, |_| false);
         assert!(bindings.is_empty());
+        assert_eq!(atom, expr!(a b));
         Ok(())
     }
 

--- a/lib/src/metta/interpreter.rs
+++ b/lib/src/metta/interpreter.rs
@@ -250,8 +250,7 @@ impl InterpreterCache {
     fn insert(&mut self, key: Atom, mut value: Results) {
         value.iter_mut().for_each(|res| {
             let vars: HashSet<&VariableAtom> = key.iter().filter_type::<&VariableAtom>().collect();
-            apply_bindings_to_atom_mut(&mut res.0, &res.1);
-            res.1.retain(|v| vars.contains(v));
+            res.1.apply_and_retain(&mut res.0, |v| vars.contains(v));
         });
         self.0.insert(key, value)
     }

--- a/lib/src/metta/interpreter_minimal.rs
+++ b/lib/src/metta/interpreter_minimal.rs
@@ -896,43 +896,39 @@ mod tests {
     #[test]
     fn interpret_atom_evaluate_variable_via_call_direct_equality() {
         let space = space("
-            (= (foo $x) (function
-              (chain (eval (bar $x)) $_ (return ())) ))
-            (= (bar $x) (function
-              ; fake internal call which wipes variables equalities
-              (chain (function (return ())) $_
-              (unify $x value
+            (= (bar) (function (return ())))
+            (= (foo $b) (function
+              (chain (eval (bar)) $_
+              (unify $b value
                 (return ())
                 (return (Error () \"Unexpected error\")) ))))");
         let result = call_interpret(&space,
-            &metta_atom("(chain (eval (foo $y)) $_ $y)"));
+            &metta_atom("(chain (eval (foo $a)) $_ $a)"));
         assert_eq!(result[0], sym!("value"));
     }
 
     #[test]
     fn interpret_atom_evaluate_variable_via_call_struct_equality() {
         let formal_arg_struct = space("
-            (= (foo ($x)) (function
-              (chain (eval (bar $x)) $_ (return ())) ))
-            (= (bar ($x)) (function
-              ; fake internal call which wipes variables equalities
-              (chain (function (return ())) $_
-              (unify $x value
+            (= (bar) (function (return ())))
+            (= (foo ($b)) (function
+              (chain (eval (bar)) $_
+              (unify $b value
                 (return ())
                 (return (Error () \"Unexpected error\")) ))))");
         let result = call_interpret(&formal_arg_struct,
-            &metta_atom("(chain (eval (foo $y)) $_ $y)"));
-        assert_eq!(result[0], expr!((("value"))));
+            &metta_atom("(chain (eval (foo $a)) $_ $a)"));
+        assert_eq!(result[0], expr!(("value")));
 
         let actual_arg_struct = space("
-            (= (foo $x) (function
-              ; fake internal call which wipes variables equalities
-              (chain (function (return ())) $_
-              (unify $x (value)
+            (= (bar) (function (return ())))
+            (= (foo $b) (function
+              (chain (eval (bar)) $_
+              (unify $b (value)
                 (return ())
                 (return (Error () \"Unexpected error\")) ))))");
         let result = call_interpret(&actual_arg_struct,
-            &metta_atom("(chain (eval (foo ($y))) $_ $y)"));
+            &metta_atom("(chain (eval (foo ($a))) $_ $a)"));
         assert_eq!(result[0], sym!("value"));
     }
 

--- a/lib/src/metta/runner/stdlib_minimal.rs
+++ b/lib/src/metta/runner/stdlib_minimal.rs
@@ -532,9 +532,7 @@ mod tests {
         let result = run_program("!(eval (car-atom (A $b)))");
         assert_eq!(result, Ok(vec![vec![expr!("A")]]));
         let result = run_program("!(eval (car-atom ($a B)))");
-        //assert_eq!(result, Ok(vec![vec![expr!(a)]]));
-        assert!(result.is_ok_and(|res| res.len() == 1 && res[0].len() == 1 &&
-            atoms_are_equivalent(&res[0][0], &expr!(a))));
+        assert_eq!(result, Ok(vec![vec![expr!(a)]]));
         let result = run_program("!(eval (car-atom ()))");
         assert_eq!(result, Ok(vec![vec![expr!("Error" ("car-atom" ()) {Str::from_str("car-atom expects a non-empty expression as an argument")})]]));
         let result = run_program("!(eval (car-atom A))");


### PR DESCRIPTION
When call is made using variable as an actual parameter the variables equality is kept in stack frame bindings to track the value of the variable. At the same time as formal argument variables are local they are not added into the `Stack::vars` set. Thus it is possible that variable equality is wiped when returning from the next nested call. And if after this call value is assigned to the formal argument variable this value will not be assigned to the actual argument variable.

In the following example:
```
(= (bar) (function (return ())))

(= (foo $b) (function
  ; fake internal call which wipes variables equalities
  (chain (eval (bar)) $_
  (unify $b value
    (return ())
    (return (Error () \"Unexpected error\")) ))))");

!(chain (eval (foo $a)) $_ $a)
```

calling `(foo $a)` adds variable equality `{ $a = $b }` into bindings and `$a` is kept inside `Stack::vars` of the first frame because its value should be passed from the first `chain`'s argument to the last one. After executing `(chain (function (return ())) $_` bindings are being cleaned up and variable equality is removed from bindings. Thus when `$b` receives value it is not propagated to the `$a`

This fix replaces formal argument variables in a body of a called function by the actual argument value or variable. In the particular case above variable `$b` in `(unify $b value (return ()) (return (Error () \"Unexpected error\")) )` is replaced by variable `$a` and value is assigned properly.