### PR TITLE
Fix string token definition in stdlib

### DIFF
--- a/lib/src/metta/runner/stdlib.rs
+++ b/lib/src/metta/runner/stdlib.rs
@@ -1872,7 +1872,7 @@ mod non_minimal_only_stdlib {
             |token| { Ok(Atom::gnd(Number::from_float_str(token)?)) });
         tref.register_token(regex(r"True|False"),
             |token| { Atom::gnd(Bool::from_str(token)) });
-        tref.register_token(regex(r#""[^"]+""#),
+        tref.register_token(regex(r#"^".*"$"#),
             |token| { let mut s = String::from(token); s.remove(0); s.pop(); Atom::gnd(Str::from_string(s)) });
         let sum_op = Atom::gnd(SumOp{});
         tref.register_token(regex(r"\+"), move |_| { sum_op.clone() });
@@ -1969,6 +1969,7 @@ mod tests {
     use crate::atom::matcher::atoms_are_equivalent;
     use crate::metta::text::*;
     use crate::metta::runner::EnvBuilder;
+    use crate::metta::runner::string::Str;
     use crate::metta::types::validate_atom;
     use crate::common::test_utils::*;
 
@@ -2712,6 +2713,25 @@ mod tests {
                     ("@param" ("@type" "%Undefined%") ("@desc" {Str::from_str("First argument")}))
                     ("@param" ("@type" "%Undefined%") ("@desc" {Str::from_str("Second argument")})) ))
                 ("@return" ("@type" "%Undefined%") ("@desc" {Str::from_str("Return value")})) )],
+        ]));
+    }
+
+    #[test]
+    fn test_string_parsing() {
+        let metta = Metta::new(Some(EnvBuilder::test_env()));
+        let parser = SExprParser::new(r#"
+            (= (id $x) $x)
+            !(id "test")
+            !(id "te st")
+            !(id "te\"st")
+            !(id "")
+        "#);
+
+        assert_eq_metta_results!(metta.run(parser), Ok(vec![
+            vec![expr!({Str::from_str("test")})],
+            vec![expr!({Str::from_str("te st")})],
+            vec![expr!({Str::from_str("te\"st")})],
+            vec![expr!({Str::from_str("")})],
         ]));
     }
 }

--- a/lib/src/metta/runner/stdlib_minimal.rs
+++ b/lib/src/metta/runner/stdlib_minimal.rs
@@ -506,7 +506,7 @@ pub fn register_rust_stdlib_tokens(target: &mut Tokenizer) {
         |token| { Ok(Atom::gnd(Number::from_float_str(token)?)) });
     tref.register_token(regex(r"True|False"),
         |token| { Atom::gnd(Bool::from_str(token)) });
-    tref.register_token(regex(r#""[^"]+""#),
+    tref.register_token(regex(r#"^".*"$"#),
         |token| { let mut s = String::from(token); s.remove(0); s.pop(); Atom::gnd(Str::from_string(s)) });
     let sum_op = Atom::gnd(SumOp{});
     tref.register_token(regex(r"\+"), move |_| { sum_op.clone() });
@@ -550,6 +550,7 @@ mod tests {
     use super::*;
     use crate::metta::text::SExprParser;
     use crate::metta::runner::EnvBuilder;
+    use crate::metta::runner::string::Str;
     use crate::matcher::atoms_are_equivalent;
     use crate::common::Operation;
     use crate::common::test_utils::metta_space;
@@ -1273,6 +1274,24 @@ mod tests {
             vec![expr!("Symbol")],
             vec![expr!("ErrorType")],
             vec![expr!("Error" ({SumOp{}} {Number::Integer(1)} {Number::Integer(2)}) ({SumOp{}} {Number::Integer(1)} {SumOp{}}))],
+        ]));
+    }
+
+    #[test]
+    fn test_string_parsing() {
+        let metta = Metta::new(Some(EnvBuilder::test_env()));
+        let parser = SExprParser::new(r#"
+            !(id "test")
+            !(id "te st")
+            !(id "te\"st")
+            !(id "")
+        "#);
+
+        assert_eq_metta_results!(metta.run(parser), Ok(vec![
+            vec![expr!({Str::from_str("test")})],
+            vec![expr!({Str::from_str("te st")})],
+            vec![expr!({Str::from_str("te\"st")})],
+            vec![expr!({Str::from_str("")})],
         ]));
     }
 }

--- a/python/hyperon/stdlib.py
+++ b/python/hyperon/stdlib.py
@@ -119,7 +119,7 @@ def type_tokens():
         r"[-+]?\d+" : lambda token: ValueAtom(int(token), 'Number'),
         r"[-+]?\d+\.\d+": lambda token: ValueAtom(float(token), 'Number'),
         r"[-+]?\d+(\.\d+)?[eE][-+]?\d+": lambda token: ValueAtom(float(token), 'Number'),
-        "\"[^\"]*\"": lambda token: ValueAtom(str(token[1:-1]), 'String'),
+        r"^\".*\"$": lambda token: ValueAtom(str(token[1:-1]), 'String'),
         "\'[^\']\'": lambda token: ValueAtom(Char(token[1]), 'Char'),
         r"True|False": lambda token: ValueAtom(token == 'True', 'Bool'),
         r'regex:"[^"]*"': lambda token: G(RegexMatchableObject(token),  AtomType.UNDEFINED)

--- a/python/tests/test_stdlib.py
+++ b/python/tests/test_stdlib.py
@@ -72,6 +72,14 @@ class StdlibTest(HyperonTestCase):
         self.assertEqualMettaRunnerResults(metta.run("!(+ 1.0e3 2.0e3)"), [[ValueAtom(3e3)]])
         self.assertEqualMettaRunnerResults(metta.run("!(+ 5e-3 -2e-3)"), [[ValueAtom(3e-3)]])
 
+    def test_string_parsing(self):
+        metta = MeTTa(env_builder=Environment.test_env())
+        metta.run("(= (id' $x) $x)")
+        self.assertEqualMettaRunnerResults(metta.run("!(id' \"test\")"), [[ValueAtom("test")]])
+        self.assertEqualMettaRunnerResults(metta.run("!(id' \"te st\")"), [[ValueAtom("te st")]])
+        self.assertEqualMettaRunnerResults(metta.run("!(id' \"te\\\"st\")"), [[ValueAtom("te\"st")]])
+        self.assertEqualMettaRunnerResults(metta.run("!(id' \"\")"), [[ValueAtom("")]])
+
     def test_regex(self):
         metta = MeTTa(env_builder=Environment.test_env())
         metta.run('''(= (intent regex:"^Hello[[\.|!]]?$") (Intent Hello))


### PR DESCRIPTION
Make string a token which has double quote as a first and a last characters don't matter what is inside. Otherwise strings like `"te\"st"` are parsed as symbols because they cannot be recognized by regex `"[^"]*"`.