### PR TITLE
Add Metta.evaluate_atom() method to the Python API

### DIFF
--- a/lib/src/metta/runner/mod.rs
+++ b/lib/src/metta/runner/mod.rs
@@ -442,8 +442,6 @@ impl Metta {
         state.run_to_completion()
     }
 
-    // TODO: this method is deprecated and should be removed after switching
-    // to the minimal MeTTa
     pub fn evaluate_atom(&self, atom: Atom) -> Result<Vec<Atom>, String> {
         #[cfg(feature = "minimal")]
         let atom = if is_bare_minimal_interpreter(self) {

--- a/python/hyperon/runner.py
+++ b/python/hyperon/runner.py
@@ -205,13 +205,21 @@ class MeTTa:
         """Runs the MeTTa code from the program string containing S-Expression MeTTa syntax"""
         parser = SExprParser(program)
         results = hp.metta_run(self.cmetta, parser.cparser)
-        err_str = hp.metta_err_str(self.cmetta)
-        if (err_str is not None):
-            raise RuntimeError(err_str)
+        self._run_check_for_error()
         if flat:
             return [Atom._from_catom(catom) for result in results for catom in result]
         else:
             return [[Atom._from_catom(catom) for catom in result] for result in results]
+
+    def evaluate_atom(self, atom):
+        result = hp.metta_evaluate_atom(self.cmetta, atom.catom)
+        self._run_check_for_error()
+        return [Atom._from_catom(catom) for catom in result]
+
+    def _run_check_for_error(self):
+        err_str = hp.metta_err_str(self.cmetta)
+        if (err_str is not None):
+            raise RuntimeError(err_str)
 
 class Environment:
     """This class contains the API for configuring the host platform interface used by MeTTa"""

--- a/python/tests/test_metta.py
+++ b/python/tests/test_metta.py
@@ -34,6 +34,22 @@ class MettaTest(unittest.TestCase):
 
         self.assertEqual([[S('T')]], result)
 
+    def test_metta_evaluate_atom(self):
+        program = '''
+            (= (And T T) T)
+            (= (frog $x)
+                (And (croaks $x)
+                     (eat_flies $x)))
+            (= (croaks Fritz) T)
+            (= (eat_flies Fritz) T)
+            (= (green $x) (frog $x))
+        '''
+        runner = MeTTa(env_builder=Environment.test_env())
+        runner.run(program)
+        result = runner.evaluate_atom(E(S('green'), S('Fritz')))
+
+        self.assertEqual([S('T')], result)
+
     def test_incremental_runner(self):
         program = '''
             !(+ 1 (+ 2 (+ 3 4)))


### PR DESCRIPTION
It is required to migrate metta-motto code to the latest MeTTa interpreter (https://github.com/trueagi-io/hyperon-experimental/pull/728)