### PR TITLE
Minimize docker image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,8 @@ Cargo.lock
 .DS_Store
 .vscode
 .aider*
+__pycache__
 /build
-/python/__pycache__
 /python/hyperon.egg-info
 /python/dist
 /python/build

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-/build
+# `.gitignore` file is also used to exclued files going into Docker image
+# building context. All ignored files should be put into the same `.gitignore`
+# at the root of the repository by this reason.
 *.swp
 compile_commands.json
 .cache
@@ -7,3 +9,12 @@ Cargo.lock
 .DS_Store
 .vscode
 .aider*
+/build
+/python/__pycache__
+/python/hyperon.egg-info
+/python/dist
+/python/build
+/python/*.so
+/python/*.dylib
+/python/wheelhouse
+/python/hyperon/_version.py

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ include(ExternalProject)
 
 option(GIT "Adds git features to hyperon library; requires OpenSSL and Zlib" ON)
 
-set(HYPERONC_INSTALL_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/hyperonc-prefix")
+set(HYPERONC_INSTALL_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/hyperonc-install")
 message(STATUS "HYPERONC_INSTALL_PREFIX = ${HYPERONC_INSTALL_PREFIX}")
 
 set(IS_RELEASE_BUILD $<IF:$<OR:$<CONFIG:Release>,$<CONFIG:RelWithDebInfo>,$<CONFIG:MinSizeRel>>,1,0>)
@@ -16,7 +16,6 @@ set(BUILD_CONFIGURATION $<IF:${IS_RELEASE_BUILD},Release,Debug>)
 ExternalProject_Add(
     hyperonc
     BUILD_ALWAYS 1
-    PREFIX "${HYPERONC_INSTALL_PREFIX}"
     SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/c"
     CMAKE_ARGS
     -DGIT=${GIT}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ hyperon = { path = "./lib", version = "0.1.12" }
 regex = "1.5.4"
 log = "0.4.0"
 env_logger = "0.8.4"
+
+[profile.release]
+strip = "symbols"

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ CMD bash
 FROM os
 
 ENV BUILD=/home/user/hyperon-experimental/build
-COPY --from=build /home/user/hyperon-experimental/target/release/metta-rust /usr/bin
+COPY --from=build /home/user/hyperon-experimental/target/release/metta-repl /usr/bin
 COPY --from=build ${BUILD}/hyperonc-install /usr
 COPY --from=build ${BUILD}/hyperonpy-install /usr/local
 COPY --from=build ${BUILD}/../python/VERSION /root/version
@@ -59,7 +59,7 @@ echo ""
 echo "  Welcome to the MeTTa $(cat /root/version) running environment."
 echo "  Use the following commands to run MeTTa interpreter:"
 echo ""
-echo "  metta-rust - start Rust based REPL"
+echo "  metta-repl - start Rust based REPL"
 echo "  metta-py - start Python based script executor"
 echo ""
 EOF

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,5 +55,17 @@ ENV BUILD=/home/user/hyperon-experimental/build
 COPY --from=build /home/user/hyperon-experimental/target/release/metta-rust /usr/bin
 COPY --from=build ${BUILD}/hyperonc-install /usr
 COPY --from=build ${BUILD}/hyperonpy-install /usr/local
+COPY --from=build ${BUILD}/../python/VERSION /root/version
+
+RUN cat >>/root/welcome <<EOF
+echo ""
+echo "  Welcome to the MeTTa $(cat /root/version) running environment."
+echo "  Use the following commands to run MeTTa interpreter:"
+echo ""
+echo "  metta-rust - start Rust based REPL"
+echo "  metta-py - start Python based script executor"
+echo ""
+EOF
+RUN echo "sh /root/welcome" >/root/.bashrc
 
 CMD bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,6 @@ RUN conan profile new --detect default
 
 ADD --chown=user:users . ${HOME}/hyperon-experimental
 
-ENV PREFIX=${HOME}/prefix
-RUN mkdir ${PREFIX}
-
 WORKDIR ${HOME}/hyperon-experimental
 RUN cargo test --release
 RUN cargo build --release

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,10 @@ ENV HYPERONPY=${BUILD}/hyperonpy-install
 RUN mkdir ${HYPERONPY}
 RUN python3 -m pip install --prefix ${HYPERONPY} ../python
 
+WORKDIR ${HOME}/hyperon-experimental
+
+CMD bash
+
 FROM os
 
 ENV BUILD=/home/user/hyperon-experimental/build

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ CMD bash
 FROM os
 
 ENV BUILD=/home/user/hyperon-experimental/build
-COPY --from=build /home/user/hyperon-experimental/target/release/metta /usr/bin/metta-rust
+COPY --from=build /home/user/hyperon-experimental/target/release/metta-rust /usr/bin
 COPY --from=build ${BUILD}/hyperonc-install /usr
 COPY --from=build ${BUILD}/hyperonpy-install /usr/local
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,11 @@
-FROM ubuntu:22.04 AS os
-
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive \
-    TZ=UTC \
-    apt-get install -y python3 python3-pip
+FROM python:3.10-slim-bookworm AS os
 
 FROM os AS build
 
-RUN DEBIAN_FRONTEND=noninteractive \
+RUN apt update && \
+    DEBIAN_FRONTEND=noninteractive \
     TZ=UTC \
-    apt-get install -y sudo git curl gcc cmake \
+    apt install -y sudo git curl cmake build-essential \
         pkg-config libssl-dev zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
 
@@ -22,11 +18,11 @@ WORKDIR ${HOME}
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > /tmp/rustup.sh
 RUN sh /tmp/rustup.sh -y && rm /tmp/rustup.sh
-ENV PATH="${PATH}:/home/user/.cargo/bin"
+ENV PATH="${PATH}:${HOME}/.cargo/bin"
 RUN cargo install cbindgen
 
 RUN python3 -m pip install conan==1.64 pip==23.1.2
-ENV PATH="${PATH}:/home/user/.local/bin"
+ENV PATH="${PATH}:${HOME}/.local/bin"
 RUN conan profile new --detect default
 
 ADD --chown=user:users . ${HOME}/hyperon-experimental
@@ -35,7 +31,7 @@ ENV PREFIX=${HOME}/prefix
 RUN mkdir ${PREFIX}
 
 WORKDIR ${HOME}/hyperon-experimental
-RUN cargo test
+RUN cargo test --release
 RUN cargo build --release
 
 ENV BUILD=${HOME}/hyperon-experimental/build
@@ -51,10 +47,9 @@ RUN python3 -m pip install --prefix ${HYPERONPY} ../python
 
 FROM os
 
-RUN rm -rf /var/lib/apt/lists/*
-
 ENV BUILD=/home/user/hyperon-experimental/build
 COPY --from=build /home/user/hyperon-experimental/target/release/metta /usr/bin/metta-rust
 COPY --from=build ${BUILD}/hyperonc-install /usr
-COPY --from=build ${BUILD}/hyperonpy-install /usr
+COPY --from=build ${BUILD}/hyperonpy-install /usr/local
 
+CMD bash

--- a/README.md
+++ b/README.md
@@ -26,32 +26,36 @@ The following command installs the latest release version from PyPi package repo
 python3 -m pip install hyperon
 ```
 
-# Prepare development environment
-
-## Docker
-
-A docker image can be used as a ready to run stable and predictable development
-environment. Please keep in mind that resulting image contains temporary build
-files and takes a lot of a disk space. It is not recommended to distribute it
-as an image for running MeTTa because of its size.
-
-### Ready to use image
-
-Run latest docker image from the Dockerhub:
+Another way is using released Docker image:
 ```
 docker run -ti trueagi/hyperon:latest
 ```
 
-### Build image
+After installing package or starting Docker container run MeTTa Python based
+interpreter:
+```
+metta-py
 
-Docker 26.0.0 or greater version is required.
+```
+Using Docker you can also run Rust REPL:
+```
+metta-rust
+```
+
+# Using latest development version
+
+## Docker
+
+A docker image can be used as a ready to run stable and predictable development
+environment. Docker 26.0.0 or greater version is required to build image
+manually.
 
 Build Docker image from a local copy of the repo running:
 ```
 docker build -t trueagi/hyperon .
 ```
 
-Or build it without cloning the repo running:
+Or build it without local copy of the repo running:
 ```
 docker build \
     --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=1 \
@@ -59,9 +63,10 @@ docker build \
     http://github.com/trueagi-io/hyperon-experimental.git#main
 ```
 
-Run the image:
+Use `--target build` option to create an image which keeps the full build
+environment and can be used for developing interpreter:
 ```
-docker run --rm -ti trueagi/hyperon
+docker build --target build -t trueagi/hyperon .
 ```
 
 If the docker image doesn't work, please raise an
@@ -125,9 +130,9 @@ cargo run --example sorted_list
 
 Run Rust REPL:
 ```
-cargo run --features no_python --bin metta
+cargo run --features no_python --bin metta-rust
 ```
-You can also find executable at `./target/debug/metta`.
+You can also find executable at `./target/debug/metta-rust`.
 
 To enable logging during running tests or examples export `RUST_LOG`
 environment variable:
@@ -178,18 +183,18 @@ pytest ./tests
 
 One can run MeTTa script from command line:
 ```
-metta ./tests/scripts/<name>.metta
+metta-py ./tests/scripts/<name>.metta
 ```
 
 Run REPL:
 ```
-cargo run --bin metta
+cargo run --bin metta-rust
 ```
-You can also find executable at `./target/debug/metta`.
+You can also find executable at `./target/debug/metta-rust`.
 
 ### Logger
 
-You can enable logging by prefixing the `metta` command line by
+You can enable logging by prefixing the MeTTa command line by
 
 ```
 RUST_LOG=hyperon[::COMPONENT]*=LEVEL

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ After installing package or starting Docker container run MeTTa Python based
 interpreter:
 ```
 metta-py
-
 ```
+
 Using Docker you can also run Rust REPL:
 ```
 metta-rust

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ metta-py
 
 Using Docker you can also run Rust REPL:
 ```
-metta-rust
+metta-repl
 ```
 
 # Using latest development version
@@ -131,9 +131,9 @@ cargo run --example sorted_list
 
 Run Rust REPL:
 ```
-cargo run --features no_python --bin metta-rust
+cargo run --features no_python --bin metta-repl
 ```
-You can also find executable at `./target/debug/metta-rust`.
+You can also find executable at `./target/debug/metta-repl`.
 
 To enable logging during running tests or examples export `RUST_LOG`
 environment variable:
@@ -189,9 +189,9 @@ metta-py ./tests/scripts/<name>.metta
 
 Run REPL:
 ```
-cargo run --bin metta-rust
+cargo run --bin metta-repl
 ```
-You can also find executable at `./target/debug/metta-rust`.
+You can also find executable at `./target/debug/metta-repl`.
 
 ### Logger
 

--- a/c/.gitignore
+++ b/c/.gitignore
@@ -1,2 +1,0 @@
-/target
-Cargo.lock

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -68,3 +68,8 @@ This makes it easier to find blocks that might be source of issues. Usually it i
 not required to mark C API functions `unsafe` because they are not intended to
 be used from the Rust safe code.
 
+### Git
+
+`.gitignore` file is also used to exclued files going into Docker image
+building context. All ignored files should be put into the same `.gitignore` at
+the root of the repository by this reason.

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,8 +1,0 @@
-__pycache__
-/hyperon.egg-info
-/dist
-/build
-/*.so
-/*.dylib
-/wheelhouse
-/hyperon/_version.py

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -23,6 +23,7 @@ dynamic = [
 
 [project.scripts]
 metta = "hyperon.metta:main"
+metta-py = "hyperon.metta:main"
 
 [project.optional-dependencies]
 dev = [

--- a/repl/Cargo.toml
+++ b/repl/Cargo.toml
@@ -16,7 +16,7 @@ pep440_rs = { version = "0.3.11", optional = true }
 hyperon = { workspace = true, optional = true } #TODO: We can only link Hyperon directly or through Python, but not both at the same time.  The right fix is to allow HyperonPy to be built within Hyperon, See https://github.com/trueagi-io/hyperon-experimental/issues/283
 
 [[bin]]
-name = "metta-rust"
+name = "metta-repl"
 path = "src/main.rs"
 
 [features]

--- a/repl/Cargo.toml
+++ b/repl/Cargo.toml
@@ -16,7 +16,7 @@ pep440_rs = { version = "0.3.11", optional = true }
 hyperon = { workspace = true, optional = true } #TODO: We can only link Hyperon directly or through Python, but not both at the same time.  The right fix is to allow HyperonPy to be built within Hyperon, See https://github.com/trueagi-io/hyperon-experimental/issues/283
 
 [[bin]]
-name = "metta"
+name = "metta-rust"
 path = "src/main.rs"
 
 [features]


### PR DESCRIPTION
Use minimal Python 3.10 image based on Debian `python:3.10-slim-bookworm` as a starting point.
Use multi-stage build to start from clean environment after building is finished. In addition debug information is stripped from Rust binaries. Resulting image's size is about 180 Mb which is 50Mb greater than the Python runtime size.

Rust executable file is renamed to `metta-rust` and Python executable is aliased by `metta-py` in order to remove name conflict between them. Documentation is updated.

`.dockerignore` file is added in order to make Docker builds faster. `.dockerfile` is a soft-link to the `/.gitignore` which now keeps all files ignored by Git in repo. Welcome message is added to the container to show environment version and explain basic commands.