### PR TITLE
Improve variable related API

### DIFF
--- a/c/src/atom.rs
+++ b/c/src/atom.rs
@@ -1235,15 +1235,18 @@ pub extern "C" fn bindings_is_empty(bindings: *const bindings_t) -> bool{
 /// @brief Returns the atom bound to the supplied variable name in the `bindings_t`
 /// @ingroup matching_group
 /// @param[in]  bindings  A pointer to the `bindings_t` to inspect
-/// @param[in]  var_name  A NULL-terminated C-style string containing the name of the variable
+/// @param[in]  var  The Variable atom (L-value) for the variable <-> atom association
 /// @return The `atom_t` representing the atom that corresponds to the specified variable, or a NULL `atom_ref_t` if the variable is not present.
 /// @note The caller must take ownership responsibility for the returned `atom_t`, if it is not NULL
 ///
 #[no_mangle]
-pub extern "C" fn bindings_resolve(bindings: *const bindings_t, var_name: *const c_char) -> atom_t
+pub extern "C" fn bindings_resolve(bindings: *const bindings_t, var: atom_t) -> atom_t
 {
     let bindings = unsafe{ &*bindings }.borrow();
-    let var = VariableAtom::new(cstr_into_string(var_name));
+    let var = match var.into_inner() {
+        Atom::Variable(variable) => variable,
+        _ => panic!("var argument must be variable atom")
+    };
 
     bindings.resolve(&var).into()
 }

--- a/c/src/atom.rs
+++ b/c/src/atom.rs
@@ -254,8 +254,8 @@ pub unsafe extern "C" fn atom_var(name: *const c_char) -> atom_t {
 /// @note The caller must take ownership responsibility for the returned `atom_t`
 ///
 #[no_mangle]
-pub unsafe extern "C" fn atom_var_from_name(name: *const c_char) -> atom_t {
-    VariableAtom::from_name(cstr_as_str(name))
+pub unsafe extern "C" fn atom_var_parse_name(name: *const c_char) -> atom_t {
+    VariableAtom::parse_name(cstr_as_str(name))
         .map_or(atom_t::null(), |v| Atom::Variable(v).into())
 }
 

--- a/c/src/atom.rs
+++ b/c/src/atom.rs
@@ -247,16 +247,16 @@ pub unsafe extern "C" fn atom_var(name: *const c_char) -> atom_t {
     Atom::var(cstr_as_str(name)).into()
 }
 
-/// @brief Create a new Variable atom with the specified name and id
+/// @brief Create a new Variable atom parsing full formatted name of the variable
 /// @ingroup atom_group
-/// @param[in]  name  The name for the newly created Variable atom
-/// @param[in]  id    The unique id for the newly created Variable atom
-/// @return An `atom_t` for the Variable atom
+/// @param[in]  name  The name for the newly created Variable atom in a format `<name>#id`
+/// @return An `atom_t` for the Variable atom, returns `atom_t::null()` when parsing fails
 /// @note The caller must take ownership responsibility for the returned `atom_t`
 ///
 #[no_mangle]
-pub unsafe extern "C" fn atom_var_with_id(name: *const c_char, id: usize) -> atom_t {
-    Atom::var_with_id(cstr_as_str(name), id).into()
+pub unsafe extern "C" fn atom_var_from_name(name: *const c_char) -> atom_t {
+    VariableAtom::from_name(cstr_as_str(name))
+        .map_or(atom_t::null(), |v| Atom::Variable(v).into())
 }
 
 /// @ingroup atom_group

--- a/c/src/space.rs
+++ b/c/src/space.rs
@@ -788,12 +788,12 @@ impl Space for CSpace {
 
 impl std::fmt::Display for CSpace {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "CSpace")
+        write!(f, "CSpace-{self:p}")
     }
 }
 impl std::fmt::Debug for CSpace {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "CSpace")
+        write!(f, "CSpace-{self:p}")
     }
 }
 

--- a/lib/src/atom/mod.rs
+++ b/lib/src/atom/mod.rs
@@ -217,7 +217,7 @@ pub struct VariableAtom {
 impl VariableAtom {
     /// Constructs new variable using `name` provided. Name should not contain
     /// `#` characted which is reserved for internal name formatting (see
-    /// [VariableAtom::from_name]). Usually [Atom::var] method should be used
+    /// [VariableAtom::parse_name]). Usually [Atom::var] method should be used
     /// to create new variable atom instance. But sometimes [VariableAtom]
     /// instance is required. For example for using as a key in variable bindings
     /// (see [matcher::Bindings]).
@@ -246,17 +246,17 @@ impl VariableAtom {
     /// ```
     /// use hyperon::VariableAtom;
     ///
-    /// let x0 = VariableAtom::from_name("x");
-    /// let x42 = VariableAtom::from_name("x#42");
-    /// let xn = VariableAtom::from_name("x#");
-    /// let xe = VariableAtom::from_name("x#42#");
+    /// let x0 = VariableAtom::parse_name("x");
+    /// let x42 = VariableAtom::parse_name("x#42");
+    /// let xn = VariableAtom::parse_name("x#");
+    /// let xe = VariableAtom::parse_name("x#42#");
     ///
     /// assert_eq!(x0, Ok(VariableAtom::new_id("x", 0)));
     /// assert_eq!(x42, Ok(VariableAtom::new_id("x", 42)));
     /// assert_eq!(xn, Err(format!("Variable name is expected to contain number after # sign")));
     /// assert_eq!(xe, Err(format!("Variable name should have the following format: name[#id], actual name is x#42#")));
     /// ```
-    pub fn from_name(formatted: &str) -> Result<Self, String> {
+    pub fn parse_name(formatted: &str) -> Result<Self, String> {
         let mut parts = formatted.split('#');
         let name = parts.next().unwrap().to_string();
         if name.is_empty() {

--- a/lib/src/atom/mod.rs
+++ b/lib/src/atom/mod.rs
@@ -860,25 +860,6 @@ impl Atom {
         Self::Variable(VariableAtom::new(name))
     }
 
-    /// Constructs variable out of name and id.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use hyperon::Atom;
-    ///
-    /// let a = Atom::var_with_id("a", 1);
-    /// let aa = Atom::var_with_id("a", 1);
-    /// let b = Atom::var_with_id("b", 2);
-    ///
-    /// assert_eq!(a.to_string(), "$a#1");
-    /// assert_eq!(a, aa);
-    /// assert_ne!(a, b);
-    /// ```
-    pub fn var_with_id<T: Into<String>>(name: T, id: usize) -> Self {
-        Self::Variable(VariableAtom::new_id(name, id))
-    }
-
     /// Constructs grounded atom with customized behaviour.
     /// See [Grounded] for examples.
     pub fn gnd<T: CustomGroundedType>(gnd: T) -> Atom {

--- a/lib/src/atom/mod.rs
+++ b/lib/src/atom/mod.rs
@@ -215,17 +215,61 @@ pub struct VariableAtom {
 }
 
 impl VariableAtom {
-    /// Constructs new variable using `name` provided. Usually [Atom::var]
-    /// should be preffered. But sometimes [VariableAtom] instance is required.
-    /// For example for using as a key in variable bindings (see [matcher::Bindings]).
+    /// Constructs new variable using `name` provided. Name should not contain
+    /// `#` characted which is reserved for internal name formatting (see
+    /// [VariableAtom::from_name]). Usually [Atom::var] method should be used
+    /// to create new variable atom instance. But sometimes [VariableAtom]
+    /// instance is required. For example for using as a key in variable bindings
+    /// (see [matcher::Bindings]).
     pub fn new<T: Into<String>>(name: T) -> Self {
-        Self{ name: name.into(), id: 0 }
+        Self{ name: Self::check_name(name), id: 0 }
     }
 
     /// Constructs new variable using `name` and 'id' provided. This method is
-    /// used to convert C API [matcher::Bindings] to Rust.
+    /// used to construct proper variable for testing purposes only.
     pub fn new_id<T: Into<String>>(name: T, id: usize) -> Self {
-        Self{ name: name.into(), id: id }
+        Self{ name: Self::check_name(name), id }
+    }
+
+    #[inline]
+    fn check_name<T: Into<String>>(name: T) -> String {
+        let name = name.into();
+        assert!(name.find('#').is_none(), "character # is reserved and cannot be used in a variable name");
+        name
+    }
+
+    /// Constructs new variable instance by parsing name in format '<name>[#<id>]'.
+    /// Used to construct variable from result of the [VariableAtom::name] results.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hyperon::VariableAtom;
+    ///
+    /// let x0 = VariableAtom::from_name("x");
+    /// let x42 = VariableAtom::from_name("x#42");
+    /// let xn = VariableAtom::from_name("x#");
+    /// let xe = VariableAtom::from_name("x#42#");
+    ///
+    /// assert_eq!(x0, Ok(VariableAtom::new_id("x", 0)));
+    /// assert_eq!(x42, Ok(VariableAtom::new_id("x", 42)));
+    /// assert_eq!(xn, Err(format!("Variable name is expected to contain number after # sign")));
+    /// assert_eq!(xe, Err(format!("Variable name should have the following format: name[#id], actual name is x#42#")));
+    /// ```
+    pub fn from_name(formatted: &str) -> Result<Self, String> {
+        let mut parts = formatted.split('#');
+        let name = parts.next().unwrap().to_string();
+        if name.is_empty() {
+            return Err(format!("Variable name should be non empty"));
+        }
+        let id: usize = match parts.next() {
+            Some(id) => id.parse().map_err(|_| "Variable name is expected to contain number after # sign")?,
+            None => 0,
+        };
+        if !parts.next().is_none() {
+            return Err(format!("Variable name should have the following format: name[#id], actual name is {formatted}"));
+        }
+        Ok(Self{ name, id })
     }
 
     // TODO: for now name() is used to expose keys of Bindings via C API as

--- a/python/hyperon/atoms.py
+++ b/python/hyperon/atoms.py
@@ -86,15 +86,15 @@ class VariableAtom(Atom):
         """Returns the name of the Atom."""
         return hp.atom_get_name(self.catom)
 
+    @staticmethod
+    def from_name(name):
+        """Construct new VariableAtom instance from VariableAtom.get_name()
+        method results."""
+        return VariableAtom(hp.atom_var_from_name(name))
+
 def V(name):
     """A convenient method to construct a VariableAtom"""
-    if '#' in name:
-        vname, vid = name.split('#')[0:2]
-        vid = int(vid)
-    else:
-        vname = name
-        vid = 0
-    return VariableAtom(hp.atom_var(vname, vid))
+    return VariableAtom(hp.atom_var(name))
 
 class ExpressionAtom(Atom):
     """An ExpressionAtom combines different kinds of Atoms, including expressions."""

--- a/python/hyperon/atoms.py
+++ b/python/hyperon/atoms.py
@@ -585,9 +585,9 @@ class Bindings:
         hp.bindings_narrow_vars(self.cbindings, cvars)
         hp.atom_vec_free(cvars)
 
-    def resolve(self, var_name: str) -> Union[Atom, None]:
-        """Finds the atom for a given variable name"""
-        raw_atom = hp.bindings_resolve(self.cbindings, var_name)
+    def resolve(self, var: VariableAtom) -> Union[Atom, None]:
+        """Finds the atom for a given variable"""
+        raw_atom = hp.bindings_resolve(self.cbindings, var.catom)
         return None if raw_atom is None else Atom._from_catom(raw_atom)
 
     def iterator(self):

--- a/python/hyperon/atoms.py
+++ b/python/hyperon/atoms.py
@@ -87,10 +87,10 @@ class VariableAtom(Atom):
         return hp.atom_get_name(self.catom)
 
     @staticmethod
-    def from_name(name):
+    def parse_name(name):
         """Construct new VariableAtom instance from VariableAtom.get_name()
         method results."""
-        return VariableAtom(hp.atom_var_from_name(name))
+        return VariableAtom(hp.atom_var_parse_name(name))
 
 def V(name):
     """A convenient method to construct a VariableAtom"""

--- a/python/hyperon/atoms.py
+++ b/python/hyperon/atoms.py
@@ -679,15 +679,12 @@ class BindingsSet:
         self.shadow_list = None
         hp.bindings_set_push(self.c_set, bindings.cbindings)
 
-    def add_var_binding(self, var: Union[str, Atom], value: Atom) -> bool:
+    def add_var_binding(self, var: VariableAtom, value: Atom) -> bool:
         """Adds a new variable to atom association to every Bindings frame in a
         BindingsSet.
         """
         self.shadow_list = None
-        if isinstance(var, Atom):
-            return hp.bindings_set_add_var_binding(self.c_set, var.catom, value.catom)
-        else:
-            return hp.bindings_set_add_var_binding(self.c_set, V(var), value.catom)
+        return hp.bindings_set_add_var_binding(self.c_set, var.catom, value.catom)
 
     def add_var_equality(self, a: Atom, b: Atom) -> bool:
         """Asserts equality between two Variable atoms in a BindingsSet."""

--- a/python/hyperon/atoms.py
+++ b/python/hyperon/atoms.py
@@ -569,12 +569,9 @@ class Bindings:
         """Merges with another Bindings instance, into a Bindings Set."""
         return BindingsSet(hp.bindings_merge(self.cbindings, other.cbindings))
 
-    def add_var_binding(self, var: Union[str, Atom], atom: Atom) -> bool:
+    def add_var_binding(self, var: VariableAtom, atom: Atom) -> bool:
         """Adds a binding between a variable and an Atom."""
-        if isinstance(var, Atom):
-            return hp.bindings_add_var_binding(self.cbindings, var.catom, atom.catom)
-        else:
-            return hp.bindings_add_var_binding(self.cbindings, var, atom.catom)
+        return hp.bindings_add_var_binding(self.cbindings, var.catom, atom.catom)
 
     def is_empty(self) -> bool:
         """Checks if a bindings contains no associations."""

--- a/python/hyperon/atoms.py
+++ b/python/hyperon/atoms.py
@@ -593,7 +593,7 @@ class Bindings:
     def iterator(self):
         """Returns an iterator over the variable-atom pairs in the bindings"""
         res = hp.bindings_list(self.cbindings)
-        result = [(r[0], Atom._from_catom(r[1])) for r in res]
+        result = [(Atom._from_catom(r[0]), Atom._from_catom(r[1])) for r in res]
         return iter(result)
 
 class BindingsSet:

--- a/python/hyperon/exts/das_gate/dasgate.py
+++ b/python/hyperon/exts/das_gate/dasgate.py
@@ -130,7 +130,7 @@ class DASpace(AbstractSpace):
         for a in answer:
             bindings = Bindings()
             if a[0] is None:
-                bindings.add_var_binding("res", self._handle2atom3(a[1]))
+                bindings.add_var_binding(V("res"), self._handle2atom3(a[1]))
             else:
                 mapping = dict(ast.literal_eval(a[0]))
                 for var, val in mapping.items():

--- a/python/hyperon/exts/das_gate/dasgate.py
+++ b/python/hyperon/exts/das_gate/dasgate.py
@@ -134,7 +134,7 @@ class DASpace(AbstractSpace):
             else:
                 mapping = dict(ast.literal_eval(a[0]))
                 for var, val in mapping.items():
-                    bindings.add_var_binding(V(var), self._handle2atom4(val))
+                    bindings.add_var_binding(VariableAtom.from_name(var), self._handle2atom4(val))
             new_bindings_set.push(bindings)
         return new_bindings_set
 
@@ -149,7 +149,7 @@ class DASpace(AbstractSpace):
                 bindings = Bindings()
                 if not a.assignment is None:
                     for var, val in a.assignment.mapping.items():
-                        bindings.add_var_binding(V(var), self._handle2atom5(val))
+                        bindings.add_var_binding(VariableAtom.from_name(var), self._handle2atom5(val))
                 new_bindings_set.push(bindings)
         return new_bindings_set
 
@@ -157,7 +157,7 @@ class DASpace(AbstractSpace):
         for mapping, subgraph in answer:
             bindings = Bindings()
             for var, val in mapping.mapping.items():
-                bindings.add_var_binding(V(var), self._handle2atom5(val))
+                bindings.add_var_binding(VariableAtom.from_name(var), self._handle2atom5(val))
             new_bindings_set.push(bindings)
         return new_bindings_set
 
@@ -165,7 +165,7 @@ class DASpace(AbstractSpace):
         for mapping, subgraph in answer:
             bindings = Bindings()
             for var, val in mapping.mapping.items():
-                bindings.add_var_binding(V(var), self._handle2atom(val))
+                bindings.add_var_binding(VariableAtom.from_name(var), self._handle2atom(val))
             new_bindings_set.push(bindings)
         return new_bindings_set
 
@@ -208,7 +208,7 @@ class DASpace(AbstractSpace):
         for a in answer['mapping']:
             bindings = Bindings()
             for var, val in a.mapping.items():
-                bindings.add_var_binding(V(var), self._handle2atom(val))
+                bindings.add_var_binding(VariableAtom.from_name(var), self._handle2atom(val))
             new_bindings_set.push(bindings)
         return new_bindings_set
 

--- a/python/hyperon/exts/das_gate/dasgate.py
+++ b/python/hyperon/exts/das_gate/dasgate.py
@@ -52,7 +52,7 @@ class DASpace(AbstractSpace):
                 [self._atom2dict_new(ch) for ch in targets]}
         else:
             if isinstance(atom, VariableAtom):
-                return {"atom_type": "variable", "name": repr(atom)}
+                return {"atom_type": "variable", "name": atom.get_name()}
             elif isinstance(atom, SymbolAtom):
                 return {"atom_type": "node", "type": "Symbol", "name": repr(atom)}
             elif isinstance(atom, GroundedAtom):
@@ -63,7 +63,7 @@ class DASpace(AbstractSpace):
         while stack:
             node = stack.pop()
             if isinstance(node, VariableAtom):
-                yield {"atom_type": "variable", "name": repr(node)}
+                yield {"atom_type": "variable", "name": node.get_name()}
             if isinstance(node, ExpressionAtom):
                 targets = node.get_children()
                 for ch in targets:
@@ -78,7 +78,7 @@ class DASpace(AbstractSpace):
                 targets=[self._atom2query(ch) for ch in targets])
         else:
             if isinstance(atom, VariableAtom):
-                return Variable(repr(atom))
+                return Variable(atom.get_name())
             else:
                 return Node("Symbol", repr(atom))
 
@@ -134,8 +134,7 @@ class DASpace(AbstractSpace):
             else:
                 mapping = dict(ast.literal_eval(a[0]))
                 for var, val in mapping.items():
-                    # remove '$', because it is automatically added
-                    bindings.add_var_binding(V(var[1:]), self._handle2atom4(val))
+                    bindings.add_var_binding(V(var), self._handle2atom4(val))
             new_bindings_set.push(bindings)
         return new_bindings_set
 
@@ -150,8 +149,7 @@ class DASpace(AbstractSpace):
                 bindings = Bindings()
                 if not a.assignment is None:
                     for var, val in a.assignment.mapping.items():
-                        # remove '$', because it is automatically added
-                        bindings.add_var_binding(V(var[1:]), self._handle2atom5(val))
+                        bindings.add_var_binding(V(var), self._handle2atom5(val))
                 new_bindings_set.push(bindings)
         return new_bindings_set
 
@@ -159,8 +157,7 @@ class DASpace(AbstractSpace):
         for mapping, subgraph in answer:
             bindings = Bindings()
             for var, val in mapping.mapping.items():
-                # remove '$', because it is automatically added
-                bindings.add_var_binding(V(var[1:]), self._handle2atom5(val))
+                bindings.add_var_binding(V(var), self._handle2atom5(val))
             new_bindings_set.push(bindings)
         return new_bindings_set
 
@@ -168,8 +165,7 @@ class DASpace(AbstractSpace):
         for mapping, subgraph in answer:
             bindings = Bindings()
             for var, val in mapping.mapping.items():
-                # remove '$', because it is automatically added
-                bindings.add_var_binding(V(var[1:]), self._handle2atom(val))
+                bindings.add_var_binding(V(var), self._handle2atom(val))
             new_bindings_set.push(bindings)
         return new_bindings_set
 
@@ -212,8 +208,7 @@ class DASpace(AbstractSpace):
         for a in answer['mapping']:
             bindings = Bindings()
             for var, val in a.mapping.items():
-                # remove '$', because it is automatically added
-                bindings.add_var_binding(V(var[1:]), self._handle2atom(val))
+                bindings.add_var_binding(V(var), self._handle2atom(val))
             new_bindings_set.push(bindings)
         return new_bindings_set
 

--- a/python/hyperon/exts/das_gate/dasgate.py
+++ b/python/hyperon/exts/das_gate/dasgate.py
@@ -134,7 +134,7 @@ class DASpace(AbstractSpace):
             else:
                 mapping = dict(ast.literal_eval(a[0]))
                 for var, val in mapping.items():
-                    bindings.add_var_binding(VariableAtom.from_name(var), self._handle2atom4(val))
+                    bindings.add_var_binding(VariableAtom.parse_name(var), self._handle2atom4(val))
             new_bindings_set.push(bindings)
         return new_bindings_set
 
@@ -149,7 +149,7 @@ class DASpace(AbstractSpace):
                 bindings = Bindings()
                 if not a.assignment is None:
                     for var, val in a.assignment.mapping.items():
-                        bindings.add_var_binding(VariableAtom.from_name(var), self._handle2atom5(val))
+                        bindings.add_var_binding(VariableAtom.parse_name(var), self._handle2atom5(val))
                 new_bindings_set.push(bindings)
         return new_bindings_set
 
@@ -157,7 +157,7 @@ class DASpace(AbstractSpace):
         for mapping, subgraph in answer:
             bindings = Bindings()
             for var, val in mapping.mapping.items():
-                bindings.add_var_binding(VariableAtom.from_name(var), self._handle2atom5(val))
+                bindings.add_var_binding(VariableAtom.parse_name(var), self._handle2atom5(val))
             new_bindings_set.push(bindings)
         return new_bindings_set
 
@@ -165,7 +165,7 @@ class DASpace(AbstractSpace):
         for mapping, subgraph in answer:
             bindings = Bindings()
             for var, val in mapping.mapping.items():
-                bindings.add_var_binding(VariableAtom.from_name(var), self._handle2atom(val))
+                bindings.add_var_binding(VariableAtom.parse_name(var), self._handle2atom(val))
             new_bindings_set.push(bindings)
         return new_bindings_set
 
@@ -208,7 +208,7 @@ class DASpace(AbstractSpace):
         for a in answer['mapping']:
             bindings = Bindings()
             for var, val in a.mapping.items():
-                bindings.add_var_binding(VariableAtom.from_name(var), self._handle2atom(val))
+                bindings.add_var_binding(VariableAtom.parse_name(var), self._handle2atom(val))
             new_bindings_set.push(bindings)
         return new_bindings_set
 

--- a/python/hyperonpy.cpp
+++ b/python/hyperonpy.cpp
@@ -652,7 +652,7 @@ PYBIND11_MODULE(hyperonpy, m) {
 
     m.def("atom_sym", [](char const* name) { return CAtom(atom_sym(name)); }, "Create symbol atom");
     m.def("atom_var", [](char const* name) { return CAtom(atom_var(name)); }, "Create variable atom");
-    m.def("atom_var_from_name", [](char const* name) { return CAtom(atom_var_from_name(name)); }, "Create variable atom parsing name in format <name>#<id>");
+    m.def("atom_var_parse_name", [](char const* name) { return CAtom(atom_var_parse_name(name)); }, "Create variable atom parsing name in format <name>#<id>");
     m.def("atom_expr", [](py::list _children) {
             size_t size = py::len(_children);
             atom_t children[size];

--- a/python/hyperonpy.cpp
+++ b/python/hyperonpy.cpp
@@ -752,11 +752,6 @@ PYBIND11_MODULE(hyperonpy, m) {
     }, "Merges bindings into a BindingsSet, allowing for conflicting bindings to split");
     m.def("bindings_eq", [](CBindings left, CBindings right){ return bindings_eq(left.ptr(), right.ptr());}, "Compares bindings"  );
     m.def("bindings_add_var_binding",
-          [](CBindings bindings, char const* varName, CAtom atom) {
-              return bindings_add_var_binding(bindings.ptr(), atom_var(varName), atom_clone(atom.ptr()));
-          },
-          "Links variable to atom" );
-    m.def("bindings_add_var_binding",
           [](CBindings bindings, CAtom var, CAtom atom) {
               return bindings_add_var_binding(bindings.ptr(), atom_clone(var.ptr()), atom_clone(atom.ptr()));
           },

--- a/python/hyperonpy.cpp
+++ b/python/hyperonpy.cpp
@@ -651,7 +651,8 @@ PYBIND11_MODULE(hyperonpy, m) {
     py::class_<CAtom>(m, "CAtom");
 
     m.def("atom_sym", [](char const* name) { return CAtom(atom_sym(name)); }, "Create symbol atom");
-    m.def("atom_var", [](char const* name, unsigned int id = 0) { return CAtom(atom_var_with_id(name, id)); }, "Create variable atom");
+    m.def("atom_var", [](char const* name) { return CAtom(atom_var(name)); }, "Create variable atom");
+    m.def("atom_var_from_name", [](char const* name) { return CAtom(atom_var_from_name(name)); }, "Create variable atom parsing name in format <name>#<id>");
     m.def("atom_expr", [](py::list _children) {
             size_t size = py::len(_children);
             atom_t children[size];

--- a/python/hyperonpy.cpp
+++ b/python/hyperonpy.cpp
@@ -762,8 +762,8 @@ PYBIND11_MODULE(hyperonpy, m) {
             bindings_narrow_vars(bindings.ptr(), vars.ptr());
         }, "Remove vars from Bindings, except those specified" );
 
-    m.def("bindings_resolve", [](CBindings bindings, char const* varName) -> nonstd::optional<CAtom> {
-            auto const res = bindings_resolve(bindings.ptr(), varName);
+    m.def("bindings_resolve", [](CBindings bindings, CAtom var) -> nonstd::optional<CAtom> {
+            auto const res = bindings_resolve(bindings.ptr(), atom_clone(var.ptr()));
             return atom_is_null(&res) ? nonstd::nullopt : nonstd::optional<CAtom>(CAtom(res));
         }, "Resolve" );
 

--- a/python/hyperonpy.cpp
+++ b/python/hyperonpy.cpp
@@ -495,14 +495,9 @@ void py_space_free_payload(void *payload) {
     delete static_cast<PySpace const*>(payload);
 }
 
-void copy_to_list_callback(atom_ref_t var, atom_ref_t atom, void* context){
-
+void copy_pair_of_atoms_to_list_callback(atom_ref_t var, atom_ref_t atom, void* context){
     pybind11::list& var_atom_list = *( (pybind11::list*)(context) );
-
-    var_atom_list.append(
-            std::make_pair(
-                func_to_string((write_to_buf_func_t)&atom_get_name, &var),
-                CAtom(atom)));
+    var_atom_list.append(std::make_pair(CAtom(var), CAtom(atom)));
 }
 
 void atom_copy_to_list_callback(atom_ref_t atom, void* context){
@@ -775,7 +770,7 @@ PYBIND11_MODULE(hyperonpy, m) {
         pybind11::list var_atom_list;
         bindings_traverse(
                 bindings.ptr(),
-                copy_to_list_callback,
+                copy_pair_of_atoms_to_list_callback,
                 &var_atom_list);
 
         return var_atom_list;

--- a/python/sandbox/sql_space/sql_space.py
+++ b/python/sandbox/sql_space/sql_space.py
@@ -175,7 +175,7 @@ class SqlSpace(GroundingSpace):
         except (Exception, psycopg2.DatabaseError) as error:
             bindings_set = BindingsSet.empty()
             bindings = Bindings()
-            bindings.add_var_binding("error on insert: ", ValueAtom(error))
+            bindings.add_var_binding(V("error on insert: "), ValueAtom(error))
             bindings_set.push(bindings)
             return bindings_set
         return BindingsSet.empty()
@@ -192,9 +192,9 @@ class SqlSpace(GroundingSpace):
                     self.cursor.execute(sql_query)
                     values = self.cursor.fetchall()
                     if len(vars_names) == 0 and len(values) > 0:
-                        vars = [f"var{i + 1}" for i in range(len(values[0]))]
+                        vars = [V(f"var{i + 1}") for i in range(len(values[0]))]
                     else:
-                        vars = [v[1:] for v in vars_names]
+                        vars = [V(v[1:]) for v in vars_names]
                     if len(vars) > 0 and len(values) > 0:
                         return results2bindings(vars, values)
                 return new_bindings_set

--- a/python/sandbox/sql_space/sql_space.py
+++ b/python/sandbox/sql_space/sql_space.py
@@ -98,7 +98,7 @@ class SqlHelper:
         for val in res:
             temp_dict = {}
             for k, v in val.items():
-                temp_dict['$' + str(k)] = str(v)
+                temp_dict[k.get_name()] = str(v)
             variables.append(temp_dict)
         atoms = self.get_query_atoms(query_atom)
         new_atoms = []

--- a/python/tests/test_bindings.py
+++ b/python/tests/test_bindings.py
@@ -68,11 +68,11 @@ class BindingsTest(unittest.TestCase):
 
     def test_bindings_resolve(self):
 
-        self.assertIsNone(self.emptyBindings.resolve("a"))
-        self.assertIsNone(self.bindings.resolve("XYXY"))
+        self.assertIsNone(self.emptyBindings.resolve(V("a")))
+        self.assertIsNone(self.bindings.resolve(V("XYXY")))
 
         atom_expected = S("b")
-        atom_resolved = self.bindings.resolve("a")
+        atom_resolved = self.bindings.resolve(V("a"))
         self.assertEqual(atom_expected, atom_resolved)
 
     def test_bindings_iterator(self):

--- a/python/tests/test_bindings.py
+++ b/python/tests/test_bindings.py
@@ -9,8 +9,8 @@ class BindingsTest(unittest.TestCase):
         self.emptyBindings = Bindings()
 
         self.bindings = Bindings()
-        self.bindings.add_var_binding("a", S("b"))
-        self.bindings.add_var_binding("x", S("y"))
+        self.bindings.add_var_binding(V("a"), S("b"))
+        self.bindings.add_var_binding(V("x"), S("y"))
 
 
     def tearDown(self) -> None:


### PR DESCRIPTION
Follow up #729. This PR contains two main parts:
1. Remove `Bindings` and `BindingsSet` method variants which work with strings instead of variables. This is technical debt after introducing full functional Python API for the variable bindings.
2. Add `VariableAtom::parse_name()` method to parse `VariableAtom::name()` method results into Rust and Python API. This is a technical debt after introducing unique variable instances.

New methods are used to fix DAS gate variable conversion logic.

@besSveta please check this change doesn't break `sql_space.py` logic.
@angeloprobst FYI.