### PR TITLE
Propagating python errors in loader through to MeTTa

### DIFF
--- a/python/hyperon/runner.py
+++ b/python/hyperon/runner.py
@@ -362,8 +362,7 @@ def _priv_make_module_loader_func_for_pymod(pymod_name, load_corelib=False, reso
                 if '__name__' in dir(obj) and obj.__name__ == 'metta_register':
                     obj(run_context)
 
-        except:
-            # LP-TODO-Next, need to create error pathway through C interface 
-            raise RuntimeError("Error loading Python module: ", pymod_name)
+        except Exception as e:
+            raise RuntimeError("Error loading Python module: ", pymod_name, e)
 
     return loader_func

--- a/python/hyperonpy.cpp
+++ b/python/hyperonpy.cpp
@@ -569,7 +569,13 @@ void load_mod_fmt_callback(const void* payload, run_context_t* run_context, void
     py::object* callback_context_obj = (py::object*)callback_context;
     py::function py_func = fmt_interface_obj->attr("_load_called_from_c");
     CRunContext c_run_context = CRunContext(run_context);
-    py_func(&c_run_context, callback_context_obj);
+    try {
+        py_func(&c_run_context, callback_context_obj);
+    } catch (py::error_already_set &e) {
+        char message[4096];
+        snprintf(message, lenghtof(message), "Exception caught:\n%s", e.what());
+        run_context_raise_error(run_context, message);
+    }
 }
 
 void free_mod_fmt_context(void* callback_context) {

--- a/python/tests/test_extend.py
+++ b/python/tests/test_extend.py
@@ -112,12 +112,8 @@ class ExtendErrorTest(unittest.TestCase):
         This test verifies that an error from a Python extension is properly propagated
         '''
         metta = MeTTa(env_builder=Environment.custom_env(working_dir=os.getcwd(), disable_config=True, is_test=True))
-        try:
-          metta.run("!(import! &self error_pyext)")
-        except Exception as err:
-            pass
-        else:
-            raise Exception('error_pyext.py should raise an error when loading, so no-err is an error')
+        result = metta.run("!(import! &self error_pyext)")
+        self.assertEqual(S('Error'), result[0][0].get_children()[0])
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The `test_error_pyext` test in the `test_extend.py` was aborting due to an (intentional) uncaught exception from Python.

This PR fixes it by implementing the missing error pathway from C loader function, and then using that pathway in hyperonpy