### PR TITLE
[BUGFIX] Fixing DAS vars resolution

### DIFF
--- a/c/src/atom.rs
+++ b/c/src/atom.rs
@@ -236,15 +236,27 @@ pub unsafe extern "C" fn atom_expr_from_vec(children: atom_vec_t) -> atom_t {
     Atom::expr(children).into()
 }
 
-/// @brief Create a new Variable atom with the specified identifier
+/// @brief Create a new Variable atom with the specified name
 /// @ingroup atom_group
-/// @param[in]  name  The identifier for the newly created Variable atom
+/// @param[in]  name  The name for the newly created Variable atom
 /// @return An `atom_t` for the Variable atom
 /// @note The caller must take ownership responsibility for the returned `atom_t`
 ///
 #[no_mangle]
 pub unsafe extern "C" fn atom_var(name: *const c_char) -> atom_t {
     Atom::var(cstr_as_str(name)).into()
+}
+
+/// @brief Create a new Variable atom with the specified name and id
+/// @ingroup atom_group
+/// @param[in]  name  The name for the newly created Variable atom
+/// @param[in]  id    The unique id for the newly created Variable atom
+/// @return An `atom_t` for the Variable atom
+/// @note The caller must take ownership responsibility for the returned `atom_t`
+///
+#[no_mangle]
+pub unsafe extern "C" fn atom_var_with_id(name: *const c_char, id: usize) -> atom_t {
+    Atom::var_with_id(cstr_as_str(name), id).into()
 }
 
 /// @ingroup atom_group

--- a/lib/src/atom/mod.rs
+++ b/lib/src/atom/mod.rs
@@ -816,6 +816,25 @@ impl Atom {
         Self::Variable(VariableAtom::new(name))
     }
 
+    /// Constructs variable out of name and id.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hyperon::Atom;
+    ///
+    /// let a = Atom::var_with_id("a", 1);
+    /// let aa = Atom::var_with_id("a", 1);
+    /// let b = Atom::var_with_id("b", 2);
+    ///
+    /// assert_eq!(a.to_string(), "$a#1");
+    /// assert_eq!(a, aa);
+    /// assert_ne!(a, b);
+    /// ```
+    pub fn var_with_id<T: Into<String>>(name: T, id: usize) -> Self {
+        Self::Variable(VariableAtom::new_id(name, id))
+    }
+
     /// Constructs grounded atom with customized behaviour.
     /// See [Grounded] for examples.
     pub fn gnd<T: CustomGroundedType>(gnd: T) -> Atom {

--- a/python/hyperon/atoms.py
+++ b/python/hyperon/atoms.py
@@ -88,7 +88,13 @@ class VariableAtom(Atom):
 
 def V(name):
     """A convenient method to construct a VariableAtom"""
-    return VariableAtom(hp.atom_var(name))
+    if '#' in name:
+        vname, vid = name.split('#')[0:2]
+        vid = int(vid)
+    else:
+        vname = name
+        vid = 0
+    return VariableAtom(hp.atom_var(vname, vid))
 
 class ExpressionAtom(Atom):
     """An ExpressionAtom combines different kinds of Atoms, including expressions."""
@@ -566,7 +572,7 @@ class Bindings:
     def add_var_binding(self, var: Union[str, Atom], atom: Atom) -> bool:
         """Adds a binding between a variable and an Atom."""
         if isinstance(var, Atom):
-            return hp.bindings_add_var_binding(self.cbindings, var.get_name(), atom.catom)
+            return hp.bindings_add_var_binding(self.cbindings, var.catom, atom.catom)
         else:
             return hp.bindings_add_var_binding(self.cbindings, var, atom.catom)
 

--- a/python/hyperonpy.cpp
+++ b/python/hyperonpy.cpp
@@ -656,7 +656,7 @@ PYBIND11_MODULE(hyperonpy, m) {
     py::class_<CAtom>(m, "CAtom");
 
     m.def("atom_sym", [](char const* name) { return CAtom(atom_sym(name)); }, "Create symbol atom");
-    m.def("atom_var", [](char const* name, int id = 0) { return CAtom(atom_var_with_id(name, id)); }, "Create variable atom");
+    m.def("atom_var", [](char const* name, unsigned int id = 0) { return CAtom(atom_var_with_id(name, id)); }, "Create variable atom");
     m.def("atom_expr", [](py::list _children) {
             size_t size = py::len(_children);
             atom_t children[size];

--- a/python/hyperonpy.cpp
+++ b/python/hyperonpy.cpp
@@ -656,7 +656,7 @@ PYBIND11_MODULE(hyperonpy, m) {
     py::class_<CAtom>(m, "CAtom");
 
     m.def("atom_sym", [](char const* name) { return CAtom(atom_sym(name)); }, "Create symbol atom");
-    m.def("atom_var", [](char const* name) { return CAtom(atom_var(name)); }, "Create variable atom");
+    m.def("atom_var", [](char const* name, int id = 0) { return CAtom(atom_var_with_id(name, id)); }, "Create variable atom");
     m.def("atom_expr", [](py::list _children) {
             size_t size = py::len(_children);
             atom_t children[size];
@@ -754,6 +754,11 @@ PYBIND11_MODULE(hyperonpy, m) {
     m.def("bindings_add_var_binding",
           [](CBindings bindings, char const* varName, CAtom atom) {
               return bindings_add_var_binding(bindings.ptr(), atom_var(varName), atom_clone(atom.ptr()));
+          },
+          "Links variable to atom" );
+    m.def("bindings_add_var_binding",
+          [](CBindings bindings, CAtom var, CAtom atom) {
+              return bindings_add_var_binding(bindings.ptr(), atom_clone(var.ptr()), atom_clone(atom.ptr()));
           },
           "Links variable to atom" );
     m.def("bindings_is_empty", [](CBindings bindings){ return bindings_is_empty(bindings.ptr());}, "Returns true if bindings is empty");


### PR DESCRIPTION
### Rationale
While working with MeTTa and DAS Gate, I faced the following situation: the same query that works perfectly with the built-in atom space, when executed using DAS, does not resolve some variables if a function is defined and called to match some condition.
For example:
```
[(parent of Paul = $y#40)]
[(parent of Paul = John)]
```
The first line is the output of a query on DAS. And the second one comes from the same query but using the built-in space.

The issue does not happen on DAS if the match is made without calling a function.
For example, this query fails (output shows a non-resolved variable):
```lisp
(= (get_parent_from_das $x) (match &das (Parent $y $x) $y))
!(parent of Paul = (get_parent_from_das Paul))
```
However, this `match` works perfectly (it shows the value):
```lisp
!(match &das (Parent $y Paul) (parent of Paul = $y))
```
And both queries are equivalent.

### Sample Script
(two first queries do not have variables properly resolved)
```lisp
!(import! &self das_gate)

!(bind! &das (new-das))
!(bind! &local (new-space))

!(add-atom &das (Parent John Paul))  ; Paul is child of John
!(add-atom &das (Person Paul))

!(add-atom &local (Parent John Paul))  ; Paul is child of John
!(add-atom &local (Person Paul))

; getting parent from das using a function
(= (get_parent_from_das $x)
    (match &das (Parent $y $x) $y))
!(parent of Paul = (get_parent_from_das Paul))  ; person as a constant
!(match &das (Person $x)  ; person as a wildcard
    (parent of $x = (get_parent_from_das $x)))

; getting parent from das, inline, no function
!(match &das (Parent $y Paul) (parent of Paul = $y))  ; person as a constant
!(match &das (Person $x)  ; person as a wildcard
    (parent of $x = (match &das (Parent $y $x) $y)))

; getting parent from local using a function
(= (get_parent_from_local $x)
    (match &local (Parent $y $x) $y))
!(parent of Paul = (get_parent_from_local Paul))  ; person as a constant
!(match &local (Person $x)  ; person as a wildcard
    (parent of $x = (get_parent_from_local $x)))

; getting parent from local, inline, no function
!(match &local (Parent $y Paul) (parent of Paul = $y))  ; person as a constant
!(match &local (Person $x)  ; person as a wildcard
    (parent of $x = (match &local (Parent $y $x) $y)))
```
Output is:
(two first lines should show `John` instead of `$y#40` and `$y#55`)
```
[(Parent of Paul = $y#40)]
[(Parent of Paul = $y#55)]
[(Parent of Paul = John)]
[(Parent of Paul = John)]
[(Parent of Paul = John)]
[(Parent of Paul = John)]
[(Parent of Paul = John)]
[(Parent of Paul = John)]
```
### Vitaly's feedback on Mattermost
> Issue is on the DAS gate side. Variable's identity in hyperon-experimental consists of two parts: variable name and unique id. When DAS Gate converts variables to the DAS variables it merges these two parts into the the name like `y#39`. But when value is returned and should be applied to the template variable in template is not converted and has name `y` with `39` as unique id. Thus these two variables are not matched and value is not substituted. It is not a case for the simple query where variables doesn't have unique identifier. 