### PR TITLE
Fix native interface of the Python serializer

### DIFF
--- a/python/hyperon/atoms.py
+++ b/python/hyperon/atoms.py
@@ -177,13 +177,16 @@ def _priv_gnd_get_object(atom):
         return SpaceRef._from_cspace(hp.atom_get_space(atom.catom))
     elif typ == S('Bool') or typ == S('Number'):
         converter = ConvertingSerializer()
-        hp.atom_gnd_serialize(atom.catom, converter)
-        if converter.value is None:
-            raise RuntimeError(f"Could not convert atom {atom}")
+        try:
+            res = hp.atom_gnd_serialize(atom.catom, converter)
+        except Exception as e:
+            raise RuntimeError(f"Could not convert atom {atom} to Python value, exception caught: {e}")
+        if res != SerialResult.OK or converter.value is None:
+            raise RuntimeError(f"Could not convert atom {atom} to Python value")
         else:
             return ValueObject(converter.value)
     else:
-        raise TypeError(f"Cannot get_object of unsupported non-C {atom}")
+        raise TypeError(f"Cannot get Python object of unsupported non-C atom {atom}")
 
 
 def G(object, type=AtomType.UNDEFINED):

--- a/python/hyperonpy.cpp
+++ b/python/hyperonpy.cpp
@@ -256,11 +256,11 @@ struct PySerializer : public Serializer {
     }
 
     serial_result_t serialize_int(py::int_ v) override {
-        PYBIND11_OVERRIDE_PURE(serial_result_t, Serializer, serialize_longlong, v);
+        PYBIND11_OVERRIDE_PURE(serial_result_t, Serializer, serialize_int, v);
     }
 
     serial_result_t serialize_float(py::float_ v) override {
-        PYBIND11_OVERRIDE_PURE(serial_result_t, Serializer, serialize_double, v);
+        PYBIND11_OVERRIDE_PURE(serial_result_t, Serializer, serialize_float, v);
     }
 };
 

--- a/python/tests/test_grounded_type.py
+++ b/python/tests/test_grounded_type.py
@@ -138,5 +138,18 @@ class GroundedTypeTest(unittest.TestCase):
         self.assertNotEqual(metta.parse_single("untop").get_grounded_type(),
                 metta.parse_single("untyped").get_grounded_type())
 
+    def test_conversion_between_rust_and_python(self):
+        self.maxDiff = None
+        metta = MeTTa(env_builder=Environment.test_env())
+        integer = metta.run('!(+ 1 (random-int 4 5))', flat=True)[0].get_object()
+        self.assertEqual(integer, ValueObject(5))
+        float = metta.run('!(+ 1.0 (random-float 4 5))', flat=True)[0].get_object()
+        self.assertTrue(float.value >= 5.0 and float.value < 6)
+        bool = metta.run('!(not (flip))', flat=True)[0].get_object()
+        self.assertTrue(bool.value or  not bool.value)
+        false = metta.run('!(not True)', flat=True)[0].get_object()
+        self.assertEquals(false, ValueObject(False))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fix names of the functions inside pybind11 macro stub.
@DaddyWesker should fix example from #791 