### PR TITLE
Fix python 3.12 incompatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ page](https://www.rust-lang.org/tools/install). Make sure your
 Rust (see the Notes at the installation page).
 
   Requirements for building C and Python API
-  * Python3 and Python3-dev (3.7 or later, but not 3.12)
+  * Python3 and Python3-dev (3.7 or later)
   * Pip (23.1.2 or later)
   * GCC (7.5 or later)
   * CMake (3.19 or later)

--- a/c/conanfile.txt
+++ b/c/conanfile.txt
@@ -3,3 +3,6 @@ libcheck/0.15.2
 
 [generators]
 cmake
+
+[options]
+libcheck:with_subunit=False

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "hyperon"
 description = "Hyperon API in Python"
 readme = "README.md"
-requires-python = ">=3.7,<3.12"
+requires-python = ">=3.7"
 keywords = ["metta", "hyperon", "opencog"]
 license = {text = "MIT License"}
 classifiers = [


### PR DESCRIPTION
Fixes #584 Turn off using `subunit` in `libcheck` to fix incompatibility