### PR TITLE
Show grounded atom conversion exceptions if any

### DIFF
--- a/python/hyperon/atoms.py
+++ b/python/hyperon/atoms.py
@@ -329,9 +329,9 @@ def unwrap_args(atoms):
                     except:
                         raise NoReduceError()
                 continue
-        try:
+        if hasattr(a, 'get_object'):
             args.append(a.get_object().content)
-        except:
+        else:
             # NOTE:
             # Currently, applying grounded operations to pure atoms is not reduced.
             # If we want, we can raise an exception, or form an error expression instead,


### PR DESCRIPTION
Previous implementation hides conversion exception thrown from get_object() method. It makes debug difficult. Handle attempts to call get_object() on non-grounded atoms by separate condition. All other errors are thrown to the upper stack frames.