### PR TITLE
Various fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@ FROM python:3.10-slim-bookworm AS os
 
 FROM os AS build
 
-RUN apt update && \
+RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive \
     TZ=UTC \
-    apt install -y sudo git curl cmake build-essential \
+    apt-get install -y sudo git curl cmake build-essential \
         pkg-config libssl-dev zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -213,14 +213,14 @@ For example, to log all hyperon messages at the `debug` level and
 below, while running `script.metta`, you may type:
 
 ```
-RUST_LOG=hyperon=debug metta script.metta
+RUST_LOG=hyperon=debug metta-py script.metta
 ```
 
 Or, to log all hyperon messages at the `trace` level and below,
 restricted to module `metta` and submodule `types`, you may type:
 
 ```
-RUST_LOG=hyperon::metta::types=trace metta script.metta
+RUST_LOG=hyperon::metta::types=trace metta-py script.metta
 ```
 
 By default all log messages are directed to stderr.


### PR DESCRIPTION
Use `metta-py` in README.md. Fix "Unstable interface" warning when Docker is built. Fix crash on adding a single variable into a space.