### PR TITLE
Add Dockerhub publishing step to the release GitHub Action workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,6 +130,8 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           load: true
+          build-args: |
+            BUILDKIT_CONTEXT_KEEP_GIT_DIR=1
           tags: trueagi/hyperon:test
 
       - name: Test
@@ -146,6 +148,8 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
+          build-args: |
+            BUILDKIT_CONTEXT_KEEP_GIT_DIR=1
           tags: |
             trueagi/hyperon:${{github.event.release.tag_name}}
             trueagi/hyperon:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
     permissions:
       id-token: write
     environment:
-      name: test
+      name: pypi-test
     runs-on: ubuntu-latest
     needs: [build-wheels]
     if: github.event.action == 'published'
@@ -99,7 +99,7 @@ jobs:
     permissions:
       id-token: write
     environment:
-      name: production
+      name: pypi-production
     runs-on: ubuntu-latest
     needs: [build-wheels]
     if: github.event.action == 'published'
@@ -117,7 +117,7 @@ jobs:
   publish-docker:
     name: Publish Docker image
     environment:
-      name: production
+      name: dockerhub-production
     runs-on: ubuntu-latest
     needs: [build-wheels]
     if: github.event.action == 'published'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,17 @@
 # This workflow builds Python distribution packages using cibuildwheel tool and
-# environment and publishes packages as a part of a GitHub release.
+# environment and publishes packages as a part of a GitHub release. Also it
+# releases container image to the DockerHub.
 
 # This workflow uses actions that are not certified by GitHub.  They are
 # provided by a third-party and are governed by separate terms of service,
 # privacy policy, and support documentation.
 
-name: release python
+name: release
 
 on:
   workflow_dispatch:
   release:
     types: [published]
-
 
 jobs:
   build-wheels:
@@ -82,15 +82,17 @@ jobs:
     needs: [build-wheels]
     if: github.event.action == 'published'
     steps:
-    - uses: actions/download-artifact@v4
-      with:
-        pattern: python-wheels-*
-        merge-multiple: true
-        path: dist
-    - name: Publish package distributions to Test PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        repository-url: https://test.pypi.org/legacy/
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: python-wheels-*
+          merge-multiple: true
+          path: dist
+
+      - name: Publish package distributions to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
 
   publish-pypi:
     name: Publish to PyPI
@@ -102,10 +104,48 @@ jobs:
     needs: [build-wheels]
     if: github.event.action == 'published'
     steps:
-    - uses: actions/download-artifact@v4
-      with:
-        pattern: python-wheels-*
-        merge-multiple: true
-        path: dist
-    - name: Publish package distributions to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: python-wheels-*
+          merge-multiple: true
+          path: dist
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  publish-docker:
+    name: Publish Docker image
+    environment:
+      name: production
+    runs-on: ubuntu-latest
+    needs: [build-wheels]
+    if: github.event.action == 'published'
+    steps:
+
+      - name: Set up Docker BuildX
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and export to Docker
+        uses: docker/build-push-action@v6
+        with:
+          load: true
+          tags: trueagi/hyperon:test
+
+      - name: Test
+        run: |
+          echo "(* 7 6)" | docker run --rm trueagi/hyperon:test metta-repl
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: |
+            trueagi/hyperon:${{github.event.release.tag_name}}
+            trueagi/hyperon:latest

--- a/repl/Cargo.toml
+++ b/repl/Cargo.toml
@@ -14,6 +14,7 @@ signal-hook = "0.3.17"
 pyo3 = { version = "0.19.2", features = ["auto-initialize"], optional = true }
 pep440_rs = { version = "0.3.11", optional = true }
 hyperon = { workspace = true, optional = true } #TODO: We can only link Hyperon directly or through Python, but not both at the same time.  The right fix is to allow HyperonPy to be built within Hyperon, See https://github.com/trueagi-io/hyperon-experimental/issues/283
+semver = "1.0.23"
 
 [[bin]]
 name = "metta-repl"

--- a/repl/Cargo.toml
+++ b/repl/Cargo.toml
@@ -14,7 +14,6 @@ signal-hook = "0.3.17"
 pyo3 = { version = "0.19.2", features = ["auto-initialize"], optional = true }
 pep440_rs = { version = "0.3.11", optional = true }
 hyperon = { workspace = true, optional = true } #TODO: We can only link Hyperon directly or through Python, but not both at the same time.  The right fix is to allow HyperonPy to be built within Hyperon, See https://github.com/trueagi-io/hyperon-experimental/issues/283
-semver = "1.0.23"
 
 [[bin]]
 name = "metta-repl"

--- a/repl/src/metta_shim.rs
+++ b/repl/src/metta_shim.rs
@@ -95,23 +95,7 @@ pub mod metta_interface_mod {
 
         fn required_hyperon_version() -> String {
             const PACKAGE_VERSION: &str = env!("CARGO_PKG_VERSION");
-
-            fn comparator(op: semver::Op, ver: &semver::Version) -> semver::Comparator {
-                semver::Comparator{
-                    op,
-                    major: ver.major,
-                    minor: Some(ver.minor),
-                    patch: Some(0),
-                    pre: semver::Prerelease::EMPTY,
-                }
-            }
-
-            let mut ver = semver::Version::parse(PACKAGE_VERSION).unwrap();
-            let lower_bound = comparator(semver::Op::GreaterEq, &ver);
-            ver.minor = ver.minor + 1;
-            let upper_bound = comparator(semver::Op::Less, &ver);
-            let req = semver::VersionReq{ comparators: vec![lower_bound, upper_bound] };
-            req.to_string()
+            format!("=={PACKAGE_VERSION}")
         }
 
         pub fn init_common_env(working_dir: PathBuf, include_paths: Vec<PathBuf>) -> Result<MettaShim, String> {

--- a/repl/src/metta_shim.rs
+++ b/repl/src/metta_shim.rs
@@ -51,7 +51,6 @@ pub mod metta_interface_mod {
     }
 
     pub fn confirm_hyperonpy_version(req_str: &str) -> Result<(), String> {
-
         let req = parse_version_specifiers(req_str).unwrap();
         let version_string = get_hyperonpy_version()?;
         //NOTE: Version parsing errors will be encountered by users building hyperonpy from source with an abnormal configuration
@@ -78,7 +77,8 @@ pub mod metta_interface_mod {
 
             match || -> Result<_, String> {
                 //Confirm the hyperonpy version is compatible
-                confirm_hyperonpy_version(">=0.1.0, <0.2.0")?;
+                let req_str = Self::required_hyperon_version();
+                confirm_hyperonpy_version(&req_str)?;
 
                 //Initialize the Hyperon environment
                 let new_shim = MettaShim::init_common_env(working_dir, include_paths)?;
@@ -91,6 +91,27 @@ pub mod metta_interface_mod {
                     std::process::exit(-1);
                 }
             }
+        }
+
+        fn required_hyperon_version() -> String {
+            const PACKAGE_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+            fn comparator(op: semver::Op, ver: &semver::Version) -> semver::Comparator {
+                semver::Comparator{
+                    op,
+                    major: ver.major,
+                    minor: Some(ver.minor),
+                    patch: Some(0),
+                    pre: semver::Prerelease::EMPTY,
+                }
+            }
+
+            let mut ver = semver::Version::parse(PACKAGE_VERSION).unwrap();
+            let lower_bound = comparator(semver::Op::GreaterEq, &ver);
+            ver.minor = ver.minor + 1;
+            let upper_bound = comparator(semver::Op::Less, &ver);
+            let req = semver::VersionReq{ comparators: vec![lower_bound, upper_bound] };
+            req.to_string()
         }
 
         pub fn init_common_env(working_dir: PathBuf, include_paths: Vec<PathBuf>) -> Result<MettaShim, String> {


### PR DESCRIPTION
Fix version checking procedure in REPL to not hardcode the required version (@luketpeterson please review).
Add Docker image building and publishing step into release workflow.
Separate test and production environments for PyPi and DockerHub to be able approve each step separately.