### PR TITLE
Fix metta function to make evaluation using the passed context space

### DIFF
--- a/lib/src/metta/mod.rs
+++ b/lib/src/metta/mod.rs
@@ -30,6 +30,7 @@ pub const NO_VALID_ALTERNATIVES : Atom = sym!("NoValidAlternatives");
 pub const EMPTY_SYMBOL : Atom = sym!("Empty");
 
 pub const EVAL_SYMBOL : Atom = sym!("eval");
+pub const EVALC_SYMBOL : Atom = sym!("evalc");
 pub const CHAIN_SYMBOL : Atom = sym!("chain");
 pub const UNIFY_SYMBOL : Atom = sym!("unify");
 pub const DECONS_ATOM_SYMBOL : Atom = sym!("decons-atom");

--- a/lib/src/metta/runner/stdlib_minimal.metta
+++ b/lib/src/metta/runner/stdlib_minimal.metta
@@ -38,6 +38,14 @@
   (@return "Result of evaluation"))
 (: eval (-> Atom Atom))
 
+(@doc evalc
+  (@desc "Evaluates input atom, makes one step of the evaluation")
+  (@params (
+    (@param "Atom to be evaluated, can be reduced via equality expression (= ...) or by calling a grounded function")
+    (@param "Space to evaluate atom in its context")))
+  (@return "Result of evaluation"))
+(: evalc (-> Atom Grounded Atom))
+
 (@doc chain
   (@desc "Evaluates first argument, binds it to the variable (second argument) and then evaluates third argument which contains (or not) mentioned variable")
   (@params (


### PR DESCRIPTION
Fixes #803 Add additional evalc operation which can evaluate passed atom using passed space. Use evalc to implement metta function. Add unit test for the case.