### PR TITLE
Separation of stdlib

### DIFF
--- a/lib/src/metta/interpreter_minimal.rs
+++ b/lib/src/metta/interpreter_minimal.rs
@@ -6,7 +6,7 @@ use crate::atom::matcher::*;
 use crate::space::*;
 use crate::metta::*;
 use crate::metta::types::*;
-use crate::metta::runner::stdlib_minimal::IfEqualOp;
+use crate::metta::runner::stdlib_minimal::stdlib_common_tokens::IfEqualOp;
 use crate::common::collections::CowArray;
 
 use std::fmt::{Debug, Display, Formatter};

--- a/lib/src/metta/runner/stdlib_minimal/mod.rs
+++ b/lib/src/metta/runner/stdlib_minimal/mod.rs
@@ -4,6 +4,9 @@ pub mod stdlib_math;
 #[macro_use]
 pub mod stdlib_common_tokens;
 
+#[macro_use]
+pub mod stdlib_runner_tokens;
+
 use crate::*;
 use crate::space::*;
 use crate::metta::*;
@@ -11,17 +14,14 @@ use crate::metta::text::Tokenizer;
 use crate::common::assert::vec_eq_no_order;
 use crate::common::shared::Shared;
 use crate::metta::text::SExprParser;
-use crate::metta::runner::{Metta, RunContext, ModuleLoader, ResourceKey};
+use crate::metta::runner::{Metta, RunContext, ModuleLoader};
 use crate::metta::runner::string::Str;
-use crate::common::CachingMapper;
 #[cfg(feature = "pkg_mgmt")]
 use crate::metta::runner::{git_catalog::ModuleGitLocation, mod_name_from_url, pkg_mgmt::UpdateMode};
 
-use std::convert::TryInto;
 use std::rc::Rc;
 use std::cell::RefCell;
 use std::fmt::Display;
-use std::collections::HashMap;
 use regex::Regex;
 use rand::Rng;
 
@@ -54,342 +54,6 @@ macro_rules! grounded_op {
 
 pub(crate) use grounded_op;
 
-#[derive(Clone, Debug)]
-pub struct ImportOp {
-    //TODO-HACK: This is a terrible horrible ugly hack that should be fixed ASAP
-    context: std::sync::Arc<std::sync::Mutex<Vec<std::sync::Arc<std::sync::Mutex<&'static mut RunContext<'static, 'static>>>>>>,
-}
-
-grounded_op!(ImportOp, "import!");
-
-impl ImportOp {
-    pub fn new(metta: Metta) -> Self {
-        Self{ context: metta.0.context.clone() }
-    }
-}
-
-impl Grounded for ImportOp {
-    fn type_(&self) -> Atom {
-        //TODO: Ideally the "import as" / "import into" part would be optional
-        //A deeper discussion on arg semantics as it relates to import! is here:
-        // https://github.com/trueagi-io/hyperon-experimental/pull/580#discussion_r1491332304
-        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_ATOM, ATOM_TYPE_ATOM, UNIT_TYPE])
-    }
-
-    fn as_execute(&self) -> Option<&dyn CustomExecute> {
-        Some(self)
-    }
-}
-
-impl CustomExecute for ImportOp {
-    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        //QUESTION: "Import" can mean several (3) different things.  In Python parlance, it can mean
-        //1. "import module" opt. ("as bar")
-        //2. "from module import foo" opt. ("as bar")
-        //3. "from module import *"
-        //
-        //Do we want one MeTTa operation with multiple ways of invoking it?  Or do we want different
-        // implementations for different versions of the import operation?  (since we don't have key-words)
-        // like "from" and "as" (unless we want to add them)
-        //
-        //The old version of this operation supported 1. or 3., depending on whether a "space" argument
-        // mapped to an atom that already existed or not.  If the space atom existed and was a Space, then
-        // the operation would perform behavior 3 (by importing only the space atom and no token).
-        // Otherwise it would perform behavior 1, by adding a token, but not adding the child space atom to
-        // the parent space.
-        //
-        //For now, in order to not lose functionality, I have kept this behavior.
-        //
-        // ** TO SUMMARIZE **
-        // If the destination argument is the &self Space atom, the behavior is (3) ie "from module import *",
-        // and if the destination argument is a Symbol atom, the behavior is (1) ie "import module as foo"
-        //
-        //The Underlying functionality for behavior 2 exists in MettaMod::import_item_from_dependency_as,
-        //  but it isn't called yet because I wanted to discuss the way to expose it as a MeTTa op.
-        //For behavior 3, there are deeper questions about desired behavior around tokenizer entries,
-        //  transitive imports, etc.  I have summarized those concerns in the discussion comments above
-        //  MettaMod::import_all_from_dependency
-        //
-
-        let arg_error = || ExecError::from("import! expects a destination &space and a module name argument");
-        let dest_arg = args.get(0).ok_or_else(arg_error)?;
-        let mod_name_atom = args.get(1).ok_or_else(arg_error)?;
-
-        // TODO: replace Symbol by grounded String?
-        let mod_name = match mod_name_atom {
-            Atom::Symbol(mod_name) => mod_name.name(),
-            _ => return Err("import! expects a module name as the first argument".into())
-        };
-        let mod_name = strip_quotes(mod_name);
-
-        // Load the module into the runner, or get the ModId if it's already loaded
-        //TODO: Remove this hack to access the RunContext, when it's part of the arguments to `execute`
-        let ctx_ref = self.context.lock().unwrap().last().unwrap().clone();
-        let mut context = ctx_ref.lock().unwrap();
-        let mod_id = context.load_module(mod_name)?;
-
-        // Import the module, as per the behavior described above
-        match dest_arg {
-            Atom::Symbol(dest_sym) => {
-                context.import_dependency_as(mod_id, Some(dest_sym.name().to_string()))?;
-            }
-            other_atom => {
-                match &other_atom {
-                    Atom::Grounded(_) if Atom::as_gnd::<DynSpace>(other_atom) == Some(context.module().space()) => {
-                        context.import_all_from_dependency(mod_id)?;
-                    },
-                    _ => {
-                        return Err(format!("import! destination argument must be a symbol atom naming a new space, or &self.  Found: {other_atom:?}").into());
-                    }
-                }
-            }
-            // None => {
-            //     //TODO: Currently this pattern is unreachable on account of arity-checking in the MeTTa
-            //     // interpreter, but I have the code path in here for when it is possible
-            //     context.module().import_dependency_as(&context.metta, mod_id, None)?;
-            // },
-        }
-
-        unit_result()
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct IncludeOp {
-    //TODO-HACK: This is a terrible horrible ugly hack that should be fixed ASAP
-    context: std::sync::Arc<std::sync::Mutex<Vec<std::sync::Arc<std::sync::Mutex<&'static mut RunContext<'static, 'static>>>>>>,
-}
-
-grounded_op!(IncludeOp, "include");
-
-impl IncludeOp {
-    pub fn new(metta: Metta) -> Self {
-        Self{ context: metta.0.context.clone() }
-    }
-}
-
-impl Grounded for IncludeOp {
-    fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_ATOM, ATOM_TYPE_ATOM])
-    }
-
-    fn as_execute(&self) -> Option<&dyn CustomExecute> {
-        Some(self)
-    }
-}
-
-impl CustomExecute for IncludeOp {
-    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        let arg_error = || ExecError::from("include expects a module name argument");
-        let mod_name_atom = args.get(0).ok_or_else(arg_error)?;
-
-        // TODO: replace Symbol by grounded String?
-        let mod_name = match mod_name_atom {
-            Atom::Symbol(mod_name) => mod_name.name(),
-            _ => return Err(arg_error())
-        };
-        let mod_name = strip_quotes(mod_name);
-
-        //TODO: Remove this hack to access the RunContext, when it's part of the arguments to `execute`
-        let ctx_ref = self.context.lock().unwrap().last().unwrap().clone();
-        let mut context = ctx_ref.lock().unwrap();
-        let program_buf = context.load_resource_from_module(mod_name, ResourceKey::MainMettaSrc)?;
-
-        // Interpret the loaded MeTTa S-Expression text
-        let program_text = String::from_utf8(program_buf)
-            .map_err(|e| e.to_string())?;
-        let parser = crate::metta::text::OwnedSExprParser::new(program_text);
-        let eval_result = context.run_inline(|context| {
-            context.push_parser(Box::new(parser));
-            Ok(())
-        })?;
-
-        //NOTE: Current behavior returns the result of the last sub-eval to match the old
-        // `import!` before before module isolation.  However that means the results prior to
-        // the last are dropped.  I don't know how to fix this or if it's even wrong, but it's
-        // different from the way "eval-type" APIs work when called from host code, e.g. Rust
-        Ok(eval_result.into_iter().last().unwrap_or_else(|| vec![]))
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct BindOp {
-    tokenizer: Shared<Tokenizer>,
-}
-
-grounded_op!(BindOp, "bind!");
-
-impl BindOp {
-    pub fn new(tokenizer: Shared<Tokenizer>) -> Self {
-        Self{ tokenizer }
-    }
-}
-
-impl Grounded for BindOp {
-    fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_SYMBOL, ATOM_TYPE_UNDEFINED, UNIT_TYPE])
-    }
-
-    fn as_execute(&self) -> Option<&dyn CustomExecute> {
-        Some(self)
-    }
-}
-
-impl CustomExecute for BindOp {
-    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        let arg_error = || ExecError::from("bind! expects two arguments: token and atom");
-        let token = <&SymbolAtom>::try_from(args.get(0).ok_or_else(arg_error)?).map_err(|_| "bind! expects symbol atom as a token")?.name();
-        let atom = args.get(1).ok_or_else(arg_error)?.clone();
-
-        let token_regex = Regex::new(token).map_err(|err| format!("Could convert token {} into regex: {}", token, err))?;
-        self.tokenizer.borrow_mut().register_token(token_regex, move |_| { atom.clone() });
-        unit_result()
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct PragmaOp {
-    settings: Shared<HashMap<String, Atom>>,
-}
-
-grounded_op!(PragmaOp, "pragma!");
-
-impl PragmaOp {
-    pub fn new(settings: Shared<HashMap<String, Atom>>) -> Self {
-        Self{ settings }
-    }
-}
-
-impl Grounded for PragmaOp {
-    fn type_(&self) -> Atom {
-        ATOM_TYPE_UNDEFINED
-    }
-
-    fn as_execute(&self) -> Option<&dyn CustomExecute> {
-        Some(self)
-    }
-}
-
-impl CustomExecute for PragmaOp {
-    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        let arg_error = || ExecError::from("pragma! expects key and value as arguments");
-        let key = <&SymbolAtom>::try_from(args.get(0).ok_or_else(arg_error)?).map_err(|_| "pragma! expects symbol atom as a key")?.name();
-        let value = args.get(1).ok_or_else(arg_error)?;
-        self.settings.borrow_mut().insert(key.into(), value.clone());
-        unit_result()
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct PrintlnOp {}
-
-grounded_op!(PrintlnOp, "println!");
-
-impl Grounded for PrintlnOp {
-    fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_UNDEFINED, UNIT_TYPE])
-    }
-
-    fn as_execute(&self) -> Option<&dyn CustomExecute> {
-        Some(self)
-    }
-}
-
-impl CustomExecute for PrintlnOp {
-    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        let arg_error = || ExecError::from("println! expects single atom as an argument");
-        let atom = args.get(0).ok_or_else(arg_error)?;
-        println!("{}", atom_to_string(atom));
-        unit_result()
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct FormatArgsOp {}
-
-grounded_op!(FormatArgsOp, "format-args");
-
-use dyn_fmt::AsStrFormatExt;
-
-impl Grounded for FormatArgsOp {
-    fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_ATOM, ATOM_TYPE_EXPRESSION, ATOM_TYPE_ATOM])
-    }
-
-    fn as_execute(&self) -> Option<&dyn CustomExecute> {
-        Some(self)
-    }
-}
-
-impl CustomExecute for FormatArgsOp {
-    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        let arg_error = || ExecError::from("format-args expects format string as a first argument and expression as a second argument");
-        let format = atom_to_string(args.get(0).ok_or_else(arg_error)?);
-        let args = TryInto::<&ExpressionAtom>::try_into(args.get(1).ok_or_else(arg_error)?)?;
-        let args: Vec<String> = args.children().iter()
-            .map(|atom| atom_to_string(atom))
-            .collect();
-        let res = format.format(args.as_slice());
-        Ok(vec![Atom::gnd(Str::from_string(res))])
-    }
-}
-
-/// Implement trace! built-in.
-///
-/// It is equivalent to Idris or Haskell Trace, that is, it prints a
-/// message to stderr and pass a value along.
-///
-/// For instance
-/// ```metta
-/// !(trace! "Here?" 42)
-/// ```
-/// prints to stderr
-/// ```stderr
-/// Here?
-/// ```
-/// and returns
-/// ```metta
-/// [42]
-/// ```
-///
-/// Note that the first argument does not need to be a string, which
-/// makes `trace!` actually quite capable on its own.  For instance
-/// ```metta
-/// !(trace! ("Hello world!" (if True A B) 1 2 3) 42)
-/// ```
-/// prints to stderr
-/// ```stderr
-/// (Hello world! A 1 2 3)
-/// ```
-/// and returns
-/// ```metta
-/// [42]
-/// ```
-
-#[derive(Clone, Debug)]
-pub struct TraceOp {}
-
-grounded_op!(TraceOp, "trace!");
-
-impl Grounded for TraceOp {
-    fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_UNDEFINED, Atom::var("a"), Atom::var("a")])
-    }
-
-    fn as_execute(&self) -> Option<&dyn CustomExecute> {
-        Some(self)
-    }
-}
-
-impl CustomExecute for TraceOp {
-    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        let arg_error = || ExecError::from("trace! expects two atoms as arguments");
-        let val = args.get(1).ok_or_else(arg_error)?;
-        let msg = args.get(0).ok_or_else(arg_error)?;
-        eprintln!("{}", msg);
-        Ok(vec![val.clone()])
-    }
-}
 
 #[derive(Clone, PartialEq, Debug)]
 pub struct StateAtom {
@@ -420,46 +84,6 @@ impl Grounded for StateAtom {
             Atom::Grounded(a) => a.type_(),
         };
         Atom::expr([expr!("StateMonad"), typ])
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct SealedOp {}
-
-grounded_op!(SealedOp, "sealed");
-
-impl Grounded for SealedOp {
-    fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_EXPRESSION, ATOM_TYPE_ATOM, ATOM_TYPE_ATOM])
-    }
-
-    fn as_execute(&self) -> Option<&dyn CustomExecute> {
-        Some(self)
-    }
-}
-
-impl CustomExecute for SealedOp {
-    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        let arg_error = || ExecError::from("sealed expects two arguments: var_list and expression");
-
-        let mut term_to_seal = args.get(1).ok_or_else(arg_error)?.clone();
-        let var_list = args.get(0).ok_or_else(arg_error)?.clone();
-
-        let mut local_var_mapper = CachingMapper::new(|var: &VariableAtom| var.clone().make_unique());
-
-        var_list.iter().filter_type::<&VariableAtom>()
-            .for_each(|var| { let _ = local_var_mapper.replace(var); });
-
-        term_to_seal.iter_mut().filter_type::<&mut VariableAtom>()
-            .for_each(|var| match local_var_mapper.mapping().get(var) {
-                Some(v) => *var = v.clone(),
-                None => {},
-            });
-
-        let result = vec![term_to_seal.clone()];
-        log::debug!("sealed::execute: var_list: {}, term_to_seal: {}, result: {:?}", var_list, term_to_seal, result);
-
-        Ok(result)
     }
 }
 
@@ -679,35 +303,6 @@ impl CustomExecute for RandomFloatOp {
     }
 }
 
-#[derive(Clone, Debug)]
-pub struct PrintAlternativesOp {}
-
-grounded_op!(PrintAlternativesOp, "print-alternatives!");
-
-impl Grounded for PrintAlternativesOp {
-    fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_ATOM, ATOM_TYPE_EXPRESSION, UNIT_TYPE])
-    }
-
-    fn as_execute(&self) -> Option<&dyn CustomExecute> {
-        Some(self)
-    }
-}
-
-impl CustomExecute for PrintAlternativesOp {
-    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        let arg_error = || ExecError::from("print-alternatives! expects format string as a first argument and expression as a second argument");
-        let atom = atom_to_string(args.get(0).ok_or_else(arg_error)?);
-        let args = TryInto::<&ExpressionAtom>::try_into(args.get(1).ok_or_else(arg_error)?)?;
-        let args: Vec<String> = args.children().iter()
-            .map(|atom| atom_to_string(atom))
-            .collect();
-        println!("{} {}:", args.len(), atom);
-        args.iter().for_each(|arg| println!("    {}", arg));
-        Ok(vec![UNIT_ATOM])
-    }
-}
-
 fn atom_to_string(atom: &Atom) -> String {
     match atom {
         Atom::Grounded(gnd) if gnd.type_() == ATOM_TYPE_STRING => {
@@ -719,8 +314,6 @@ fn atom_to_string(atom: &Atom) -> String {
         _ => atom.to_string(),
     }
 }
-
-
 
 // TODO: remove hiding errors completely after making it possible passing
 // them to the user
@@ -745,250 +338,6 @@ fn assert_results_equal(actual: &Vec<Atom>, expected: &Vec<Atom>, atom: &Atom) -
     match vec_eq_no_order(actual.iter(), expected.iter()) {
         Ok(()) => unit_result(),
         Err(diff) => Err(ExecError::Runtime(format!("{}\n{}", report, diff)))
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct AssertEqualOp {
-    space: DynSpace,
-}
-
-grounded_op!(AssertEqualOp, "assertEqual");
-
-impl AssertEqualOp {
-    pub fn new(space: DynSpace) -> Self {
-        Self{ space }
-    }
-}
-
-impl Grounded for AssertEqualOp {
-    fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_ATOM, ATOM_TYPE_ATOM, ATOM_TYPE_ATOM])
-    }
-
-    fn as_execute(&self) -> Option<&dyn CustomExecute> {
-        Some(self)
-    }
-}
-
-impl CustomExecute for AssertEqualOp {
-    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        log::debug!("AssertEqualOp::execute: {:?}", args);
-        let arg_error = || ExecError::from("assertEqual expects two atoms as arguments: actual and expected");
-        let actual_atom = args.get(0).ok_or_else(arg_error)?;
-        let expected_atom = args.get(1).ok_or_else(arg_error)?;
-
-        let actual = interpret_no_error(self.space.clone(), actual_atom)?;
-        let expected = interpret_no_error(self.space.clone(), expected_atom)?;
-
-        assert_results_equal(&actual, &expected, actual_atom)
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct AssertEqualToResultOp {
-    space: DynSpace,
-}
-
-grounded_op!(AssertEqualToResultOp, "assertEqualToResult");
-
-impl AssertEqualToResultOp {
-    pub fn new(space: DynSpace) -> Self {
-        Self{ space }
-    }
-}
-
-impl Grounded for AssertEqualToResultOp {
-    fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_ATOM, ATOM_TYPE_ATOM, ATOM_TYPE_ATOM])
-    }
-
-    fn as_execute(&self) -> Option<&dyn CustomExecute> {
-        Some(self)
-    }
-}
-
-impl CustomExecute for AssertEqualToResultOp {
-    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        log::debug!("AssertEqualToResultOp::execute: {:?}", args);
-        let arg_error = || ExecError::from("assertEqualToResult expects two atoms as arguments: actual and expected");
-        let actual_atom = args.get(0).ok_or_else(arg_error)?;
-        let expected = TryInto::<&ExpressionAtom>::try_into(args.get(1).ok_or_else(arg_error)?)
-            .map_err(|_| arg_error())?
-            .children();
-
-        let actual = interpret_no_error(self.space.clone(), actual_atom)?;
-
-        assert_results_equal(&actual, &expected.into(), actual_atom)
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct SuperposeOp {
-    space: DynSpace,
-}
-
-grounded_op!(SuperposeOp, "superpose");
-
-impl SuperposeOp {
-    fn new(space: DynSpace) -> Self {
-        Self{ space }
-    }
-}
-
-impl Grounded for SuperposeOp {
-    fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_EXPRESSION, ATOM_TYPE_UNDEFINED])
-    }
-
-    fn as_execute(&self) -> Option<&dyn CustomExecute> {
-        Some(self)
-    }
-}
-
-impl CustomExecute for SuperposeOp {
-    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        let arg_error = || ExecError::from("superpose expects single expression as an argument");
-        let atom = args.get(0).ok_or_else(arg_error)?;
-        let expr  = TryInto::<&ExpressionAtom>::try_into(atom).map_err(|_| arg_error())?;
-
-        if expr.children().is_empty() {
-            Ok(vec![EMPTY_SYMBOL])
-        } else {
-            let mut superposed = Vec::new();
-            for atom in expr.children() {
-                match interpret_no_error(self.space.clone(), atom) {
-                    Ok(results) => { superposed.extend(results); },
-                    Err(message) => { return Err(format!("Error: {}", message).into()) },
-                }
-            }
-            Ok(superposed)
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct CollapseOp {
-    space: DynSpace,
-}
-
-grounded_op!(CollapseOp, "collapse");
-
-impl CollapseOp {
-    pub fn new(space: DynSpace) -> Self {
-        Self{ space }
-    }
-}
-
-impl Grounded for CollapseOp {
-    fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_ATOM, ATOM_TYPE_ATOM])
-    }
-
-    fn as_execute(&self) -> Option<&dyn CustomExecute> {
-        Some(self)
-    }
-}
-
-impl CustomExecute for CollapseOp {
-    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        let arg_error = || ExecError::from("collapse expects single executable atom as an argument");
-        let atom = args.get(0).ok_or_else(arg_error)?;
-
-        // TODO: Calling interpreter inside the operation is not too good
-        // Could it be done via returning atom for the further interpretation?
-        let result = interpret_no_error(self.space.clone(), atom)?;
-
-        Ok(vec![Atom::expr(result)])
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct CaptureOp {
-    space: DynSpace,
-}
-
-grounded_op!(CaptureOp, "capture");
-
-impl CaptureOp {
-    pub fn new(space: DynSpace) -> Self {
-        Self{ space }
-    }
-}
-
-impl Grounded for CaptureOp {
-    fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_ATOM, ATOM_TYPE_ATOM])
-    }
-
-    fn as_execute(&self) -> Option<&dyn CustomExecute> {
-        Some(self)
-    }
-}
-
-impl CustomExecute for CaptureOp {
-    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        let arg_error = || ExecError::from("capture expects one argument");
-        let atom = args.get(0).ok_or_else(arg_error)?;
-        interpret(self.space.clone(), &atom).map_err(|e| ExecError::from(e))
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct CaseOp {
-    space: DynSpace,
-}
-
-grounded_op!(CaseOp, "case");
-
-impl CaseOp {
-    pub fn new(space: DynSpace) -> Self {
-        Self{ space }
-    }
-}
-
-impl Grounded for CaseOp {
-    fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_ATOM, ATOM_TYPE_EXPRESSION, ATOM_TYPE_ATOM])
-    }
-
-    fn as_execute(&self) -> Option<&dyn CustomExecute> {
-        Some(self)
-    }
-}
-
-impl CustomExecute for CaseOp {
-    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        let arg_error = || ExecError::from("case expects two arguments: atom and expression of cases");
-        let cases = args.get(1).ok_or_else(arg_error)?;
-        let atom = args.get(0).ok_or_else(arg_error)?;
-        log::debug!("CaseOp::execute: atom: {}, cases: {:?}", atom, cases);
-
-        let switch = |interpreted: Atom| -> Atom {
-            Atom::expr([sym!("switch"), interpreted, cases.clone()])
-        };
-
-        // Interpreting argument inside CaseOp is required because otherwise `Empty` result
-        // calculated inside interpreter cuts the whole branch of the interpretation. Also we
-        // cannot use `unify` in a unit test because after interpreting `(chain... (chain
-        // (metta (unify ...) Atom <space>)) ...)` `chain` executes `unify` and also gets
-        // `Empty` even if we have `Atom` as a resulting type. It can be solved by different ways.
-        // One way is to invent new type `EmptyType` (type of the `Empty` atom) and use this type
-        // in a function to allow `Empty` atoms as an input. `EmptyType` type should not be
-        // casted to the `%Undefined%` thus one cannot pass `Empty` to the function which accepts
-        // `%Undefined%`. Another way is to introduce "call" level. Thus if function called
-        // returned the result to the `chain` it should stop reducing it and insert it into the
-        // last argument.
-        let results = interpret(self.space.clone(), atom);
-        log::debug!("CaseOp::execute: atom results: {:?}", results);
-        let results = match results {
-            Ok(results) if results.is_empty() =>
-                vec![switch(EMPTY_SYMBOL)],
-            Ok(results) =>
-                results.into_iter().map(|atom| switch(atom)).collect(),
-            Err(err) => vec![Atom::expr([ERROR_SYMBOL, atom.clone(), Atom::sym(err)])],
-        };
-        Ok(results)
     }
 }
 
@@ -1091,35 +440,35 @@ pub fn register_common_tokens(tref: &mut Tokenizer, _tokenizer: Shared<Tokenizer
 // to the runner & module state.  https://github.com/trueagi-io/hyperon-experimental/issues/410
 pub fn register_runner_tokens(tref: &mut Tokenizer, tokenizer: Shared<Tokenizer>, space: &DynSpace, metta: &Metta) {
 
-    let assert_equal_op = Atom::gnd(AssertEqualOp::new(space.clone()));
+    let assert_equal_op = Atom::gnd(stdlib_runner_tokens::AssertEqualOp::new(space.clone()));
     tref.register_token(regex(r"assertEqual"), move |_| { assert_equal_op.clone() });
-    let assert_equal_to_result_op = Atom::gnd(AssertEqualToResultOp::new(space.clone()));
+    let assert_equal_to_result_op = Atom::gnd(stdlib_runner_tokens::AssertEqualToResultOp::new(space.clone()));
     tref.register_token(regex(r"assertEqualToResult"), move |_| { assert_equal_to_result_op.clone() });
-    let superpose_op = Atom::gnd(SuperposeOp::new(space.clone()));
+    let superpose_op = Atom::gnd(stdlib_runner_tokens::SuperposeOp::new(space.clone()));
     tref.register_token(regex(r"superpose"), move |_| { superpose_op.clone() });
-    let collapse_op = Atom::gnd(CollapseOp::new(space.clone()));
+    let collapse_op = Atom::gnd(stdlib_runner_tokens::CollapseOp::new(space.clone()));
     tref.register_token(regex(r"collapse"), move |_| { collapse_op.clone() });
-    let case_op = Atom::gnd(CaseOp::new(space.clone()));
+    let case_op = Atom::gnd(stdlib_runner_tokens::CaseOp::new(space.clone()));
     tref.register_token(regex(r"case"), move |_| { case_op.clone() });
-    let capture_op = Atom::gnd(CaptureOp::new(space.clone()));
+    let capture_op = Atom::gnd(stdlib_runner_tokens::CaptureOp::new(space.clone()));
     tref.register_token(regex(r"capture"), move |_| { capture_op.clone() });
-    let pragma_op = Atom::gnd(PragmaOp::new(metta.settings().clone()));
+    let pragma_op = Atom::gnd(stdlib_runner_tokens::PragmaOp::new(metta.settings().clone()));
     tref.register_token(regex(r"pragma!"), move |_| { pragma_op.clone() });
-    let import_op = Atom::gnd(ImportOp::new(metta.clone()));
+    let import_op = Atom::gnd(stdlib_runner_tokens::ImportOp::new(metta.clone()));
     tref.register_token(regex(r"import!"), move |_| { import_op.clone() });
-    let include_op = Atom::gnd(IncludeOp::new(metta.clone()));
+    let include_op = Atom::gnd(stdlib_runner_tokens::IncludeOp::new(metta.clone()));
     tref.register_token(regex(r"include"), move |_| { include_op.clone() });
-    let bind_op = Atom::gnd(BindOp::new(tokenizer.clone()));
+    let bind_op = Atom::gnd(stdlib_runner_tokens::BindOp::new(tokenizer.clone()));
     tref.register_token(regex(r"bind!"), move |_| { bind_op.clone() });
-    let trace_op = Atom::gnd(TraceOp{});
+    let trace_op = Atom::gnd(stdlib_runner_tokens::TraceOp{});
     tref.register_token(regex(r"trace!"), move |_| { trace_op.clone() });
-    let println_op = Atom::gnd(PrintlnOp{});
+    let println_op = Atom::gnd(stdlib_runner_tokens::PrintlnOp{});
     tref.register_token(regex(r"println!"), move |_| { println_op.clone() });
-    let format_args_op = Atom::gnd(FormatArgsOp{});
+    let format_args_op = Atom::gnd(stdlib_runner_tokens::FormatArgsOp{});
     tref.register_token(regex(r"format-args"), move |_| { format_args_op.clone() });
-    let print_alternatives_op = Atom::gnd(PrintAlternativesOp{});
+    let print_alternatives_op = Atom::gnd(stdlib_runner_tokens::PrintAlternativesOp{});
     tref.register_token(regex(r"print-alternatives!"), move |_| { print_alternatives_op.clone() });
-    let sealed_op = Atom::gnd(SealedOp{});
+    let sealed_op = Atom::gnd(stdlib_runner_tokens::SealedOp{});
     tref.register_token(regex(r"sealed"), move |_| { sealed_op.clone() });
     // &self should be updated
     // TODO: adding &self might be done not by stdlib, but by MeTTa itself.
@@ -1218,9 +567,7 @@ mod tests {
     use crate::metta::runner::string::Str;
     use crate::matcher::atoms_are_equivalent;
     use crate::common::Operation;
-    use crate::common::test_utils::metta_space;
 
-    use std::convert::TryFrom;
     use std::fmt::Display;
     use regex::Regex;
 
@@ -1268,17 +615,6 @@ mod tests {
         assert_eq!(result, Ok(vec![vec![]]));
     }
 
-    #[test]
-    fn metta_case_empty() {
-        let result = run_program("!(case Empty ( (ok ok) (Empty nok) ))");
-        assert_eq!(result, Ok(vec![vec![expr!("nok")]]));
-        let result = run_program("!(case (unify (C B) (C B) ok Empty) ( (ok ok) (Empty nok) ))");
-        assert_eq!(result, Ok(vec![vec![expr!("ok")]]));
-        let result = run_program("!(case (unify (B C) (C B) ok nok) ( (ok ok) (nok nok) ))");
-        assert_eq!(result, Ok(vec![vec![expr!("nok")]]));
-        let result = run_program("!(case (unify (B C) (C B) ok Empty) ( (ok ok) (Empty nok) ))");
-        assert_eq!(result, Ok(vec![vec![expr!("nok")]]));
-    }
 
     #[test]
     fn metta_is_function() {
@@ -1420,80 +756,6 @@ mod tests {
     fn metta_interpret_single_atom_with_two_types() {
         let result = run_program("(: a A) (: a B) !(metta a %Undefined% &self)");
         assert_eq!(result, Ok(vec![vec![expr!("a")]]));
-    }
-
-    #[test]
-    fn metta_assert_equal_op() {
-        let metta = Metta::new(Some(EnvBuilder::test_env()));
-        let assert = AssertEqualOp::new(metta.space().clone());
-        let program = "
-            (= (foo $x) $x)
-            (= (bar $x) $x)
-        ";
-        assert_eq!(metta.run(SExprParser::new(program)), Ok(vec![]));
-        assert_eq!(metta.run(SExprParser::new("!(assertEqual (foo A) (bar A))")), Ok(vec![
-            vec![UNIT_ATOM],
-        ]));
-        assert_eq!(metta.run(SExprParser::new("!(assertEqual (foo A) (bar B))")), Ok(vec![
-            vec![expr!("Error" ({assert.clone()} ("foo" "A") ("bar" "B")) "\nExpected: [B]\nGot: [A]\nMissed result: B")],
-        ]));
-        assert_eq!(metta.run(SExprParser::new("!(assertEqual (foo A) Empty)")), Ok(vec![
-            vec![expr!("Error" ({assert.clone()} ("foo" "A") "Empty") "\nExpected: []\nGot: [A]\nExcessive result: A")]
-        ]));
-    }
-
-    #[test]
-    fn metta_assert_equal_to_result_op() {
-        let metta = Metta::new(Some(EnvBuilder::test_env()));
-        let assert = AssertEqualToResultOp::new(metta.space().clone());
-        let program = "
-            (= (foo) A)
-            (= (foo) B)
-            (= (bar) C)
-            (= (baz) D)
-            (= (baz) D)
-        ";
-        assert_eq!(metta.run(SExprParser::new(program)), Ok(vec![]));
-        assert_eq!(metta.run(SExprParser::new("!(assertEqualToResult (foo) (A B))")), Ok(vec![
-            vec![UNIT_ATOM],
-        ]));
-        assert_eq!(metta.run(SExprParser::new("!(assertEqualToResult (bar) (A))")), Ok(vec![
-            vec![expr!("Error" ({assert.clone()} ("bar") ("A")) "\nExpected: [A]\nGot: [C]\nMissed result: A")],
-        ]));
-        assert_eq!(metta.run(SExprParser::new("!(assertEqualToResult (baz) (D))")), Ok(vec![
-            vec![expr!("Error" ({assert.clone()} ("baz") ("D")) "\nExpected: [D]\nGot: [D, D]\nExcessive result: D")]
-        ]));
-    }
-
-    #[test]
-    fn metta_superpose() {
-        assert_eq_metta_results!(run_program("!(superpose (red yellow green))"),
-            Ok(vec![vec![expr!("red"), expr!("yellow"), expr!("green")]]));
-        let program = "
-            (= (foo) FOO)
-            (= (bar) BAR)
-            !(superpose ((foo) (bar) BAZ))
-        ";
-        assert_eq_metta_results!(run_program(program),
-            Ok(vec![vec![expr!("FOO"), expr!("BAR"), expr!("BAZ")]]));
-    }
-
-    #[test]
-    fn metta_collapse() {
-        let program = "
-            (= (color) red)
-            (= (color) green)
-            (= (color) blue)
-            !(collapse (color))
-        ";
-        let result = run_program(program).expect("Successful result is expected");
-        assert_eq!(result.len(), 1);
-        let result = result.get(0).unwrap();
-        assert_eq!(result.len(), 1);
-        let result = result.get(0).unwrap();
-        let actual = <&ExpressionAtom>::try_from(result)
-            .expect("Expression atom is expected").children();
-        assert_eq_no_order!(actual, vec![expr!("red"), expr!("green"), expr!("blue")]);
     }
 
     #[test]
@@ -1704,49 +966,6 @@ mod tests {
             Ok(vec![vec![expr!("Error" ("foo" "a" "b" "c") "IncorrectNumberOfArguments")]]));
     }
 
-    #[test]
-    fn sealed_op_runner() {
-        let nested = run_program("!(sealed ($x) (sealed ($a $b) (quote (= ($a $x $c) ($b)))))");
-        let simple_replace = run_program("!(sealed ($x $y) (quote (= ($y $z))))");
-
-        assert!(crate::atom::matcher::atoms_are_equivalent(&nested.unwrap()[0][0], &expr!("quote" ("=" (a b c) (z)))));
-        assert!(crate::atom::matcher::atoms_are_equivalent(&simple_replace.unwrap()[0][0], &expr!("quote" ("=" (y z)))));
-    }
-
-    #[test]
-    fn sealed_op_execute() {
-        let val = SealedOp{}.execute(&mut vec![expr!(x y), expr!("="(y z))]);
-        assert!(crate::atom::matcher::atoms_are_equivalent(&val.unwrap()[0], &expr!("="(y z))));
-    }
-
-    #[test]
-    fn use_sealed_to_make_scoped_variable() {
-        assert_eq!(run_program("!(let $x (input $x) (output $x))"), Ok(vec![vec![]]));
-        assert_eq!(run_program("!(let $x (input $y) (output $x))"), Ok(vec![vec![expr!("output" ("input" y))]]));
-        assert_eq!(run_program("!(let (quote ($sv $st)) (sealed ($x) (quote ($x (output $x))))
-               (let $sv (input $x) $st))"), Ok(vec![vec![expr!("output" ("input" x))]]));
-    }
-
-    #[test]
-    fn test_pragma_interpreter_bare_minimal() {
-        let program = "
-            (= (bar) baz)
-            (= (foo) (bar))
-            !(foo)
-            !(pragma! interpreter bare-minimal)
-            !(foo)
-            !(eval (foo))
-        ";
-
-        assert_eq_metta_results!(run_program(program),
-            Ok(vec![
-                vec![expr!("baz")],
-                vec![UNIT_ATOM],
-                vec![expr!(("foo"))],
-                vec![expr!(("bar"))],
-            ]));
-    }
-
     #[derive(Clone, PartialEq, Debug)]
     pub struct SomeGndAtom { }
 
@@ -1941,76 +1160,6 @@ mod tests {
     }
 
     #[test]
-    fn bind_new_space_op() {
-        let tokenizer = Shared::new(Tokenizer::new());
-
-        let bind_op = BindOp::new(tokenizer.clone());
-
-        assert_eq!(bind_op.execute(&mut vec![sym!("&my"), sym!("definition")]), unit_result());
-        let borrowed = tokenizer.borrow();
-        let constr = borrowed.find_token("&my");
-        assert!(constr.is_some());
-        assert_eq!(constr.unwrap()("&my"), Ok(sym!("definition")));
-    }
-
-    fn assert_runtime_error(actual: Result<Vec<Atom>, ExecError>, expected: Regex) {
-        match actual {
-            Err(ExecError::Runtime(msg)) => assert!(expected.is_match(msg.as_str()),
-                "Incorrect error message:\nexpected: {:?}\n  actual: {:?}", expected.to_string(), msg),
-            _ => assert!(false, "Error is expected as result, {:?} returned", actual),
-        }
-    }
-
-    #[test]
-    fn assert_equal_op() {
-        let space = DynSpace::new(metta_space("
-            (= (foo) (A B))
-            (= (foo) (B C))
-            (= (bar) (B C))
-            (= (bar) (A B))
-            (= (err) (A B))
-        "));
-
-        let assert_equal_op = AssertEqualOp::new(space);
-
-        assert_eq!(assert_equal_op.execute(&mut vec![expr!(("foo")), expr!(("bar"))]), unit_result());
-
-        let actual = assert_equal_op.execute(&mut vec![expr!(("foo")), expr!(("err"))]);
-        let expected = Regex::new("\nExpected: \\[(A B)\\]\nGot: \\[\\((B C)|, |(A B)\\){3}\\]\nExcessive result: (B C)").unwrap();
-        assert_runtime_error(actual, expected);
-
-        let actual = assert_equal_op.execute(&mut vec![expr!(("err")), expr!(("foo"))]);
-        let expected = Regex::new("\nExpected: \\[\\((B C)|, |(A B)\\){3}\\]\nGot: \\[(A B)\\]\nMissed result: (B C)").unwrap();
-        assert_runtime_error(actual, expected);
-    }
-
-    #[test]
-    fn assert_equal_to_result_op() {
-        let space = DynSpace::new(metta_space("
-            (= (foo) (A B))
-            (= (foo) (B C))
-        "));
-        let assert_equal_to_result_op = AssertEqualToResultOp::new(space);
-
-        assert_eq!(assert_equal_to_result_op.execute(&mut vec![
-                expr!(("foo")), expr!(("B" "C") ("A" "B"))]),
-                unit_result());
-    }
-
-    #[test]
-    fn println_op() {
-        assert_eq!(PrintlnOp{}.execute(&mut vec![sym!("A")]), unit_result());
-    }
-
-    #[test]
-    fn trace_op() {
-        assert_eq!(TraceOp{}.execute(&mut vec![sym!("\"Here?\""), sym!("42")]),
-                   Ok(vec![sym!("42")]));
-    }
-
-
-
-    #[test]
     fn let_op_keep_variables_equalities_issue290() {
         assert_eq_metta_results!(run_program("!(let* (($f f) ($f $x)) $x)"), Ok(vec![vec![expr!("f")]]));
         assert_eq_metta_results!(run_program("!(let* (($f $x) ($f f)) $x)"), Ok(vec![vec![expr!("f")]]));
@@ -2122,6 +1271,4 @@ mod tests {
         let res = RandomFloatOp{}.execute(&mut vec![expr!({Number::Integer(0)}), expr!({Number::Integer(0)})]);
         assert_eq!(res, Err(ExecError::from("Range is empty")));
     }
-
-
 }

--- a/lib/src/metta/runner/stdlib_minimal/mod.rs
+++ b/lib/src/metta/runner/stdlib_minimal/mod.rs
@@ -571,7 +571,7 @@ mod tests {
     use std::fmt::Display;
     use regex::Regex;
 
-    fn run_program(program: &str) -> Result<Vec<Vec<Atom>>, String> {
+    pub fn run_program(program: &str) -> Result<Vec<Vec<Atom>>, String> {
         let metta = Metta::new(Some(EnvBuilder::test_env()));
         metta.run(SExprParser::new(program))
     }

--- a/lib/src/metta/runner/stdlib_minimal/mod.rs
+++ b/lib/src/metta/runner/stdlib_minimal/mod.rs
@@ -1,19 +1,19 @@
 #[macro_use]
 pub mod stdlib_math;
 
+#[macro_use]
+pub mod stdlib_common_tokens;
+
 use crate::*;
 use crate::space::*;
 use crate::metta::*;
 use crate::metta::text::Tokenizer;
-use crate::metta::types::{get_atom_types, get_meta_type};
 use crate::common::assert::vec_eq_no_order;
 use crate::common::shared::Shared;
 use crate::metta::text::SExprParser;
 use crate::metta::runner::{Metta, RunContext, ModuleLoader, ResourceKey};
 use crate::metta::runner::string::Str;
 use crate::common::CachingMapper;
-use crate::common::multitrie::MultiTrie;
-use crate::space::grounding::atom_to_trie_key;
 #[cfg(feature = "pkg_mgmt")]
 use crate::metta::runner::{git_catalog::ModuleGitLocation, mod_name_from_url, pkg_mgmt::UpdateMode};
 
@@ -212,93 +212,6 @@ impl CustomExecute for IncludeOp {
     }
 }
 
-/// mod-space! returns the space of a specified module, loading the module if it's not loaded already
-//NOTE: The "impure" '!' denoted in the op atom name is due to the side effect of loading the module.  If
-// we want a side-effect-free version, it could be implemented by calling `RunContext::get_module_by_name`
-// instead of `RunContext::load_module`, but then the user would need to use `register-module!`, `import!`,
-// or some other mechanism to make sure the module is loaded in advance.
-#[derive(Clone, Debug)]
-pub struct ModSpaceOp {
-    //TODO-HACK: This is a terrible horrible ugly hack that should be fixed ASAP
-    context: std::sync::Arc<std::sync::Mutex<Vec<std::sync::Arc<std::sync::Mutex<&'static mut RunContext<'static, 'static>>>>>>,
-}
-
-grounded_op!(ModSpaceOp, "mod-space!");
-
-impl ModSpaceOp {
-    pub fn new(metta: Metta) -> Self {
-        Self{ context: metta.0.context.clone() }
-    }
-}
-
-impl Grounded for ModSpaceOp {
-    fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_ATOM, rust_type_atom::<DynSpace>()])
-    }
-
-    fn as_execute(&self) -> Option<&dyn CustomExecute> {
-        Some(self)
-    }
-}
-
-impl CustomExecute for ModSpaceOp {
-    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        let arg_error = "mod-space! expects a module name argument";
-        let mod_name_atom = args.get(0).ok_or_else(|| ExecError::from(arg_error))?;
-
-        // TODO: replace Symbol by grounded String?
-        let mod_name = match mod_name_atom {
-            Atom::Symbol(mod_name) => mod_name.name(),
-            _ => {return Err(ExecError::from(arg_error))}
-        };
-        let mod_name = strip_quotes(mod_name);
-
-        // Load the module into the runner, or get the ModId if it's already loaded
-        //TODO: Remove this hack to access the RunContext, when it's part of the arguments to `execute`
-        let ctx_ref = self.context.lock().unwrap().last().unwrap().clone();
-        let mut context = ctx_ref.lock().unwrap();
-        let mod_id = context.load_module(mod_name)?;
-
-        let space = Atom::gnd(context.metta().module_space(mod_id));
-        Ok(vec![space])
-    }
-}
-
-/// This operation prints the modules loaded from the top of the runner
-///
-/// NOTE: This is a temporary stop-gap to help MeTTa users inspect which modules they have loaded and
-/// debug module import issues.  Ultimately it probably makes sense to make this information accessible
-/// as a special kind of Space, so that it would be possible to work with it programmatically.
-#[derive(Clone, Debug)]
-pub struct PrintModsOp {
-    metta: Metta
-}
-
-grounded_op!(PrintModsOp, "print-mods!");
-
-impl PrintModsOp {
-    pub fn new(metta: Metta) -> Self {
-        Self{ metta }
-    }
-}
-
-impl Grounded for PrintModsOp {
-    fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, UNIT_TYPE])
-    }
-
-    fn as_execute(&self) -> Option<&dyn CustomExecute> {
-        Some(self)
-    }
-}
-
-impl CustomExecute for PrintModsOp {
-    fn execute(&self, _args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        self.metta.display_loaded_modules();
-        unit_result()
-    }
-}
-
 #[derive(Clone, Debug)]
 pub struct BindOp {
     tokenizer: Shared<Tokenizer>,
@@ -335,114 +248,6 @@ impl CustomExecute for BindOp {
 }
 
 #[derive(Clone, Debug)]
-pub struct NewSpaceOp {}
-
-grounded_op!(NewSpaceOp, "new-space");
-
-impl Grounded for NewSpaceOp {
-    fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, rust_type_atom::<DynSpace>()])
-    }
-
-    fn as_execute(&self) -> Option<&dyn CustomExecute> {
-        Some(self)
-    }
-}
-
-impl CustomExecute for NewSpaceOp {
-    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        if args.len() == 0 {
-            let space = Atom::gnd(DynSpace::new(GroundingSpace::new()));
-            Ok(vec![space])
-        } else {
-            Err("new-space doesn't expect arguments".into())
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct AddAtomOp {}
-
-grounded_op!(AddAtomOp, "add-atom");
-
-impl Grounded for AddAtomOp {
-    fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, rust_type_atom::<DynSpace>(),
-            ATOM_TYPE_ATOM, UNIT_TYPE])
-    }
-
-    fn as_execute(&self) -> Option<&dyn CustomExecute> {
-        Some(self)
-    }
-}
-
-impl CustomExecute for AddAtomOp {
-    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        let arg_error = || ExecError::from("add-atom expects two arguments: space and atom");
-        let space = args.get(0).ok_or_else(arg_error)?;
-        let atom = args.get(1).ok_or_else(arg_error)?;
-        let space = Atom::as_gnd::<DynSpace>(space).ok_or("add-atom expects a space as the first argument")?;
-        space.borrow_mut().add(atom.clone());
-        unit_result()
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct RemoveAtomOp {}
-
-grounded_op!(RemoveAtomOp, "remove-atom");
-
-impl Grounded for RemoveAtomOp {
-    fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, rust_type_atom::<DynSpace>(),
-            ATOM_TYPE_ATOM, UNIT_TYPE])
-    }
-
-    fn as_execute(&self) -> Option<&dyn CustomExecute> {
-        Some(self)
-    }
-}
-
-impl CustomExecute for RemoveAtomOp {
-    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        let arg_error = || ExecError::from("remove-atom expects two arguments: space and atom");
-        let space = args.get(0).ok_or_else(arg_error)?;
-        let atom = args.get(1).ok_or_else(arg_error)?;
-        let space = Atom::as_gnd::<DynSpace>(space).ok_or("remove-atom expects a space as the first argument")?;
-        space.borrow_mut().remove(atom);
-        // TODO? Is it necessary to distinguish whether the atom was removed or not?
-        unit_result()
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct GetAtomsOp {}
-
-grounded_op!(GetAtomsOp, "get-atoms");
-
-impl Grounded for GetAtomsOp {
-    fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, rust_type_atom::<DynSpace>(),
-            ATOM_TYPE_ATOM])
-    }
-
-    fn as_execute(&self) -> Option<&dyn CustomExecute> {
-        Some(self)
-    }
-}
-
-impl CustomExecute for GetAtomsOp {
-    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        let arg_error = || ExecError::from("get-atoms expects one argument: space");
-        let space = args.get(0).ok_or_else(arg_error)?;
-        let space = Atom::as_gnd::<DynSpace>(space).ok_or("get-atoms expects a space as its argument")?;
-        space.borrow().as_space().atom_iter()
-            .map(|iter| iter.cloned().map(|a| make_variables_unique(a)).collect())
-            .ok_or(ExecError::Runtime("Unsupported Operation. Can't traverse atoms in this space".to_string()))
-    }
-}
-
-#[derive(Clone, Debug)]
 pub struct PragmaOp {
     settings: Shared<HashMap<String, Atom>>,
 }
@@ -474,58 +279,6 @@ impl CustomExecute for PragmaOp {
         unit_result()
     }
 }
-
-#[derive(Clone, Debug)]
-pub struct GetTypeSpaceOp {}
-
-grounded_op!(GetTypeSpaceOp, "get-type-space");
-
-impl Grounded for GetTypeSpaceOp {
-    fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, rust_type_atom::<DynSpace>(), ATOM_TYPE_ATOM, ATOM_TYPE_ATOM])
-    }
-
-    fn as_execute(&self) -> Option<&dyn CustomExecute> {
-        Some(self)
-    }
-}
-
-impl CustomExecute for GetTypeSpaceOp {
-    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        let arg_error = || ExecError::from("get-type-space expects two arguments: space and atom");
-        let space = args.get(0).ok_or_else(arg_error)?;
-        let space = Atom::as_gnd::<DynSpace>(space).ok_or("get-type-space expects a space as the first argument")?;
-        let atom = args.get(1).ok_or_else(arg_error)?;
-        log::debug!("GetTypeSpaceOp::execute: space: {}, atom: {}", space, atom);
-
-        Ok(get_atom_types(space, atom))
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct GetMetaTypeOp { }
-
-grounded_op!(GetMetaTypeOp, "get-metatype");
-
-impl Grounded for GetMetaTypeOp {
-    fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_ATOM, ATOM_TYPE_ATOM])
-    }
-
-    fn as_execute(&self) -> Option<&dyn CustomExecute> {
-        Some(self)
-    }
-}
-
-impl CustomExecute for GetMetaTypeOp {
-    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        let arg_error = || ExecError::from("get-metatype expects single atom as an argument");
-        let atom = args.get(0).ok_or_else(arg_error)?;
-
-        Ok(vec![get_meta_type(&atom)])
-    }
-}
-
 
 #[derive(Clone, Debug)]
 pub struct PrintlnOp {}
@@ -638,27 +391,6 @@ impl CustomExecute for TraceOp {
     }
 }
 
-#[derive(Clone, Debug)]
-pub struct NopOp {}
-
-grounded_op!(NopOp, "nop");
-
-impl Grounded for NopOp {
-    fn type_(&self) -> Atom {
-        ATOM_TYPE_UNDEFINED
-    }
-
-    fn as_execute(&self) -> Option<&dyn CustomExecute> {
-        Some(self)
-    }
-}
-
-impl CustomExecute for NopOp {
-    fn execute(&self, _args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        unit_result()
-    }
-}
-
 #[derive(Clone, PartialEq, Debug)]
 pub struct StateAtom {
     state: Rc<RefCell<Atom>>
@@ -688,79 +420,6 @@ impl Grounded for StateAtom {
             Atom::Grounded(a) => a.type_(),
         };
         Atom::expr([expr!("StateMonad"), typ])
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct NewStateOp { }
-
-grounded_op!(NewStateOp, "new-state");
-
-impl Grounded for NewStateOp {
-    fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, expr!(tnso), expr!("StateMonad" tnso)])
-    }
-
-    fn as_execute(&self) -> Option<&dyn CustomExecute> {
-        Some(self)
-    }
-}
-
-impl CustomExecute for NewStateOp {
-    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        let arg_error = "new-state expects single atom as an argument";
-        let atom = args.get(0).ok_or(arg_error)?;
-        Ok(vec![Atom::gnd(StateAtom::new(atom.clone()))])
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct GetStateOp { }
-
-grounded_op!(GetStateOp, "get-state");
-
-impl Grounded for GetStateOp {
-    fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, expr!("StateMonad" tgso), expr!(tgso)])
-    }
-
-    fn as_execute(&self) -> Option<&dyn CustomExecute> {
-        Some(self)
-    }
-}
-
-impl CustomExecute for GetStateOp {
-    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        let arg_error = "get-state expects single state atom as an argument";
-        let state = args.get(0).ok_or(arg_error)?;
-        let atom = Atom::as_gnd::<StateAtom>(state).ok_or(arg_error)?;
-        Ok(vec![atom.state.borrow().clone()])
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct ChangeStateOp { }
-
-grounded_op!(ChangeStateOp, "change-state!");
-
-impl Grounded for ChangeStateOp {
-    fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, expr!("StateMonad" tcso), expr!(tcso), expr!("StateMonad" tcso)])
-    }
-
-    fn as_execute(&self) -> Option<&dyn CustomExecute> {
-        Some(self)
-    }
-}
-
-impl CustomExecute for ChangeStateOp {
-    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        let arg_error = "change-state! expects a state atom and its new value as arguments";
-        let atom = args.get(0).ok_or(arg_error)?;
-        let state = Atom::as_gnd::<StateAtom>(atom).ok_or("change-state! expects a state as the first argument")?;
-        let new_value = args.get(1).ok_or(arg_error)?;
-        *state.state.borrow_mut() = new_value.clone();
-        Ok(vec![atom.clone()])
     }
 }
 
@@ -826,33 +485,6 @@ impl CustomExecute for EqualOp {
         let b = args.get(1).ok_or_else(arg_error)?;
 
         Ok(vec![Atom::gnd(Bool(a == b))])
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct MatchOp {}
-
-grounded_op!(MatchOp, "match");
-
-impl Grounded for MatchOp {
-    fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, rust_type_atom::<DynSpace>(), ATOM_TYPE_ATOM, ATOM_TYPE_ATOM, ATOM_TYPE_UNDEFINED])
-    }
-
-    fn as_execute(&self) -> Option<&dyn CustomExecute> {
-        Some(self)
-    }
-}
-
-impl CustomExecute for MatchOp {
-    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        let arg_error = || ExecError::from("match expects three arguments: space, pattern and template");
-        let space = args.get(0).ok_or_else(arg_error)?;
-        let pattern = args.get(1).ok_or_else(arg_error)?;
-        let template = args.get(2).ok_or_else(arg_error)?;
-        log::debug!("MatchOp::execute: space: {:?}, pattern: {:?}, template: {:?}", space, pattern, template);
-        let space = Atom::as_gnd::<DynSpace>(space).ok_or("match expects a space as the first argument")?;
-        Ok(space.borrow().subst(&pattern, &template))
     }
 }
 
@@ -984,313 +616,6 @@ pub(crate) mod pkg_mgmt_ops {
     }
 }
 
-#[derive(Clone, Debug)]
-pub struct UniqueAtomOp {}
-
-grounded_op!(UniqueAtomOp, "unique-atom");
-
-impl Grounded for UniqueAtomOp {
-    fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_EXPRESSION, ATOM_TYPE_EXPRESSION])
-    }
-
-    fn as_execute(&self) -> Option<&dyn CustomExecute> {
-        Some(self)
-    }
-}
-
-impl CustomExecute for UniqueAtomOp {
-    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        let arg_error = || ExecError::from("unique expects single expression atom as an argument");
-        let expr = TryInto::<&ExpressionAtom>::try_into(args.get(0).ok_or_else(arg_error)?)?;
-
-        let mut atoms: Vec<Atom> = expr.children().into();
-        let mut set = GroundingSpace::new();
-        atoms.retain(|x| {
-            let not_contained = set.query(x).is_empty();
-            if not_contained { set.add(x.clone()) };
-            not_contained
-        });
-        Ok(vec![Atom::expr(atoms)])
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct UnionAtomOp {}
-
-grounded_op!(UnionAtomOp, "union-atom");
-
-impl Grounded for UnionAtomOp {
-    fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_EXPRESSION, ATOM_TYPE_EXPRESSION, ATOM_TYPE_EXPRESSION])
-    }
-
-    fn as_execute(&self) -> Option<&dyn CustomExecute> {
-        Some(self)
-    }
-}
-
-impl CustomExecute for UnionAtomOp {
-    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        let arg_error = || ExecError::from("union expects and executable LHS and RHS atom");
-        let mut lhs: Vec<Atom> = TryInto::<&ExpressionAtom>::try_into(args.get(0).ok_or_else(arg_error)?)?.children().into();
-        let rhs: Vec<Atom> = TryInto::<&ExpressionAtom>::try_into(args.get(1).ok_or_else(arg_error)?)?.children().into();
-
-        lhs.extend(rhs);
-
-        Ok(vec![Atom::expr(lhs)])
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct IntersectionAtomOp {}
-
-grounded_op!(IntersectionAtomOp, "intersection-atom");
-
-impl Grounded for IntersectionAtomOp {
-    fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_EXPRESSION, ATOM_TYPE_EXPRESSION, ATOM_TYPE_EXPRESSION])
-    }
-
-    fn as_execute(&self) -> Option<&dyn CustomExecute> {
-        Some(self)
-    }
-}
-
-impl CustomExecute for IntersectionAtomOp {
-    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        let arg_error = || ExecError::from("intersection expects and executable LHS and RHS atom");
-        let mut lhs: Vec<Atom> = TryInto::<&ExpressionAtom>::try_into(args.get(0).ok_or_else(arg_error)?)?.children().into();
-        let rhs = TryInto::<&ExpressionAtom>::try_into(args.get(1).ok_or_else(arg_error)?)?.children();
-
-        let mut rhs_index: MultiTrie<SymbolAtom, Vec<usize>> = MultiTrie::new();
-        for (index, rhs_item) in rhs.iter().enumerate() {
-            let k = atom_to_trie_key(&rhs_item);
-            // FIXME this should
-            // a) use a mutable value endpoint which the MultiTrie does not support atm
-            // b) use a linked list, which Rust barely supports atm
-            let r = rhs_index.get(&k).next();
-            match r.cloned() {
-                Some(bucket) => {
-                    rhs_index.remove(&k, &bucket);
-                    let mut nbucket = bucket;
-                    nbucket.push(index);
-                    let nbucket = nbucket;
-                    rhs_index.insert(k, nbucket);
-                }
-                None => { rhs_index.insert(k, vec![index]) }
-            }
-        }
-
-        lhs.retain(|candidate| {
-            let k = atom_to_trie_key(candidate);
-            let r = rhs_index.get(&k).next();
-            match r.cloned() {
-                None => { false }
-                Some(bucket) => {
-                    match bucket.iter().position(|item| &rhs[*item] == candidate) {
-                        None => { false }
-                        Some(i) => {
-                            rhs_index.remove(&k, &bucket);
-                            if bucket.len() > 1 {
-                                let mut nbucket = bucket;
-                                nbucket.remove(i);
-                                rhs_index.insert(k, nbucket);
-                            }
-                            true
-                        }
-                    }
-                }
-            }
-        });
-
-        Ok(vec![Atom::expr(lhs)])
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct MaxAtomOp {}
-
-grounded_op!(MaxAtomOp, "max-atom");
-
-impl Grounded for MaxAtomOp {
-    fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_EXPRESSION, ATOM_TYPE_NUMBER])
-    }
-
-    fn as_execute(&self) -> Option<&dyn CustomExecute> {
-        Some(self)
-    }
-}
-
-impl CustomExecute for MaxAtomOp {
-    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        let arg_error = || ExecError::from("max-atom expects one argument: expression");
-        let children = TryInto::<&ExpressionAtom>::try_into(args.get(0).ok_or_else(arg_error)?)?.children();
-        if children.is_empty() {
-            Err(ExecError::from("Empty expression"))
-        } else {
-            children.into_iter().fold(Ok(f64::NEG_INFINITY), |res, x| {
-                match (res, Number::from_atom(x)) {
-                    (res @ Err(_), _) => res,
-                    (_, None) => Err(ExecError::from("Only numbers are allowed in expression")),
-                    (Ok(max), Some(x)) => Ok(f64::max(max, x.into())),
-                }
-            })
-        }.map(|max| vec![Atom::gnd(Number::Float(max))])
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct MinAtomOp {}
-
-grounded_op!(MinAtomOp, "min-atom");
-
-impl Grounded for MinAtomOp {
-    fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_EXPRESSION, ATOM_TYPE_NUMBER])
-    }
-
-    fn as_execute(&self) -> Option<&dyn CustomExecute> {
-        Some(self)
-    }
-}
-
-impl CustomExecute for MinAtomOp {
-    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        let arg_error = || ExecError::from("min-atom expects one argument: expression");
-        let children = TryInto::<&ExpressionAtom>::try_into(args.get(0).ok_or_else(arg_error)?)?.children();
-        if children.is_empty() {
-            Err(ExecError::from("Empty expression"))
-        } else {
-            children.into_iter().fold(Ok(f64::INFINITY), |res, x| {
-                match (res, Number::from_atom(x)) {
-                    (res @ Err(_), _) => res,
-                    (_, None) => Err(ExecError::from("Only numbers are allowed in expression")),
-                    (Ok(min), Some(x)) => Ok(f64::min(min, x.into())),
-                }
-            })
-        }.map(|min| vec![Atom::gnd(Number::Float(min))])
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct SizeAtomOp {}
-
-grounded_op!(SizeAtomOp, "size-atom");
-
-impl Grounded for SizeAtomOp {
-    fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_EXPRESSION, ATOM_TYPE_NUMBER])
-    }
-
-    fn as_execute(&self) -> Option<&dyn CustomExecute> {
-        Some(self)
-    }
-}
-
-impl CustomExecute for SizeAtomOp {
-    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        let arg_error = || ExecError::from("size-atom expects one argument: expression");
-        let children = TryInto::<&ExpressionAtom>::try_into(args.get(0).ok_or_else(arg_error)?)?.children();
-        let size = children.len();
-        Ok(vec![Atom::gnd(Number::Integer(size as i64))])
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct IndexAtomOp {}
-
-grounded_op!(IndexAtomOp, "index-atom");
-
-impl Grounded for IndexAtomOp {
-    fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_EXPRESSION, ATOM_TYPE_NUMBER, ATOM_TYPE_ATOM])
-    }
-
-    fn as_execute(&self) -> Option<&dyn CustomExecute> {
-        Some(self)
-    }
-}
-
-impl CustomExecute for IndexAtomOp {
-    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        let arg_error = || ExecError::from("index-atom expects two arguments: expression and atom");
-        let children = TryInto::<&ExpressionAtom>::try_into(args.get(0).ok_or_else(arg_error)?)?.children();
-        let index = args.get(1).and_then(Number::from_atom).ok_or_else(arg_error)?;
-        match children.get(Into::<i64>::into(index) as usize) {
-            Some(atom) => Ok(vec![atom.clone()]),
-            None => Err(ExecError::from("Index is out of bounds")),
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct SubtractionAtomOp {}
-
-grounded_op!(SubtractionAtomOp, "subtraction-atom");
-
-impl Grounded for SubtractionAtomOp {
-    fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_EXPRESSION, ATOM_TYPE_EXPRESSION, ATOM_TYPE_EXPRESSION])
-    }
-
-    fn as_execute(&self) -> Option<&dyn CustomExecute> {
-        Some(self)
-    }
-}
-
-impl CustomExecute for SubtractionAtomOp {
-    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        let arg_error = || ExecError::from("subtraction expects and executable LHS and RHS atom");
-        let mut lhs: Vec<Atom> = TryInto::<&ExpressionAtom>::try_into(args.get(0).ok_or_else(arg_error)?)?.children().into();
-        let rhs = TryInto::<&ExpressionAtom>::try_into(args.get(1).ok_or_else(arg_error)?)?.children();
-
-        let mut rhs_index: MultiTrie<SymbolAtom, Vec<usize>> = MultiTrie::new();
-        for (index, rhs_item) in rhs.iter().enumerate() {
-            let k = atom_to_trie_key(&rhs_item);
-            // FIXME this should
-            // a) use a mutable value endpoint which the MultiTrie does not support atm
-            // b) use a linked list, which Rust barely supports atm
-            let r = rhs_index.get(&k).next();
-            match r.cloned() {
-                Some(bucket) => {
-                    rhs_index.remove(&k, &bucket);
-                    let mut nbucket = bucket;
-                    nbucket.push(index);
-                    let nbucket = nbucket;
-                    rhs_index.insert(k, nbucket);
-                }
-                None => { rhs_index.insert(k, vec![index]) }
-            }
-        }
-
-        lhs.retain(|candidate| {
-            let k = atom_to_trie_key(candidate);
-            let r = rhs_index.get(&k).next();
-            match r.cloned() {
-                None => { true }
-                Some(bucket) => {
-                    match bucket.iter().position(|item| &rhs[*item] == candidate) {
-                        None => { true }
-                        Some(i) => {
-                            rhs_index.remove(&k, &bucket);
-                            if bucket.len() > 1 {
-                                let mut nbucket = bucket;
-                                nbucket.remove(i);
-                                rhs_index.insert(k, nbucket);
-                            }
-                            false
-                        }
-                    }
-                }
-            }
-        });
-
-        Ok(vec![Atom::expr(lhs)])
-    }
-}
-
 //TODO: In the current version of rand it is possible for rust to hang if range end's value is too
 // big. In future releases (0.9+) of rand signature of sample_single will be changed and it will be
 // possible to use match construction to cover overflow and other errors. So after library will be
@@ -1394,77 +719,8 @@ fn atom_to_string(atom: &Atom) -> String {
         _ => atom.to_string(),
     }
 }
-#[derive(Clone, Debug)]
-pub struct GetTypeOp {
-    space: DynSpace,
-}
 
-grounded_op!(GetTypeOp, "get-type");
 
-impl GetTypeOp {
-    pub fn new(space: DynSpace) -> Self {
-        Self{ space }
-    }
-}
-
-impl Grounded for GetTypeOp {
-    fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_ATOM, ATOM_TYPE_ATOM])
-    }
-
-    fn as_execute(&self) -> Option<&dyn CustomExecute> {
-        Some(self)
-    }
-}
-
-impl CustomExecute for GetTypeOp {
-    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        let arg_error = || ExecError::from("get-type expects single atom as an argument");
-        let atom = args.get(0).ok_or_else(arg_error)?;
-        let space = match args.get(1) {
-            Some(space) => Atom::as_gnd::<DynSpace>(space)
-                .ok_or("match expects a space as the first argument"),
-            None => Ok(&self.space),
-        }?;
-        let types = get_atom_types(space, atom);
-        if types.is_empty() {
-            Ok(vec![EMPTY_SYMBOL])
-        } else {
-            Ok(types)
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct IfEqualOp { }
-
-grounded_op!(IfEqualOp, "if-equal");
-
-impl Grounded for IfEqualOp {
-    fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_ATOM, ATOM_TYPE_ATOM, ATOM_TYPE_ATOM, ATOM_TYPE_ATOM, ATOM_TYPE_ATOM])
-    }
-
-    fn as_execute(&self) -> Option<&dyn CustomExecute> {
-        Some(self)
-    }
-}
-
-impl CustomExecute for IfEqualOp {
-    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        let arg_error = || ExecError::from("if-equal expects <atom> <pattern> <then> <else> as an argument");
-        let atom = args.get(0).ok_or_else(arg_error)?;
-        let pattern = args.get(1).ok_or_else(arg_error)?;
-        let then = args.get(2).ok_or_else(arg_error)?;
-        let else_ = args.get(3).ok_or_else(arg_error)?;
-
-        if crate::matcher::atoms_are_equivalent(atom, pattern) {
-            Ok(vec![then.clone()])
-        } else {
-            Ok(vec![else_.clone()])
-        }
-    }
-}
 
 // TODO: remove hiding errors completely after making it possible passing
 // them to the user
@@ -1740,55 +996,55 @@ impl CustomExecute for CaseOp {
 // to the runner & module state.  https://github.com/trueagi-io/hyperon-experimental/issues/410
 pub fn register_common_tokens(tref: &mut Tokenizer, _tokenizer: Shared<Tokenizer>, space: &DynSpace, metta: &Metta) {
 
-    let get_type_op = Atom::gnd(GetTypeOp::new(space.clone()));
+    let get_type_op = Atom::gnd(stdlib_common_tokens::GetTypeOp::new(space.clone()));
     tref.register_token(regex(r"get-type"), move |_| { get_type_op.clone() });
-    let get_type_space_op = Atom::gnd(GetTypeSpaceOp{});
+    let get_type_space_op = Atom::gnd(stdlib_common_tokens::GetTypeSpaceOp{});
     tref.register_token(regex(r"get-type-space"), move |_| { get_type_space_op.clone() });
-    let get_meta_type_op = Atom::gnd(GetMetaTypeOp{});
+    let get_meta_type_op = Atom::gnd(stdlib_common_tokens::GetMetaTypeOp{});
     tref.register_token(regex(r"get-metatype"), move |_| { get_meta_type_op.clone() });
-    let is_equivalent = Atom::gnd(IfEqualOp{});
+    let is_equivalent = Atom::gnd(stdlib_common_tokens::IfEqualOp{});
     tref.register_token(regex(r"if-equal"), move |_| { is_equivalent.clone() });
-    let new_space_op = Atom::gnd(NewSpaceOp{});
+    let new_space_op = Atom::gnd(stdlib_common_tokens::NewSpaceOp{});
     tref.register_token(regex(r"new-space"), move |_| { new_space_op.clone() });
-    let add_atom_op = Atom::gnd(AddAtomOp{});
+    let add_atom_op = Atom::gnd(stdlib_common_tokens::AddAtomOp{});
     tref.register_token(regex(r"add-atom"), move |_| { add_atom_op.clone() });
-    let remove_atom_op = Atom::gnd(RemoveAtomOp{});
+    let remove_atom_op = Atom::gnd(stdlib_common_tokens::RemoveAtomOp{});
     tref.register_token(regex(r"remove-atom"), move |_| { remove_atom_op.clone() });
-    let get_atoms_op = Atom::gnd(GetAtomsOp{});
+    let get_atoms_op = Atom::gnd(stdlib_common_tokens::GetAtomsOp{});
     tref.register_token(regex(r"get-atoms"), move |_| { get_atoms_op.clone() });
-    let new_state_op = Atom::gnd(NewStateOp{});
+    let new_state_op = Atom::gnd(stdlib_common_tokens::NewStateOp{});
     tref.register_token(regex(r"new-state"), move |_| { new_state_op.clone() });
-    let change_state_op = Atom::gnd(ChangeStateOp{});
+    let change_state_op = Atom::gnd(stdlib_common_tokens::ChangeStateOp{});
     tref.register_token(regex(r"change-state!"), move |_| { change_state_op.clone() });
-    let get_state_op = Atom::gnd(GetStateOp{});
+    let get_state_op = Atom::gnd(stdlib_common_tokens::GetStateOp{});
     tref.register_token(regex(r"get-state"), move |_| { get_state_op.clone() });
-    let nop_op = Atom::gnd(NopOp{});
+    let nop_op = Atom::gnd(stdlib_common_tokens::NopOp{});
     tref.register_token(regex(r"nop"), move |_| { nop_op.clone() });
-    let match_op = Atom::gnd(MatchOp{});
+    let match_op = Atom::gnd(stdlib_common_tokens::MatchOp{});
     tref.register_token(regex(r"match"), move |_| { match_op.clone() });
-    let min_atom_op = Atom::gnd(MinAtomOp{});
+    let min_atom_op = Atom::gnd(stdlib_common_tokens::MinAtomOp{});
     tref.register_token(regex(r"min-atom"), move |_| { min_atom_op.clone() });
-    let max_atom_op = Atom::gnd(MaxAtomOp{});
+    let max_atom_op = Atom::gnd(stdlib_common_tokens::MaxAtomOp{});
     tref.register_token(regex(r"max-atom"), move |_| { max_atom_op.clone() });
-    let size_atom_op = Atom::gnd(SizeAtomOp{});
+    let size_atom_op = Atom::gnd(stdlib_common_tokens::SizeAtomOp{});
     tref.register_token(regex(r"size-atom"), move |_| { size_atom_op.clone() });
-    let index_atom_op = Atom::gnd(IndexAtomOp{});
+    let index_atom_op = Atom::gnd(stdlib_common_tokens::IndexAtomOp{});
     tref.register_token(regex(r"index-atom"), move |_| { index_atom_op.clone() });
     let random_int_op = Atom::gnd(RandomIntOp{});
     tref.register_token(regex(r"random-int"), move |_| { random_int_op.clone() });
     let random_float_op = Atom::gnd(RandomFloatOp{});
     tref.register_token(regex(r"random-float"), move |_| { random_float_op.clone() });
-    let mod_space_op = Atom::gnd(ModSpaceOp::new(metta.clone()));
+    let mod_space_op = Atom::gnd(stdlib_common_tokens::ModSpaceOp::new(metta.clone()));
     tref.register_token(regex(r"mod-space!"), move |_| { mod_space_op.clone() });
-    let print_mods_op = Atom::gnd(PrintModsOp::new(metta.clone()));
+    let print_mods_op = Atom::gnd(stdlib_common_tokens::PrintModsOp::new(metta.clone()));
     tref.register_token(regex(r"print-mods!"), move |_| { print_mods_op.clone() });
-    let unique_op = Atom::gnd(UniqueAtomOp{});
+    let unique_op = Atom::gnd(stdlib_common_tokens::UniqueAtomOp{});
     tref.register_token(regex(r"unique-atom"), move |_| { unique_op.clone() });
-    let subtraction_op = Atom::gnd(SubtractionAtomOp{});
+    let subtraction_op = Atom::gnd(stdlib_common_tokens::SubtractionAtomOp{});
     tref.register_token(regex(r"subtraction-atom"), move |_| { subtraction_op.clone() });
-    let intersection_op = Atom::gnd(IntersectionAtomOp{});
+    let intersection_op = Atom::gnd(stdlib_common_tokens::IntersectionAtomOp{});
     tref.register_token(regex(r"intersection-atom"), move |_| { intersection_op.clone() });
-    let union_op = Atom::gnd(UnionAtomOp{});
+    let union_op = Atom::gnd(stdlib_common_tokens::UnionAtomOp{});
     tref.register_token(regex(r"union-atom"), move |_| { union_op.clone() });
     let pow_math_op = Atom::gnd(stdlib_math::PowMathOp {});
     tref.register_token(regex(r"pow-math"), move |_| { pow_math_op.clone() });
@@ -1974,36 +1230,6 @@ mod tests {
     }
 
     #[test]
-    fn get_type_op() {
-        let space = DynSpace::new(metta_space("
-            (: B Type)
-            (: C Type)
-            (: A B)
-            (: A C)
-        "));
-
-        let get_type_op = GetTypeOp::new(space.clone());
-        assert_eq_no_order!(get_type_op.execute(&mut vec![sym!("A"), expr!({space.clone()})]).unwrap(),
-            vec![sym!("B"), sym!("C")]);
-    }
-
-    #[test]
-    fn get_type_op_non_valid_atom() {
-        let space = DynSpace::new(metta_space("
-            (: f (-> Number String))
-            (: 42 Number)
-            (: \"test\" String)
-        "));
-
-        let get_type_op = GetTypeOp::new(space.clone());
-        assert_eq_no_order!(get_type_op.execute(&mut vec![expr!("f" "42"), expr!({space.clone()})]).unwrap(),
-            vec![sym!("String")]);
-        assert_eq_no_order!(get_type_op.execute(&mut vec![expr!("f" "\"test\""), expr!({space.clone()})]).unwrap(),
-            vec![EMPTY_SYMBOL]);
-    }
-
-
-    #[test]
     fn metta_car_atom() {
         let result = run_program("!(eval (car-atom (A $b)))");
         assert_eq!(result, Ok(vec![vec![expr!("A")]]));
@@ -2022,32 +1248,6 @@ mod tests {
         assert_eq!(run_program(&format!("!(cdr-atom ())")), Ok(vec![vec![expr!("Error" ("cdr-atom" ()) {Str::from_str("cdr-atom expects a non-empty expression as an argument")})]]));
         assert_eq!(run_program(&format!("!(cdr-atom a)")), Ok(vec![vec![expr!("Error" ("cdr-atom" "a") {Str::from_str("cdr-atom expects a non-empty expression as an argument")})]]));
         assert_eq!(run_program(&format!("!(cdr-atom $a)")), Ok(vec![vec![expr!("Error" ("cdr-atom" a) {Str::from_str("cdr-atom expects a non-empty expression as an argument")})]]));
-    }
-
-    #[test]
-    fn metta_size_atom() {
-        assert_eq!(run_program(&format!("!(size-atom (5 4 3 2 1))")), Ok(vec![vec![expr!({Number::Integer(5)})]]));
-        assert_eq!(run_program(&format!("!(size-atom ())")), Ok(vec![vec![expr!({Number::Integer(0)})]]));
-    }
-
-    #[test]
-    fn metta_min_atom() {
-        assert_eq!(run_program(&format!("!(min-atom (5 4 5.5))")), Ok(vec![vec![expr!({Number::Integer(4)})]]));
-        assert_eq!(run_program(&format!("!(min-atom ())")), Ok(vec![vec![expr!("Error" ({ MinAtomOp{} } ()) "Empty expression")]]));
-        assert_eq!(run_program(&format!("!(min-atom (3 A B 5))")), Ok(vec![vec![expr!("Error" ({ MinAtomOp{} } ({Number::Integer(3)} "A" "B" {Number::Integer(5)})) "Only numbers are allowed in expression")]]));
-    }
-
-    #[test]
-    fn metta_max_atom() {
-        assert_eq!(run_program(&format!("!(max-atom (5 4 5.5))")), Ok(vec![vec![expr!({Number::Float(5.5)})]]));
-        assert_eq!(run_program(&format!("!(max-atom ())")), Ok(vec![vec![expr!("Error" ({ MaxAtomOp{} } ()) "Empty expression")]]));
-        assert_eq!(run_program(&format!("!(max-atom (3 A B 5))")), Ok(vec![vec![expr!("Error" ({ MaxAtomOp{} } ({Number::Integer(3)} "A" "B" {Number::Integer(5)})) "Only numbers are allowed in expression")]]));
-    }
-
-    #[test]
-    fn metta_index_atom() {
-        assert_eq!(run_program(&format!("!(index-atom (5 4 3 2 1) 2)")), Ok(vec![vec![expr!({Number::Integer(3)})]]));
-        assert_eq!(run_program(&format!("!(index-atom (A B C D E) 5)")), Ok(vec![vec![expr!("Error" ({ IndexAtomOp{} } ("A" "B" "C" "D" "E") {Number::Integer(5)}) "Index is out of bounds")]]));
     }
 
     #[test]
@@ -2719,24 +1919,6 @@ mod tests {
     }
 
     #[test]
-    fn test_error_is_used_as_an_argument() {
-        let metta = Metta::new(Some(EnvBuilder::test_env()));
-        let parser = SExprParser::new(r#"
-            !(get-type Error)
-            !(get-metatype Error)
-            !(get-type (Error Foo Boo))
-            !(Error (+ 1 2) (+ 1 +))
-        "#);
-
-        assert_eq_metta_results!(metta.run(parser), Ok(vec![
-            vec![expr!("->" "Atom" "Atom" "ErrorType")],
-            vec![expr!("Symbol")],
-            vec![expr!("ErrorType")],
-            vec![expr!("Error" ({SumOp{}} {Number::Integer(1)} {Number::Integer(2)}) ({SumOp{}} {Number::Integer(1)} {SumOp{}}))],
-        ]));
-    }
-
-    #[test]
     fn test_string_parsing() {
         let metta = Metta::new(Some(EnvBuilder::test_env()));
         let parser = SExprParser::new(r#"
@@ -2756,85 +1938,6 @@ mod tests {
             vec![expr!({Str::from_str("te\nst")})],
             vec![expr!({Str::from_str("te\nst")} "test")],
         ]));
-    }
-
-    #[test]
-    fn mod_space_op() {
-        let program = r#"
-            !(bind! &new_space (new-space))
-            !(add-atom &new_space (mod-space! stdlib))
-            !(get-atoms &new_space)
-        "#;
-        let runner = Metta::new(Some(runner::environment::EnvBuilder::test_env()));
-        let result = runner.run(SExprParser::new(program)).unwrap();
-
-        let stdlib_space = runner.module_space(runner.get_module_by_name("stdlib").unwrap());
-        assert_eq!(result[2], vec![Atom::gnd(stdlib_space)]);
-    }
-
-    #[test]
-    fn match_op() {
-        let space = DynSpace::new(metta_space("(A B)"));
-        let match_op = MatchOp{};
-        assert_eq!(match_op.execute(&mut vec![expr!({space}), expr!("A" "B"), expr!("B" "A")]),
-            Ok(vec![expr!("B" "A")]));
-    }
-
-    #[test]
-    fn match_op_issue_530() {
-        let space = DynSpace::new(metta_space("(A $a $a)"));
-        let match_op = MatchOp{};
-        let result = match_op.execute(&mut vec![expr!({space}), expr!("A" x y), expr!("A" x y)]).unwrap();
-        assert_eq!(result.len(), 1);
-        assert!(atoms_are_equivalent(&result[0], &expr!("A" x x)),
-            "atoms are not equivalent: expected: {}, actual: {}", expr!("A" x x), result[0]);
-    }
-
-
-    #[test]
-    fn new_space_op() {
-        let res = NewSpaceOp{}.execute(&mut vec![]).expect("No result returned");
-        let space = res.get(0).expect("Result is empty");
-        let space = space.as_gnd::<DynSpace>().expect("Result is not space");
-        let space_atoms: Vec<Atom> = space.borrow().as_space().atom_iter().unwrap().cloned().collect();
-        assert_eq_no_order!(space_atoms, Vec::<Atom>::new());
-    }
-
-    #[test]
-    fn add_atom_op() {
-        let space = DynSpace::new(GroundingSpace::new());
-        let satom = Atom::gnd(space.clone());
-        let res = AddAtomOp{}.execute(&mut vec![satom, expr!(("foo" "bar"))]).expect("No result returned");
-        assert_eq!(res, vec![UNIT_ATOM]);
-        let space_atoms: Vec<Atom> = space.borrow().as_space().atom_iter().unwrap().cloned().collect();
-        assert_eq_no_order!(space_atoms, vec![expr!(("foo" "bar"))]);
-    }
-
-    #[test]
-    fn remove_atom_op() {
-        let space = DynSpace::new(metta_space("
-            (foo bar)
-            (bar foo)
-        "));
-        let satom = Atom::gnd(space.clone());
-        let res = RemoveAtomOp{}.execute(&mut vec![satom, expr!(("foo" "bar"))]).expect("No result returned");
-        // REM: can return Bool in future
-        assert_eq!(res, vec![UNIT_ATOM]);
-        let space_atoms: Vec<Atom> = space.borrow().as_space().atom_iter().unwrap().cloned().collect();
-        assert_eq_no_order!(space_atoms, vec![expr!(("bar" "foo"))]);
-    }
-
-    #[test]
-    fn get_atoms_op() {
-        let space = DynSpace::new(metta_space("
-            (foo bar)
-            (bar foo)
-        "));
-        let satom = Atom::gnd(space.clone());
-        let res = GetAtomsOp{}.execute(&mut vec![satom]).expect("No result returned");
-        let space_atoms: Vec<Atom> = space.borrow().as_space().atom_iter().unwrap().cloned().collect();
-        assert_eq_no_order!(res, space_atoms);
-        assert_eq_no_order!(res, vec![expr!(("foo" "bar")), expr!(("bar" "foo"))]);
     }
 
     #[test]
@@ -2895,104 +1998,6 @@ mod tests {
     }
 
     #[test]
-    fn unique_op() {
-        let unique_op = UniqueAtomOp{};
-        let actual = unique_op.execute(&mut vec![expr!(
-                ("A" ("B" "C"))
-                ("A" ("B" "C"))
-                ("f" "g")
-                ("f" "g")
-                ("f" "g")
-                "Z"
-        )]).unwrap();
-        assert_eq_no_order!(actual,
-                   vec![expr!(("A" ("B" "C")) ("f" "g") "Z")]);
-    }
-
-    #[test]
-    fn union_op() {
-        let union_op = UnionAtomOp{};
-        let actual = union_op.execute(&mut vec![expr!(
-                ("A" ("B" "C"))
-                ("A" ("B" "C"))
-                ("f" "g")
-                ("f" "g")
-                ("f" "g")
-                "Z"
-            ), expr!(
-                ("A" ("B" "C"))
-                "p"
-                "p"
-                ("Q" "a")
-            )]).unwrap();
-        assert_eq_no_order!(actual,
-                   vec![expr!(("A" ("B" "C")) ("A" ("B" "C"))
-                        ("f" "g") ("f" "g") ("f" "g") "Z"
-                        ("A" ("B" "C")) "p" "p" ("Q" "a"))]);
-    }
-
-    #[test]
-    fn intersection_op() {
-        let intersection_op = IntersectionAtomOp{};
-        let actual = intersection_op.execute(&mut vec![expr!(
-                "Z"
-                ("A" ("B" "C"))
-                ("A" ("B" "C"))
-                ("f" "g")
-                ("f" "g")
-                ("f" "g")
-                ("P" "b")
-            ), expr!(
-                ("f" "g")
-                ("f" "g")
-                ("A" ("B" "C"))
-                "p"
-                "p"
-                ("Q" "a")
-                "Z"
-            )]).unwrap();
-        assert_eq_no_order!(actual, vec![expr!("Z" ("A" ("B" "C")) ("f" "g") ("f" "g"))]);
-
-        assert_eq_no_order!(intersection_op.execute(&mut vec![expr!(
-                { Number::Integer(5) }
-                { Number::Integer(4) }
-                { Number::Integer(3) }
-                { Number::Integer(2) }
-            ), expr!(
-                { Number::Integer(5) }
-                { Number::Integer(3) }
-            )]).unwrap(), vec![expr!({Number::Integer(5)} {Number::Integer(3)})]);
-    }
-
-    #[test]
-    fn subtraction_op() {
-        let subtraction_op = SubtractionAtomOp{};
-        let actual = subtraction_op.execute(&mut vec![expr!(
-                "Z"
-                "S"
-                "S"
-                ("A" ("B" "C"))
-                ("A" ("B" "C"))
-                ("f" "g")
-                ("f" "g")
-                ("f" "g")
-                ("P" "b")
-            ), expr!(
-                ("f" "g")
-                ("A" ("B" "C"))
-                "p"
-                "P"
-                ("Q" "a")
-                "Z"
-                "S"
-                "S"
-                "S"
-            )]).unwrap();
-        assert_eq_no_order!(actual,
-                   vec![expr!(("A" ("B" "C")) ("f" "g") ("f" "g") ("P" "b"))]);
-    }
-
-    #[test]
     fn println_op() {
         assert_eq!(PrintlnOp{}.execute(&mut vec![sym!("A")]), unit_result());
     }
@@ -3003,10 +2008,7 @@ mod tests {
                    Ok(vec![sym!("42")]));
     }
 
-    #[test]
-    fn nop_op() {
-        assert_eq!(NopOp{}.execute(&mut vec![]), unit_result());
-    }
+
 
     #[test]
     fn let_op_keep_variables_equalities_issue290() {
@@ -3041,19 +2043,6 @@ mod tests {
             ;; [(→ P R)]
         ";
         assert_eq_metta_results!(run_program(program), Ok(vec![vec![expr!("→" "P" "R")]]));
-    }
-
-    #[test]
-    fn state_ops() {
-        let result = NewStateOp{}.execute(&mut vec![expr!("A" "B")]).unwrap();
-        let old_state = result.get(0).ok_or("error").unwrap();
-        assert_eq!(old_state, &Atom::gnd(StateAtom::new(expr!("A" "B"))));
-        let result = ChangeStateOp{}.execute(&mut vec!(old_state.clone(), expr!("C" "D"))).unwrap();
-        let new_state = result.get(0).ok_or("error").unwrap();
-        assert_eq!(old_state, new_state);
-        assert_eq!(new_state, &Atom::gnd(StateAtom::new(expr!("C" "D"))));
-        let result = GetStateOp{}.execute(&mut vec![new_state.clone()]);
-        assert_eq!(result, Ok(vec![expr!("C" "D")]))
     }
 
     #[test]
@@ -3134,39 +2123,5 @@ mod tests {
         assert_eq!(res, Err(ExecError::from("Range is empty")));
     }
 
-    #[test]
-    fn size_atom_op() {
-        let res = SizeAtomOp{}.execute(&mut vec![expr!({Number::Integer(5)} {Number::Integer(4)} {Number::Integer(3)} {Number::Integer(2)} {Number::Integer(1)})]).expect("No result returned");
-        assert_eq!(res, vec![expr!({Number::Integer(5)})]);
-        let res = SizeAtomOp{}.execute(&mut vec![expr!()]).expect("No result returned");
-        assert_eq!(res, vec![expr!({Number::Integer(0)})]);
-    }
 
-    #[test]
-    fn min_atom_op() {
-        let res = MinAtomOp{}.execute(&mut vec![expr!({Number::Integer(5)} {Number::Integer(4)} {Number::Float(5.5)})]).expect("No result returned");
-        assert_eq!(res, vec![expr!({Number::Integer(4)})]);
-        let res = MinAtomOp{}.execute(&mut vec![expr!({Number::Integer(5)} {Number::Integer(4)} "A")]);
-        assert_eq!(res, Err(ExecError::from("Only numbers are allowed in expression")));
-        let res = MinAtomOp{}.execute(&mut vec![expr!()]);
-        assert_eq!(res, Err(ExecError::from("Empty expression")));
-    }
-
-    #[test]
-    fn max_atom_op() {
-        let res = MaxAtomOp{}.execute(&mut vec![expr!({Number::Integer(5)} {Number::Integer(4)} {Number::Float(5.5)})]).expect("No result returned");
-        assert_eq!(res, vec![expr!({Number::Float(5.5)})]);
-        let res = MaxAtomOp{}.execute(&mut vec![expr!({Number::Integer(5)} {Number::Integer(4)} "A")]);
-        assert_eq!(res, Err(ExecError::from("Only numbers are allowed in expression")));
-        let res = MaxAtomOp{}.execute(&mut vec![expr!()]);
-        assert_eq!(res, Err(ExecError::from("Empty expression")));
-    }
-
-    #[test]
-    fn index_atom_op() {
-        let res = IndexAtomOp{}.execute(&mut vec![expr!({Number::Integer(5)} {Number::Integer(4)} {Number::Integer(3)} {Number::Integer(2)} {Number::Integer(1)}), expr!({Number::Integer(2)})]).expect("No result returned");
-        assert_eq!(res, vec![expr!({Number::Integer(3)})]);
-        let res = IndexAtomOp{}.execute(&mut vec![expr!({Number::Integer(5)} {Number::Integer(4)} {Number::Integer(3)} {Number::Integer(2)} {Number::Integer(1)}), expr!({Number::Integer(5)})]);
-        assert_eq!(res, Err(ExecError::from("Index is out of bounds")));
-    }
 }

--- a/lib/src/metta/runner/stdlib_minimal/stdlib_common_tokens.rs
+++ b/lib/src/metta/runner/stdlib_minimal/stdlib_common_tokens.rs
@@ -6,7 +6,6 @@ use crate::metta::runner::{Metta, RunContext};
 use crate::common::multitrie::MultiTrie;
 use crate::space::grounding::atom_to_trie_key;
 #[cfg(feature = "pkg_mgmt")]
-// use crate::metta::runner::{git_catalog::ModuleGitLocation, mod_name_from_url, pkg_mgmt::UpdateMode};
 
 use std::convert::TryInto;
 

--- a/lib/src/metta/runner/stdlib_minimal/stdlib_common_tokens.rs
+++ b/lib/src/metta/runner/stdlib_minimal/stdlib_common_tokens.rs
@@ -768,11 +768,7 @@ mod tests {
     use crate::metta::runner::EnvBuilder;
     use crate::matcher::atoms_are_equivalent;
     use crate::common::test_utils::metta_space;
-
-    fn run_program(program: &str) -> Result<Vec<Vec<Atom>>, String> {
-        let metta = Metta::new(Some(EnvBuilder::test_env()));
-        metta.run(SExprParser::new(program))
-    }
+    use crate::metta::runner::stdlib_minimal::tests::run_program;
 
     #[test]
     fn get_type_op() {

--- a/lib/src/metta/runner/stdlib_minimal/stdlib_common_tokens.rs
+++ b/lib/src/metta/runner/stdlib_minimal/stdlib_common_tokens.rs
@@ -1,0 +1,1082 @@
+use crate::*;
+use crate::space::*;
+use crate::metta::*;
+use crate::metta::types::{get_atom_types, get_meta_type};
+use crate::metta::runner::{Metta, RunContext};
+use crate::common::multitrie::MultiTrie;
+use crate::space::grounding::atom_to_trie_key;
+#[cfg(feature = "pkg_mgmt")]
+// use crate::metta::runner::{git_catalog::ModuleGitLocation, mod_name_from_url, pkg_mgmt::UpdateMode};
+
+use std::convert::TryInto;
+
+use crate::metta::runner::arithmetics::*;
+use crate::metta::runner::string::*;
+use crate::metta::runner::stdlib_minimal::grounded_op;
+use crate::metta::runner::stdlib_minimal::unit_result;
+use crate::metta::runner::stdlib_minimal::StateAtom;
+
+#[derive(Clone, Debug)]
+pub struct GetTypeOp {
+    space: DynSpace,
+}
+
+grounded_op!(GetTypeOp, "get-type");
+
+impl GetTypeOp {
+    pub fn new(space: DynSpace) -> Self {
+        Self{ space }
+    }
+}
+
+impl Grounded for GetTypeOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_ATOM, ATOM_TYPE_ATOM])
+    }
+
+    fn as_execute(&self) -> Option<&dyn CustomExecute> {
+        Some(self)
+    }
+}
+
+impl CustomExecute for GetTypeOp {
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        let arg_error = || ExecError::from("get-type expects single atom as an argument");
+        let atom = args.get(0).ok_or_else(arg_error)?;
+        let space = match args.get(1) {
+            Some(space) => Atom::as_gnd::<DynSpace>(space)
+                .ok_or("match expects a space as the first argument"),
+            None => Ok(&self.space),
+        }?;
+        let types = get_atom_types(space, atom);
+        if types.is_empty() {
+            Ok(vec![EMPTY_SYMBOL])
+        } else {
+            Ok(types)
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct GetTypeSpaceOp {}
+
+grounded_op!(GetTypeSpaceOp, "get-type-space");
+
+impl Grounded for GetTypeSpaceOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, rust_type_atom::<DynSpace>(), ATOM_TYPE_ATOM, ATOM_TYPE_ATOM])
+    }
+
+    fn as_execute(&self) -> Option<&dyn CustomExecute> {
+        Some(self)
+    }
+}
+
+impl CustomExecute for GetTypeSpaceOp {
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        let arg_error = || ExecError::from("get-type-space expects two arguments: space and atom");
+        let space = args.get(0).ok_or_else(arg_error)?;
+        let space = Atom::as_gnd::<DynSpace>(space).ok_or("get-type-space expects a space as the first argument")?;
+        let atom = args.get(1).ok_or_else(arg_error)?;
+        log::debug!("GetTypeSpaceOp::execute: space: {}, atom: {}", space, atom);
+
+        Ok(get_atom_types(space, atom))
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct GetMetaTypeOp { }
+
+grounded_op!(GetMetaTypeOp, "get-metatype");
+
+impl Grounded for GetMetaTypeOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_ATOM, ATOM_TYPE_ATOM])
+    }
+
+    fn as_execute(&self) -> Option<&dyn CustomExecute> {
+        Some(self)
+    }
+}
+
+impl CustomExecute for GetMetaTypeOp {
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        let arg_error = || ExecError::from("get-metatype expects single atom as an argument");
+        let atom = args.get(0).ok_or_else(arg_error)?;
+
+        Ok(vec![get_meta_type(&atom)])
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct IfEqualOp { }
+
+grounded_op!(IfEqualOp, "if-equal");
+
+impl Grounded for IfEqualOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_ATOM, ATOM_TYPE_ATOM, ATOM_TYPE_ATOM, ATOM_TYPE_ATOM, ATOM_TYPE_ATOM])
+    }
+
+    fn as_execute(&self) -> Option<&dyn CustomExecute> {
+        Some(self)
+    }
+}
+
+impl CustomExecute for IfEqualOp {
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        let arg_error = || ExecError::from("if-equal expects <atom> <pattern> <then> <else> as an argument");
+        let atom = args.get(0).ok_or_else(arg_error)?;
+        let pattern = args.get(1).ok_or_else(arg_error)?;
+        let then = args.get(2).ok_or_else(arg_error)?;
+        let else_ = args.get(3).ok_or_else(arg_error)?;
+
+        if crate::matcher::atoms_are_equivalent(atom, pattern) {
+            Ok(vec![then.clone()])
+        } else {
+            Ok(vec![else_.clone()])
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct NewSpaceOp {}
+
+grounded_op!(NewSpaceOp, "new-space");
+
+impl Grounded for NewSpaceOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, rust_type_atom::<DynSpace>()])
+    }
+
+    fn as_execute(&self) -> Option<&dyn CustomExecute> {
+        Some(self)
+    }
+}
+
+impl CustomExecute for NewSpaceOp {
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        if args.len() == 0 {
+            let space = Atom::gnd(DynSpace::new(GroundingSpace::new()));
+            Ok(vec![space])
+        } else {
+            Err("new-space doesn't expect arguments".into())
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct AddAtomOp {}
+
+grounded_op!(AddAtomOp, "add-atom");
+
+impl Grounded for AddAtomOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, rust_type_atom::<DynSpace>(),
+            ATOM_TYPE_ATOM, UNIT_TYPE])
+    }
+
+    fn as_execute(&self) -> Option<&dyn CustomExecute> {
+        Some(self)
+    }
+}
+
+impl CustomExecute for AddAtomOp {
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        let arg_error = || ExecError::from("add-atom expects two arguments: space and atom");
+        let space = args.get(0).ok_or_else(arg_error)?;
+        let atom = args.get(1).ok_or_else(arg_error)?;
+        let space = Atom::as_gnd::<DynSpace>(space).ok_or("add-atom expects a space as the first argument")?;
+        space.borrow_mut().add(atom.clone());
+        unit_result()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct RemoveAtomOp {}
+
+grounded_op!(RemoveAtomOp, "remove-atom");
+
+impl Grounded for RemoveAtomOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, rust_type_atom::<DynSpace>(),
+            ATOM_TYPE_ATOM, UNIT_TYPE])
+    }
+
+    fn as_execute(&self) -> Option<&dyn CustomExecute> {
+        Some(self)
+    }
+}
+
+impl CustomExecute for RemoveAtomOp {
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        let arg_error = || ExecError::from("remove-atom expects two arguments: space and atom");
+        let space = args.get(0).ok_or_else(arg_error)?;
+        let atom = args.get(1).ok_or_else(arg_error)?;
+        let space = Atom::as_gnd::<DynSpace>(space).ok_or("remove-atom expects a space as the first argument")?;
+        space.borrow_mut().remove(atom);
+        // TODO? Is it necessary to distinguish whether the atom was removed or not?
+        unit_result()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct GetAtomsOp {}
+
+grounded_op!(GetAtomsOp, "get-atoms");
+
+impl Grounded for GetAtomsOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, rust_type_atom::<DynSpace>(),
+            ATOM_TYPE_ATOM])
+    }
+
+    fn as_execute(&self) -> Option<&dyn CustomExecute> {
+        Some(self)
+    }
+}
+
+impl CustomExecute for GetAtomsOp {
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        let arg_error = || ExecError::from("get-atoms expects one argument: space");
+        let space = args.get(0).ok_or_else(arg_error)?;
+        let space = Atom::as_gnd::<DynSpace>(space).ok_or("get-atoms expects a space as its argument")?;
+        space.borrow().as_space().atom_iter()
+            .map(|iter| iter.cloned().map(|a| make_variables_unique(a)).collect())
+            .ok_or(ExecError::Runtime("Unsupported Operation. Can't traverse atoms in this space".to_string()))
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct NewStateOp { }
+
+grounded_op!(NewStateOp, "new-state");
+
+impl Grounded for NewStateOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, expr!(tnso), expr!("StateMonad" tnso)])
+    }
+
+    fn as_execute(&self) -> Option<&dyn CustomExecute> {
+        Some(self)
+    }
+}
+
+impl CustomExecute for NewStateOp {
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        let arg_error = "new-state expects single atom as an argument";
+        let atom = args.get(0).ok_or(arg_error)?;
+        Ok(vec![Atom::gnd(StateAtom::new(atom.clone()))])
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ChangeStateOp { }
+
+grounded_op!(ChangeStateOp, "change-state!");
+
+impl Grounded for ChangeStateOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, expr!("StateMonad" tcso), expr!(tcso), expr!("StateMonad" tcso)])
+    }
+
+    fn as_execute(&self) -> Option<&dyn CustomExecute> {
+        Some(self)
+    }
+}
+
+impl CustomExecute for ChangeStateOp {
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        let arg_error = "change-state! expects a state atom and its new value as arguments";
+        let atom = args.get(0).ok_or(arg_error)?;
+        let state = Atom::as_gnd::<StateAtom>(atom).ok_or("change-state! expects a state as the first argument")?;
+        let new_value = args.get(1).ok_or(arg_error)?;
+        *state.state.borrow_mut() = new_value.clone();
+        Ok(vec![atom.clone()])
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct GetStateOp { }
+
+grounded_op!(GetStateOp, "get-state");
+
+impl Grounded for GetStateOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, expr!("StateMonad" tgso), expr!(tgso)])
+    }
+
+    fn as_execute(&self) -> Option<&dyn CustomExecute> {
+        Some(self)
+    }
+}
+
+impl CustomExecute for GetStateOp {
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        let arg_error = "get-state expects single state atom as an argument";
+        let state = args.get(0).ok_or(arg_error)?;
+        let atom = Atom::as_gnd::<StateAtom>(state).ok_or(arg_error)?;
+        Ok(vec![atom.state.borrow().clone()])
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct NopOp {}
+
+grounded_op!(NopOp, "nop");
+
+impl Grounded for NopOp {
+    fn type_(&self) -> Atom {
+        ATOM_TYPE_UNDEFINED
+    }
+
+    fn as_execute(&self) -> Option<&dyn CustomExecute> {
+        Some(self)
+    }
+}
+
+impl CustomExecute for NopOp {
+    fn execute(&self, _args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        unit_result()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct MatchOp {}
+
+grounded_op!(MatchOp, "match");
+
+impl Grounded for MatchOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, rust_type_atom::<DynSpace>(), ATOM_TYPE_ATOM, ATOM_TYPE_ATOM, ATOM_TYPE_UNDEFINED])
+    }
+
+    fn as_execute(&self) -> Option<&dyn CustomExecute> {
+        Some(self)
+    }
+}
+
+impl CustomExecute for MatchOp {
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        let arg_error = || ExecError::from("match expects three arguments: space, pattern and template");
+        let space = args.get(0).ok_or_else(arg_error)?;
+        let pattern = args.get(1).ok_or_else(arg_error)?;
+        let template = args.get(2).ok_or_else(arg_error)?;
+        log::debug!("MatchOp::execute: space: {:?}, pattern: {:?}, template: {:?}", space, pattern, template);
+        let space = Atom::as_gnd::<DynSpace>(space).ok_or("match expects a space as the first argument")?;
+        Ok(space.borrow().subst(&pattern, &template))
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct MinAtomOp {}
+
+grounded_op!(MinAtomOp, "min-atom");
+
+impl Grounded for MinAtomOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_EXPRESSION, ATOM_TYPE_NUMBER])
+    }
+
+    fn as_execute(&self) -> Option<&dyn CustomExecute> {
+        Some(self)
+    }
+}
+
+impl CustomExecute for MinAtomOp {
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        let arg_error = || ExecError::from("min-atom expects one argument: expression");
+        let children = TryInto::<&ExpressionAtom>::try_into(args.get(0).ok_or_else(arg_error)?)?.children();
+        if children.is_empty() {
+            Err(ExecError::from("Empty expression"))
+        } else {
+            children.into_iter().fold(Ok(f64::INFINITY), |res, x| {
+                match (res, Number::from_atom(x)) {
+                    (res @ Err(_), _) => res,
+                    (_, None) => Err(ExecError::from("Only numbers are allowed in expression")),
+                    (Ok(min), Some(x)) => Ok(f64::min(min, x.into())),
+                }
+            })
+        }.map(|min| vec![Atom::gnd(Number::Float(min))])
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct MaxAtomOp {}
+
+grounded_op!(MaxAtomOp, "max-atom");
+
+impl Grounded for MaxAtomOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_EXPRESSION, ATOM_TYPE_NUMBER])
+    }
+
+    fn as_execute(&self) -> Option<&dyn CustomExecute> {
+        Some(self)
+    }
+}
+
+impl CustomExecute for MaxAtomOp {
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        let arg_error = || ExecError::from("max-atom expects one argument: expression");
+        let children = TryInto::<&ExpressionAtom>::try_into(args.get(0).ok_or_else(arg_error)?)?.children();
+        if children.is_empty() {
+            Err(ExecError::from("Empty expression"))
+        } else {
+            children.into_iter().fold(Ok(f64::NEG_INFINITY), |res, x| {
+                match (res, Number::from_atom(x)) {
+                    (res @ Err(_), _) => res,
+                    (_, None) => Err(ExecError::from("Only numbers are allowed in expression")),
+                    (Ok(max), Some(x)) => Ok(f64::max(max, x.into())),
+                }
+            })
+        }.map(|max| vec![Atom::gnd(Number::Float(max))])
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct SizeAtomOp {}
+
+grounded_op!(SizeAtomOp, "size-atom");
+
+impl Grounded for SizeAtomOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_EXPRESSION, ATOM_TYPE_NUMBER])
+    }
+
+    fn as_execute(&self) -> Option<&dyn CustomExecute> {
+        Some(self)
+    }
+}
+
+impl CustomExecute for SizeAtomOp {
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        let arg_error = || ExecError::from("size-atom expects one argument: expression");
+        let children = TryInto::<&ExpressionAtom>::try_into(args.get(0).ok_or_else(arg_error)?)?.children();
+        let size = children.len();
+        Ok(vec![Atom::gnd(Number::Integer(size as i64))])
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct IndexAtomOp {}
+
+grounded_op!(IndexAtomOp, "index-atom");
+
+impl Grounded for IndexAtomOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_EXPRESSION, ATOM_TYPE_NUMBER, ATOM_TYPE_ATOM])
+    }
+
+    fn as_execute(&self) -> Option<&dyn CustomExecute> {
+        Some(self)
+    }
+}
+
+impl CustomExecute for IndexAtomOp {
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        let arg_error = || ExecError::from("index-atom expects two arguments: expression and atom");
+        let children = TryInto::<&ExpressionAtom>::try_into(args.get(0).ok_or_else(arg_error)?)?.children();
+        let index = args.get(1).and_then(Number::from_atom).ok_or_else(arg_error)?;
+        match children.get(Into::<i64>::into(index) as usize) {
+            Some(atom) => Ok(vec![atom.clone()]),
+            None => Err(ExecError::from("Index is out of bounds")),
+        }
+    }
+}
+
+/// mod-space! returns the space of a specified module, loading the module if it's not loaded already
+//NOTE: The "impure" '!' denoted in the op atom name is due to the side effect of loading the module.  If
+// we want a side-effect-free version, it could be implemented by calling `RunContext::get_module_by_name`
+// instead of `RunContext::load_module`, but then the user would need to use `register-module!`, `import!`,
+// or some other mechanism to make sure the module is loaded in advance.
+#[derive(Clone, Debug)]
+pub struct ModSpaceOp {
+    //TODO-HACK: This is a terrible horrible ugly hack that should be fixed ASAP
+    context: std::sync::Arc<std::sync::Mutex<Vec<std::sync::Arc<std::sync::Mutex<&'static mut RunContext<'static, 'static>>>>>>,
+}
+
+grounded_op!(ModSpaceOp, "mod-space!");
+
+impl ModSpaceOp {
+    pub fn new(metta: Metta) -> Self {
+        Self{ context: metta.0.context.clone() }
+    }
+}
+
+impl Grounded for ModSpaceOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_ATOM, rust_type_atom::<DynSpace>()])
+    }
+
+    fn as_execute(&self) -> Option<&dyn CustomExecute> {
+        Some(self)
+    }
+}
+
+impl CustomExecute for ModSpaceOp {
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        let arg_error = "mod-space! expects a module name argument";
+        let mod_name_atom = args.get(0).ok_or_else(|| ExecError::from(arg_error))?;
+
+        // TODO: replace Symbol by grounded String?
+        let mod_name = match mod_name_atom {
+            Atom::Symbol(mod_name) => mod_name.name(),
+            _ => {return Err(ExecError::from(arg_error))}
+        };
+        let mod_name = strip_quotes(mod_name);
+
+        // Load the module into the runner, or get the ModId if it's already loaded
+        //TODO: Remove this hack to access the RunContext, when it's part of the arguments to `execute`
+        let ctx_ref = self.context.lock().unwrap().last().unwrap().clone();
+        let mut context = ctx_ref.lock().unwrap();
+        let mod_id = context.load_module(mod_name)?;
+
+        let space = Atom::gnd(context.metta().module_space(mod_id));
+        Ok(vec![space])
+    }
+}
+
+/// This operation prints the modules loaded from the top of the runner
+///
+/// NOTE: This is a temporary stop-gap to help MeTTa users inspect which modules they have loaded and
+/// debug module import issues.  Ultimately it probably makes sense to make this information accessible
+/// as a special kind of Space, so that it would be possible to work with it programmatically.
+#[derive(Clone, Debug)]
+pub struct PrintModsOp {
+    metta: Metta
+}
+
+grounded_op!(PrintModsOp, "print-mods!");
+
+impl PrintModsOp {
+    pub fn new(metta: Metta) -> Self {
+        Self{ metta }
+    }
+}
+
+impl Grounded for PrintModsOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, UNIT_TYPE])
+    }
+
+    fn as_execute(&self) -> Option<&dyn CustomExecute> {
+        Some(self)
+    }
+}
+
+impl CustomExecute for PrintModsOp {
+    fn execute(&self, _args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        self.metta.display_loaded_modules();
+        unit_result()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct UniqueAtomOp {}
+
+grounded_op!(UniqueAtomOp, "unique-atom");
+
+impl Grounded for UniqueAtomOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_EXPRESSION, ATOM_TYPE_EXPRESSION])
+    }
+
+    fn as_execute(&self) -> Option<&dyn CustomExecute> {
+        Some(self)
+    }
+}
+
+impl CustomExecute for UniqueAtomOp {
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        let arg_error = || ExecError::from("unique expects single expression atom as an argument");
+        let expr = TryInto::<&ExpressionAtom>::try_into(args.get(0).ok_or_else(arg_error)?)?;
+
+        let mut atoms: Vec<Atom> = expr.children().into();
+        let mut set = GroundingSpace::new();
+        atoms.retain(|x| {
+            let not_contained = set.query(x).is_empty();
+            if not_contained { set.add(x.clone()) };
+            not_contained
+        });
+        Ok(vec![Atom::expr(atoms)])
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct SubtractionAtomOp {}
+
+grounded_op!(SubtractionAtomOp, "subtraction-atom");
+
+impl Grounded for SubtractionAtomOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_EXPRESSION, ATOM_TYPE_EXPRESSION, ATOM_TYPE_EXPRESSION])
+    }
+
+    fn as_execute(&self) -> Option<&dyn CustomExecute> {
+        Some(self)
+    }
+}
+
+impl CustomExecute for SubtractionAtomOp {
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        let arg_error = || ExecError::from("subtraction expects and executable LHS and RHS atom");
+        let mut lhs: Vec<Atom> = TryInto::<&ExpressionAtom>::try_into(args.get(0).ok_or_else(arg_error)?)?.children().into();
+        let rhs = TryInto::<&ExpressionAtom>::try_into(args.get(1).ok_or_else(arg_error)?)?.children();
+
+        let mut rhs_index: MultiTrie<SymbolAtom, Vec<usize>> = MultiTrie::new();
+        for (index, rhs_item) in rhs.iter().enumerate() {
+            let k = atom_to_trie_key(&rhs_item);
+            // FIXME this should
+            // a) use a mutable value endpoint which the MultiTrie does not support atm
+            // b) use a linked list, which Rust barely supports atm
+            let r = rhs_index.get(&k).next();
+            match r.cloned() {
+                Some(bucket) => {
+                    rhs_index.remove(&k, &bucket);
+                    let mut nbucket = bucket;
+                    nbucket.push(index);
+                    let nbucket = nbucket;
+                    rhs_index.insert(k, nbucket);
+                }
+                None => { rhs_index.insert(k, vec![index]) }
+            }
+        }
+
+        lhs.retain(|candidate| {
+            let k = atom_to_trie_key(candidate);
+            let r = rhs_index.get(&k).next();
+            match r.cloned() {
+                None => { true }
+                Some(bucket) => {
+                    match bucket.iter().position(|item| &rhs[*item] == candidate) {
+                        None => { true }
+                        Some(i) => {
+                            rhs_index.remove(&k, &bucket);
+                            if bucket.len() > 1 {
+                                let mut nbucket = bucket;
+                                nbucket.remove(i);
+                                rhs_index.insert(k, nbucket);
+                            }
+                            false
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(vec![Atom::expr(lhs)])
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct IntersectionAtomOp {}
+
+grounded_op!(IntersectionAtomOp, "intersection-atom");
+
+impl Grounded for IntersectionAtomOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_EXPRESSION, ATOM_TYPE_EXPRESSION, ATOM_TYPE_EXPRESSION])
+    }
+
+    fn as_execute(&self) -> Option<&dyn CustomExecute> {
+        Some(self)
+    }
+}
+
+impl CustomExecute for IntersectionAtomOp {
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        let arg_error = || ExecError::from("intersection expects and executable LHS and RHS atom");
+        let mut lhs: Vec<Atom> = TryInto::<&ExpressionAtom>::try_into(args.get(0).ok_or_else(arg_error)?)?.children().into();
+        let rhs = TryInto::<&ExpressionAtom>::try_into(args.get(1).ok_or_else(arg_error)?)?.children();
+
+        let mut rhs_index: MultiTrie<SymbolAtom, Vec<usize>> = MultiTrie::new();
+        for (index, rhs_item) in rhs.iter().enumerate() {
+            let k = atom_to_trie_key(&rhs_item);
+            // FIXME this should
+            // a) use a mutable value endpoint which the MultiTrie does not support atm
+            // b) use a linked list, which Rust barely supports atm
+            let r = rhs_index.get(&k).next();
+            match r.cloned() {
+                Some(bucket) => {
+                    rhs_index.remove(&k, &bucket);
+                    let mut nbucket = bucket;
+                    nbucket.push(index);
+                    let nbucket = nbucket;
+                    rhs_index.insert(k, nbucket);
+                }
+                None => { rhs_index.insert(k, vec![index]) }
+            }
+        }
+
+        lhs.retain(|candidate| {
+            let k = atom_to_trie_key(candidate);
+            let r = rhs_index.get(&k).next();
+            match r.cloned() {
+                None => { false }
+                Some(bucket) => {
+                    match bucket.iter().position(|item| &rhs[*item] == candidate) {
+                        None => { false }
+                        Some(i) => {
+                            rhs_index.remove(&k, &bucket);
+                            if bucket.len() > 1 {
+                                let mut nbucket = bucket;
+                                nbucket.remove(i);
+                                rhs_index.insert(k, nbucket);
+                            }
+                            true
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(vec![Atom::expr(lhs)])
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct UnionAtomOp {}
+
+grounded_op!(UnionAtomOp, "union-atom");
+
+impl Grounded for UnionAtomOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_EXPRESSION, ATOM_TYPE_EXPRESSION, ATOM_TYPE_EXPRESSION])
+    }
+
+    fn as_execute(&self) -> Option<&dyn CustomExecute> {
+        Some(self)
+    }
+}
+
+impl CustomExecute for UnionAtomOp {
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        let arg_error = || ExecError::from("union expects and executable LHS and RHS atom");
+        let mut lhs: Vec<Atom> = TryInto::<&ExpressionAtom>::try_into(args.get(0).ok_or_else(arg_error)?)?.children().into();
+        let rhs: Vec<Atom> = TryInto::<&ExpressionAtom>::try_into(args.get(1).ok_or_else(arg_error)?)?.children().into();
+
+        lhs.extend(rhs);
+
+        Ok(vec![Atom::expr(lhs)])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metta::text::SExprParser;
+    use crate::metta::runner::EnvBuilder;
+    use crate::matcher::atoms_are_equivalent;
+    use crate::common::test_utils::metta_space;
+
+    fn run_program(program: &str) -> Result<Vec<Vec<Atom>>, String> {
+        let metta = Metta::new(Some(EnvBuilder::test_env()));
+        metta.run(SExprParser::new(program))
+    }
+
+    #[test]
+    fn get_type_op() {
+        let space = DynSpace::new(metta_space("
+            (: B Type)
+            (: C Type)
+            (: A B)
+            (: A C)
+        "));
+
+        let get_type_op = GetTypeOp::new(space.clone());
+        assert_eq_no_order!(get_type_op.execute(&mut vec![sym!("A"), expr!({space.clone()})]).unwrap(),
+            vec![sym!("B"), sym!("C")]);
+    }
+
+    #[test]
+    fn get_type_op_non_valid_atom() {
+        let space = DynSpace::new(metta_space("
+            (: f (-> Number String))
+            (: 42 Number)
+            (: \"test\" String)
+        "));
+
+        let get_type_op = GetTypeOp::new(space.clone());
+        assert_eq_no_order!(get_type_op.execute(&mut vec![expr!("f" "42"), expr!({space.clone()})]).unwrap(),
+            vec![sym!("String")]);
+        assert_eq_no_order!(get_type_op.execute(&mut vec![expr!("f" "\"test\""), expr!({space.clone()})]).unwrap(),
+            vec![EMPTY_SYMBOL]);
+    }
+
+    #[test]
+    fn match_op() {
+        let space = DynSpace::new(metta_space("(A B)"));
+        let match_op = MatchOp{};
+        assert_eq!(match_op.execute(&mut vec![expr!({space}), expr!("A" "B"), expr!("B" "A")]),
+                   Ok(vec![expr!("B" "A")]));
+    }
+
+    #[test]
+    fn match_op_issue_530() {
+        let space = DynSpace::new(metta_space("(A $a $a)"));
+        let match_op = MatchOp{};
+        let result = match_op.execute(&mut vec![expr!({space}), expr!("A" x y), expr!("A" x y)]).unwrap();
+        assert_eq!(result.len(), 1);
+        assert!(atoms_are_equivalent(&result[0], &expr!("A" x x)),
+                "atoms are not equivalent: expected: {}, actual: {}", expr!("A" x x), result[0]);
+    }
+
+    #[test]
+    fn new_space_op() {
+        let res = NewSpaceOp{}.execute(&mut vec![]).expect("No result returned");
+        let space = res.get(0).expect("Result is empty");
+        let space = space.as_gnd::<DynSpace>().expect("Result is not space");
+        let space_atoms: Vec<Atom> = space.borrow().as_space().atom_iter().unwrap().cloned().collect();
+        assert_eq_no_order!(space_atoms, Vec::<Atom>::new());
+    }
+
+    #[test]
+    fn add_atom_op() {
+        let space = DynSpace::new(GroundingSpace::new());
+        let satom = Atom::gnd(space.clone());
+        let res = AddAtomOp{}.execute(&mut vec![satom, expr!(("foo" "bar"))]).expect("No result returned");
+        assert_eq!(res, vec![UNIT_ATOM]);
+        let space_atoms: Vec<Atom> = space.borrow().as_space().atom_iter().unwrap().cloned().collect();
+        assert_eq_no_order!(space_atoms, vec![expr!(("foo" "bar"))]);
+    }
+
+    #[test]
+    fn remove_atom_op() {
+        let space = DynSpace::new(metta_space("
+            (foo bar)
+            (bar foo)
+        "));
+        let satom = Atom::gnd(space.clone());
+        let res = RemoveAtomOp{}.execute(&mut vec![satom, expr!(("foo" "bar"))]).expect("No result returned");
+        // REM: can return Bool in future
+        assert_eq!(res, vec![UNIT_ATOM]);
+        let space_atoms: Vec<Atom> = space.borrow().as_space().atom_iter().unwrap().cloned().collect();
+        assert_eq_no_order!(space_atoms, vec![expr!(("bar" "foo"))]);
+    }
+
+    #[test]
+    fn get_atoms_op() {
+        let space = DynSpace::new(metta_space("
+            (foo bar)
+            (bar foo)
+        "));
+        let satom = Atom::gnd(space.clone());
+        let res = GetAtomsOp{}.execute(&mut vec![satom]).expect("No result returned");
+        let space_atoms: Vec<Atom> = space.borrow().as_space().atom_iter().unwrap().cloned().collect();
+        assert_eq_no_order!(res, space_atoms);
+        assert_eq_no_order!(res, vec![expr!(("foo" "bar")), expr!(("bar" "foo"))]);
+    }
+
+    #[test]
+    fn unique_op() {
+        let unique_op = UniqueAtomOp{};
+        let actual = unique_op.execute(&mut vec![expr!(
+                ("A" ("B" "C"))
+                ("A" ("B" "C"))
+                ("f" "g")
+                ("f" "g")
+                ("f" "g")
+                "Z"
+        )]).unwrap();
+        assert_eq_no_order!(actual,
+                   vec![expr!(("A" ("B" "C")) ("f" "g") "Z")]);
+    }
+
+    #[test]
+    fn union_op() {
+        let union_op = UnionAtomOp{};
+        let actual = union_op.execute(&mut vec![expr!(
+                ("A" ("B" "C"))
+                ("A" ("B" "C"))
+                ("f" "g")
+                ("f" "g")
+                ("f" "g")
+                "Z"
+            ), expr!(
+                ("A" ("B" "C"))
+                "p"
+                "p"
+                ("Q" "a")
+            )]).unwrap();
+        assert_eq_no_order!(actual,
+                   vec![expr!(("A" ("B" "C")) ("A" ("B" "C"))
+                        ("f" "g") ("f" "g") ("f" "g") "Z"
+                        ("A" ("B" "C")) "p" "p" ("Q" "a"))]);
+    }
+
+    #[test]
+    fn intersection_op() {
+        let intersection_op = IntersectionAtomOp{};
+        let actual = intersection_op.execute(&mut vec![expr!(
+                "Z"
+                ("A" ("B" "C"))
+                ("A" ("B" "C"))
+                ("f" "g")
+                ("f" "g")
+                ("f" "g")
+                ("P" "b")
+            ), expr!(
+                ("f" "g")
+                ("f" "g")
+                ("A" ("B" "C"))
+                "p"
+                "p"
+                ("Q" "a")
+                "Z"
+            )]).unwrap();
+        assert_eq_no_order!(actual, vec![expr!("Z" ("A" ("B" "C")) ("f" "g") ("f" "g"))]);
+
+        assert_eq_no_order!(intersection_op.execute(&mut vec![expr!(
+                { Number::Integer(5) }
+                { Number::Integer(4) }
+                { Number::Integer(3) }
+                { Number::Integer(2) }
+            ), expr!(
+                { Number::Integer(5) }
+                { Number::Integer(3) }
+            )]).unwrap(), vec![expr!({Number::Integer(5)} {Number::Integer(3)})]);
+    }
+
+    #[test]
+    fn subtraction_op() {
+        let subtraction_op = SubtractionAtomOp{};
+        let actual = subtraction_op.execute(&mut vec![expr!(
+                "Z"
+                "S"
+                "S"
+                ("A" ("B" "C"))
+                ("A" ("B" "C"))
+                ("f" "g")
+                ("f" "g")
+                ("f" "g")
+                ("P" "b")
+            ), expr!(
+                ("f" "g")
+                ("A" ("B" "C"))
+                "p"
+                "P"
+                ("Q" "a")
+                "Z"
+                "S"
+                "S"
+                "S"
+            )]).unwrap();
+        assert_eq_no_order!(actual,
+                   vec![expr!(("A" ("B" "C")) ("f" "g") ("f" "g") ("P" "b"))]);
+    }
+
+    #[test]
+    fn nop_op() {
+        assert_eq!(NopOp{}.execute(&mut vec![]), unit_result());
+    }
+
+    #[test]
+    fn state_ops() {
+        let result = NewStateOp{}.execute(&mut vec![expr!("A" "B")]).unwrap();
+        let old_state = result.get(0).ok_or("error").unwrap();
+        assert_eq!(old_state, &Atom::gnd(StateAtom::new(expr!("A" "B"))));
+        let result = ChangeStateOp{}.execute(&mut vec!(old_state.clone(), expr!("C" "D"))).unwrap();
+        let new_state = result.get(0).ok_or("error").unwrap();
+        assert_eq!(old_state, new_state);
+        assert_eq!(new_state, &Atom::gnd(StateAtom::new(expr!("C" "D"))));
+        let result = GetStateOp{}.execute(&mut vec![new_state.clone()]);
+        assert_eq!(result, Ok(vec![expr!("C" "D")]))
+    }
+
+    #[test]
+    fn size_atom_op() {
+        let res = SizeAtomOp{}.execute(&mut vec![expr!({Number::Integer(5)} {Number::Integer(4)} {Number::Integer(3)} {Number::Integer(2)} {Number::Integer(1)})]).expect("No result returned");
+        assert_eq!(res, vec![expr!({Number::Integer(5)})]);
+        let res = SizeAtomOp{}.execute(&mut vec![expr!()]).expect("No result returned");
+        assert_eq!(res, vec![expr!({Number::Integer(0)})]);
+    }
+
+    #[test]
+    fn min_atom_op() {
+        let res = MinAtomOp{}.execute(&mut vec![expr!({Number::Integer(5)} {Number::Integer(4)} {Number::Float(5.5)})]).expect("No result returned");
+        assert_eq!(res, vec![expr!({Number::Integer(4)})]);
+        let res = MinAtomOp{}.execute(&mut vec![expr!({Number::Integer(5)} {Number::Integer(4)} "A")]);
+        assert_eq!(res, Err(ExecError::from("Only numbers are allowed in expression")));
+        let res = MinAtomOp{}.execute(&mut vec![expr!()]);
+        assert_eq!(res, Err(ExecError::from("Empty expression")));
+    }
+
+    #[test]
+    fn max_atom_op() {
+        let res = MaxAtomOp{}.execute(&mut vec![expr!({Number::Integer(5)} {Number::Integer(4)} {Number::Float(5.5)})]).expect("No result returned");
+        assert_eq!(res, vec![expr!({Number::Float(5.5)})]);
+        let res = MaxAtomOp{}.execute(&mut vec![expr!({Number::Integer(5)} {Number::Integer(4)} "A")]);
+        assert_eq!(res, Err(ExecError::from("Only numbers are allowed in expression")));
+        let res = MaxAtomOp{}.execute(&mut vec![expr!()]);
+        assert_eq!(res, Err(ExecError::from("Empty expression")));
+    }
+
+    #[test]
+    fn index_atom_op() {
+        let res = IndexAtomOp{}.execute(&mut vec![expr!({Number::Integer(5)} {Number::Integer(4)} {Number::Integer(3)} {Number::Integer(2)} {Number::Integer(1)}), expr!({Number::Integer(2)})]).expect("No result returned");
+        assert_eq!(res, vec![expr!({Number::Integer(3)})]);
+        let res = IndexAtomOp{}.execute(&mut vec![expr!({Number::Integer(5)} {Number::Integer(4)} {Number::Integer(3)} {Number::Integer(2)} {Number::Integer(1)}), expr!({Number::Integer(5)})]);
+        assert_eq!(res, Err(ExecError::from("Index is out of bounds")));
+    }
+
+    #[test]
+    fn test_error_is_used_as_an_argument() {
+        let metta = Metta::new(Some(EnvBuilder::test_env()));
+        let parser = SExprParser::new(r#"
+            !(get-type Error)
+            !(get-metatype Error)
+            !(get-type (Error Foo Boo))
+            !(Error (+ 1 2) (+ 1 +))
+        "#);
+
+        assert_eq_metta_results!(metta.run(parser), Ok(vec![
+            vec![expr!("->" "Atom" "Atom" "ErrorType")],
+            vec![expr!("Symbol")],
+            vec![expr!("ErrorType")],
+            vec![expr!("Error" ({SumOp{}} {Number::Integer(1)} {Number::Integer(2)}) ({SumOp{}} {Number::Integer(1)} {SumOp{}}))],
+        ]));
+    }
+
+    #[test]
+    fn metta_size_atom() {
+        assert_eq!(run_program(&format!("!(size-atom (5 4 3 2 1))")), Ok(vec![vec![expr!({Number::Integer(5)})]]));
+        assert_eq!(run_program(&format!("!(size-atom ())")), Ok(vec![vec![expr!({Number::Integer(0)})]]));
+    }
+
+    #[test]
+    fn metta_min_atom() {
+        assert_eq!(run_program(&format!("!(min-atom (5 4 5.5))")), Ok(vec![vec![expr!({Number::Integer(4)})]]));
+        assert_eq!(run_program(&format!("!(min-atom ())")), Ok(vec![vec![expr!("Error" ({ MinAtomOp{} } ()) "Empty expression")]]));
+        assert_eq!(run_program(&format!("!(min-atom (3 A B 5))")), Ok(vec![vec![expr!("Error" ({ MinAtomOp{} } ({Number::Integer(3)} "A" "B" {Number::Integer(5)})) "Only numbers are allowed in expression")]]));
+    }
+
+    #[test]
+    fn metta_max_atom() {
+        assert_eq!(run_program(&format!("!(max-atom (5 4 5.5))")), Ok(vec![vec![expr!({Number::Float(5.5)})]]));
+        assert_eq!(run_program(&format!("!(max-atom ())")), Ok(vec![vec![expr!("Error" ({ MaxAtomOp{} } ()) "Empty expression")]]));
+        assert_eq!(run_program(&format!("!(max-atom (3 A B 5))")), Ok(vec![vec![expr!("Error" ({ MaxAtomOp{} } ({Number::Integer(3)} "A" "B" {Number::Integer(5)})) "Only numbers are allowed in expression")]]));
+    }
+
+    #[test]
+    fn metta_index_atom() {
+        assert_eq!(run_program(&format!("!(index-atom (5 4 3 2 1) 2)")), Ok(vec![vec![expr!({Number::Integer(3)})]]));
+        assert_eq!(run_program(&format!("!(index-atom (A B C D E) 5)")), Ok(vec![vec![expr!("Error" ({ IndexAtomOp{} } ("A" "B" "C" "D" "E") {Number::Integer(5)}) "Index is out of bounds")]]));
+    }
+
+    #[test]
+    fn mod_space_op() {
+        let program = r#"
+            !(bind! &new_space (new-space))
+            !(add-atom &new_space (mod-space! stdlib))
+            !(get-atoms &new_space)
+        "#;
+        let runner = Metta::new(Some(runner::environment::EnvBuilder::test_env()));
+        let result = runner.run(SExprParser::new(program)).unwrap();
+
+        let stdlib_space = runner.module_space(runner.get_module_by_name("stdlib").unwrap());
+        assert_eq!(result[2], vec![Atom::gnd(stdlib_space)]);
+    }
+
+
+}

--- a/lib/src/metta/runner/stdlib_minimal/stdlib_math.rs
+++ b/lib/src/metta/runner/stdlib_minimal/stdlib_math.rs
@@ -408,14 +408,7 @@ impl CustomExecute for IsInfMathOp {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::metta::text::SExprParser;
-    use crate::metta::runner::EnvBuilder;
-    use crate::metta::runner::Metta;
-
-    fn run_program(program: &str) -> Result<Vec<Vec<Atom>>, String> {
-        let metta = Metta::new(Some(EnvBuilder::test_env()));
-        metta.run(SExprParser::new(program))
-    }
+    use crate::metta::runner::stdlib_minimal::tests::run_program;
 
     #[test]
     fn metta_pow_math() {

--- a/lib/src/metta/runner/stdlib_minimal/stdlib_runner_tokens.rs
+++ b/lib/src/metta/runner/stdlib_minimal/stdlib_runner_tokens.rs
@@ -676,7 +676,7 @@ mod tests {
     use crate::metta::text::SExprParser;
     use crate::metta::runner::EnvBuilder;
     use crate::common::test_utils::metta_space;
-
+    use crate::metta::runner::stdlib_minimal::tests::run_program;
     use std::convert::TryFrom;
     use regex::Regex;
 
@@ -686,11 +686,6 @@ mod tests {
                                                     "Incorrect error message:\nexpected: {:?}\n  actual: {:?}", expected.to_string(), msg),
             _ => assert!(false, "Error is expected as result, {:?} returned", actual),
         }
-    }
-
-    fn run_program(program: &str) -> Result<Vec<Vec<Atom>>, String> {
-        let metta = Metta::new(Some(EnvBuilder::test_env()));
-        metta.run(SExprParser::new(program))
     }
 
     #[test]

--- a/lib/src/metta/runner/stdlib_minimal/stdlib_runner_tokens.rs
+++ b/lib/src/metta/runner/stdlib_minimal/stdlib_runner_tokens.rs
@@ -1,0 +1,884 @@
+use crate::*;
+use crate::space::*;
+use crate::metta::*;
+use crate::metta::text::Tokenizer;
+use crate::common::shared::Shared;
+use crate::metta::runner::{Metta, RunContext, ResourceKey};
+use crate::metta::runner::string::Str;
+use crate::common::CachingMapper;
+#[cfg(feature = "pkg_mgmt")]
+
+use std::convert::TryInto;
+use std::collections::HashMap;
+use regex::Regex;
+
+use crate::metta::runner::string::*;
+use crate::metta::runner::stdlib_minimal::grounded_op;
+use crate::metta::runner::stdlib_minimal::unit_result;
+use crate::metta::runner::stdlib_minimal::interpret_no_error;
+use crate::metta::runner::stdlib_minimal::assert_results_equal;
+use crate::metta::runner::stdlib_minimal::interpret;
+use crate::metta::runner::stdlib_minimal::atom_to_string;
+
+#[derive(Clone, Debug)]
+pub struct AssertEqualOp {
+    space: DynSpace,
+}
+
+grounded_op!(AssertEqualOp, "assertEqual");
+
+impl AssertEqualOp {
+    pub fn new(space: DynSpace) -> Self {
+        Self{ space }
+    }
+}
+
+impl Grounded for AssertEqualOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_ATOM, ATOM_TYPE_ATOM, ATOM_TYPE_ATOM])
+    }
+
+    fn as_execute(&self) -> Option<&dyn CustomExecute> {
+        Some(self)
+    }
+}
+
+impl CustomExecute for AssertEqualOp {
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        log::debug!("AssertEqualOp::execute: {:?}", args);
+        let arg_error = || ExecError::from("assertEqual expects two atoms as arguments: actual and expected");
+        let actual_atom = args.get(0).ok_or_else(arg_error)?;
+        let expected_atom = args.get(1).ok_or_else(arg_error)?;
+
+        let actual = interpret_no_error(self.space.clone(), actual_atom)?;
+        let expected = interpret_no_error(self.space.clone(), expected_atom)?;
+
+        assert_results_equal(&actual, &expected, actual_atom)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct AssertEqualToResultOp {
+    space: DynSpace,
+}
+
+grounded_op!(AssertEqualToResultOp, "assertEqualToResult");
+
+impl AssertEqualToResultOp {
+    pub fn new(space: DynSpace) -> Self {
+        Self{ space }
+    }
+}
+
+impl Grounded for AssertEqualToResultOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_ATOM, ATOM_TYPE_ATOM, ATOM_TYPE_ATOM])
+    }
+
+    fn as_execute(&self) -> Option<&dyn CustomExecute> {
+        Some(self)
+    }
+}
+
+impl CustomExecute for AssertEqualToResultOp {
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        log::debug!("AssertEqualToResultOp::execute: {:?}", args);
+        let arg_error = || ExecError::from("assertEqualToResult expects two atoms as arguments: actual and expected");
+        let actual_atom = args.get(0).ok_or_else(arg_error)?;
+        let expected = TryInto::<&ExpressionAtom>::try_into(args.get(1).ok_or_else(arg_error)?)
+            .map_err(|_| arg_error())?
+            .children();
+
+        let actual = interpret_no_error(self.space.clone(), actual_atom)?;
+
+        assert_results_equal(&actual, &expected.into(), actual_atom)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct SuperposeOp {
+    space: DynSpace,
+}
+
+grounded_op!(SuperposeOp, "superpose");
+
+impl SuperposeOp {
+    pub fn new(space: DynSpace) -> Self {
+        Self{ space }
+    }
+}
+
+impl Grounded for SuperposeOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_EXPRESSION, ATOM_TYPE_UNDEFINED])
+    }
+
+    fn as_execute(&self) -> Option<&dyn CustomExecute> {
+        Some(self)
+    }
+}
+
+impl CustomExecute for SuperposeOp {
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        let arg_error = || ExecError::from("superpose expects single expression as an argument");
+        let atom = args.get(0).ok_or_else(arg_error)?;
+        let expr  = TryInto::<&ExpressionAtom>::try_into(atom).map_err(|_| arg_error())?;
+
+        if expr.children().is_empty() {
+            Ok(vec![EMPTY_SYMBOL])
+        } else {
+            let mut superposed = Vec::new();
+            for atom in expr.children() {
+                match interpret_no_error(self.space.clone(), atom) {
+                    Ok(results) => { superposed.extend(results); },
+                    Err(message) => { return Err(format!("Error: {}", message).into()) },
+                }
+            }
+            Ok(superposed)
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct CollapseOp {
+    space: DynSpace,
+}
+
+grounded_op!(CollapseOp, "collapse");
+
+impl CollapseOp {
+    pub fn new(space: DynSpace) -> Self {
+        Self{ space }
+    }
+}
+
+impl Grounded for CollapseOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_ATOM, ATOM_TYPE_ATOM])
+    }
+
+    fn as_execute(&self) -> Option<&dyn CustomExecute> {
+        Some(self)
+    }
+}
+
+impl CustomExecute for CollapseOp {
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        let arg_error = || ExecError::from("collapse expects single executable atom as an argument");
+        let atom = args.get(0).ok_or_else(arg_error)?;
+
+        // TODO: Calling interpreter inside the operation is not too good
+        // Could it be done via returning atom for the further interpretation?
+        let result = interpret_no_error(self.space.clone(), atom)?;
+
+        Ok(vec![Atom::expr(result)])
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct CaptureOp {
+    space: DynSpace,
+}
+
+grounded_op!(CaptureOp, "capture");
+
+impl CaptureOp {
+    pub fn new(space: DynSpace) -> Self {
+        Self{ space }
+    }
+}
+
+impl Grounded for CaptureOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_ATOM, ATOM_TYPE_ATOM])
+    }
+
+    fn as_execute(&self) -> Option<&dyn CustomExecute> {
+        Some(self)
+    }
+}
+
+impl CustomExecute for CaptureOp {
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        let arg_error = || ExecError::from("capture expects one argument");
+        let atom = args.get(0).ok_or_else(arg_error)?;
+        interpret(self.space.clone(), &atom).map_err(|e| ExecError::from(e))
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct CaseOp {
+    space: DynSpace,
+}
+
+grounded_op!(CaseOp, "case");
+
+impl CaseOp {
+    pub fn new(space: DynSpace) -> Self {
+        Self{ space }
+    }
+}
+
+impl Grounded for CaseOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_ATOM, ATOM_TYPE_EXPRESSION, ATOM_TYPE_ATOM])
+    }
+
+    fn as_execute(&self) -> Option<&dyn CustomExecute> {
+        Some(self)
+    }
+}
+
+impl CustomExecute for CaseOp {
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        let arg_error = || ExecError::from("case expects two arguments: atom and expression of cases");
+        let cases = args.get(1).ok_or_else(arg_error)?;
+        let atom = args.get(0).ok_or_else(arg_error)?;
+        log::debug!("CaseOp::execute: atom: {}, cases: {:?}", atom, cases);
+
+        let switch = |interpreted: Atom| -> Atom {
+            Atom::expr([sym!("switch"), interpreted, cases.clone()])
+        };
+
+        // Interpreting argument inside CaseOp is required because otherwise `Empty` result
+        // calculated inside interpreter cuts the whole branch of the interpretation. Also we
+        // cannot use `unify` in a unit test because after interpreting `(chain... (chain
+        // (metta (unify ...) Atom <space>)) ...)` `chain` executes `unify` and also gets
+        // `Empty` even if we have `Atom` as a resulting type. It can be solved by different ways.
+        // One way is to invent new type `EmptyType` (type of the `Empty` atom) and use this type
+        // in a function to allow `Empty` atoms as an input. `EmptyType` type should not be
+        // casted to the `%Undefined%` thus one cannot pass `Empty` to the function which accepts
+        // `%Undefined%`. Another way is to introduce "call" level. Thus if function called
+        // returned the result to the `chain` it should stop reducing it and insert it into the
+        // last argument.
+        let results = interpret(self.space.clone(), atom);
+        log::debug!("CaseOp::execute: atom results: {:?}", results);
+        let results = match results {
+            Ok(results) if results.is_empty() =>
+                vec![switch(EMPTY_SYMBOL)],
+            Ok(results) =>
+                results.into_iter().map(|atom| switch(atom)).collect(),
+            Err(err) => vec![Atom::expr([ERROR_SYMBOL, atom.clone(), Atom::sym(err)])],
+        };
+        Ok(results)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PragmaOp {
+    settings: Shared<HashMap<String, Atom>>,
+}
+
+grounded_op!(PragmaOp, "pragma!");
+
+impl PragmaOp {
+    pub fn new(settings: Shared<HashMap<String, Atom>>) -> Self {
+        Self{ settings }
+    }
+}
+
+impl Grounded for PragmaOp {
+    fn type_(&self) -> Atom {
+        ATOM_TYPE_UNDEFINED
+    }
+
+    fn as_execute(&self) -> Option<&dyn CustomExecute> {
+        Some(self)
+    }
+}
+
+impl CustomExecute for PragmaOp {
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        let arg_error = || ExecError::from("pragma! expects key and value as arguments");
+        let key = <&SymbolAtom>::try_from(args.get(0).ok_or_else(arg_error)?).map_err(|_| "pragma! expects symbol atom as a key")?.name();
+        let value = args.get(1).ok_or_else(arg_error)?;
+        self.settings.borrow_mut().insert(key.into(), value.clone());
+        unit_result()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ImportOp {
+    //TODO-HACK: This is a terrible horrible ugly hack that should be fixed ASAP
+    context: std::sync::Arc<std::sync::Mutex<Vec<std::sync::Arc<std::sync::Mutex<&'static mut RunContext<'static, 'static>>>>>>,
+}
+
+grounded_op!(ImportOp, "import!");
+
+impl ImportOp {
+    pub fn new(metta: Metta) -> Self {
+        Self{ context: metta.0.context.clone() }
+    }
+}
+
+impl Grounded for ImportOp {
+    fn type_(&self) -> Atom {
+        //TODO: Ideally the "import as" / "import into" part would be optional
+        //A deeper discussion on arg semantics as it relates to import! is here:
+        // https://github.com/trueagi-io/hyperon-experimental/pull/580#discussion_r1491332304
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_ATOM, ATOM_TYPE_ATOM, UNIT_TYPE])
+    }
+
+    fn as_execute(&self) -> Option<&dyn CustomExecute> {
+        Some(self)
+    }
+}
+
+impl CustomExecute for ImportOp {
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        //QUESTION: "Import" can mean several (3) different things.  In Python parlance, it can mean
+        //1. "import module" opt. ("as bar")
+        //2. "from module import foo" opt. ("as bar")
+        //3. "from module import *"
+        //
+        //Do we want one MeTTa operation with multiple ways of invoking it?  Or do we want different
+        // implementations for different versions of the import operation?  (since we don't have key-words)
+        // like "from" and "as" (unless we want to add them)
+        //
+        //The old version of this operation supported 1. or 3., depending on whether a "space" argument
+        // mapped to an atom that already existed or not.  If the space atom existed and was a Space, then
+        // the operation would perform behavior 3 (by importing only the space atom and no token).
+        // Otherwise it would perform behavior 1, by adding a token, but not adding the child space atom to
+        // the parent space.
+        //
+        //For now, in order to not lose functionality, I have kept this behavior.
+        //
+        // ** TO SUMMARIZE **
+        // If the destination argument is the &self Space atom, the behavior is (3) ie "from module import *",
+        // and if the destination argument is a Symbol atom, the behavior is (1) ie "import module as foo"
+        //
+        //The Underlying functionality for behavior 2 exists in MettaMod::import_item_from_dependency_as,
+        //  but it isn't called yet because I wanted to discuss the way to expose it as a MeTTa op.
+        //For behavior 3, there are deeper questions about desired behavior around tokenizer entries,
+        //  transitive imports, etc.  I have summarized those concerns in the discussion comments above
+        //  MettaMod::import_all_from_dependency
+        //
+
+        let arg_error = || ExecError::from("import! expects a destination &space and a module name argument");
+        let dest_arg = args.get(0).ok_or_else(arg_error)?;
+        let mod_name_atom = args.get(1).ok_or_else(arg_error)?;
+
+        // TODO: replace Symbol by grounded String?
+        let mod_name = match mod_name_atom {
+            Atom::Symbol(mod_name) => mod_name.name(),
+            _ => return Err("import! expects a module name as the first argument".into())
+        };
+        let mod_name = strip_quotes(mod_name);
+
+        // Load the module into the runner, or get the ModId if it's already loaded
+        //TODO: Remove this hack to access the RunContext, when it's part of the arguments to `execute`
+        let ctx_ref = self.context.lock().unwrap().last().unwrap().clone();
+        let mut context = ctx_ref.lock().unwrap();
+        let mod_id = context.load_module(mod_name)?;
+
+        // Import the module, as per the behavior described above
+        match dest_arg {
+            Atom::Symbol(dest_sym) => {
+                context.import_dependency_as(mod_id, Some(dest_sym.name().to_string()))?;
+            }
+            other_atom => {
+                match &other_atom {
+                    Atom::Grounded(_) if Atom::as_gnd::<DynSpace>(other_atom) == Some(context.module().space()) => {
+                        context.import_all_from_dependency(mod_id)?;
+                    },
+                    _ => {
+                        return Err(format!("import! destination argument must be a symbol atom naming a new space, or &self.  Found: {other_atom:?}").into());
+                    }
+                }
+            }
+            // None => {
+            //     //TODO: Currently this pattern is unreachable on account of arity-checking in the MeTTa
+            //     // interpreter, but I have the code path in here for when it is possible
+            //     context.module().import_dependency_as(&context.metta, mod_id, None)?;
+            // },
+        }
+
+        unit_result()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct IncludeOp {
+    //TODO-HACK: This is a terrible horrible ugly hack that should be fixed ASAP
+    context: std::sync::Arc<std::sync::Mutex<Vec<std::sync::Arc<std::sync::Mutex<&'static mut RunContext<'static, 'static>>>>>>,
+}
+
+grounded_op!(IncludeOp, "include");
+
+impl IncludeOp {
+    pub fn new(metta: Metta) -> Self {
+        Self{ context: metta.0.context.clone() }
+    }
+}
+
+impl Grounded for IncludeOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_ATOM, ATOM_TYPE_ATOM])
+    }
+
+    fn as_execute(&self) -> Option<&dyn CustomExecute> {
+        Some(self)
+    }
+}
+
+impl CustomExecute for IncludeOp {
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        let arg_error = || ExecError::from("include expects a module name argument");
+        let mod_name_atom = args.get(0).ok_or_else(arg_error)?;
+
+        // TODO: replace Symbol by grounded String?
+        let mod_name = match mod_name_atom {
+            Atom::Symbol(mod_name) => mod_name.name(),
+            _ => return Err(arg_error())
+        };
+        let mod_name = strip_quotes(mod_name);
+
+        //TODO: Remove this hack to access the RunContext, when it's part of the arguments to `execute`
+        let ctx_ref = self.context.lock().unwrap().last().unwrap().clone();
+        let mut context = ctx_ref.lock().unwrap();
+        let program_buf = context.load_resource_from_module(mod_name, ResourceKey::MainMettaSrc)?;
+
+        // Interpret the loaded MeTTa S-Expression text
+        let program_text = String::from_utf8(program_buf)
+            .map_err(|e| e.to_string())?;
+        let parser = crate::metta::text::OwnedSExprParser::new(program_text);
+        let eval_result = context.run_inline(|context| {
+            context.push_parser(Box::new(parser));
+            Ok(())
+        })?;
+
+        //NOTE: Current behavior returns the result of the last sub-eval to match the old
+        // `import!` before before module isolation.  However that means the results prior to
+        // the last are dropped.  I don't know how to fix this or if it's even wrong, but it's
+        // different from the way "eval-type" APIs work when called from host code, e.g. Rust
+        Ok(eval_result.into_iter().last().unwrap_or_else(|| vec![]))
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct BindOp {
+    tokenizer: Shared<Tokenizer>,
+}
+
+grounded_op!(BindOp, "bind!");
+
+impl BindOp {
+    pub fn new(tokenizer: Shared<Tokenizer>) -> Self {
+        Self{ tokenizer }
+    }
+}
+
+impl Grounded for BindOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_SYMBOL, ATOM_TYPE_UNDEFINED, UNIT_TYPE])
+    }
+
+    fn as_execute(&self) -> Option<&dyn CustomExecute> {
+        Some(self)
+    }
+}
+
+impl CustomExecute for BindOp {
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        let arg_error = || ExecError::from("bind! expects two arguments: token and atom");
+        let token = <&SymbolAtom>::try_from(args.get(0).ok_or_else(arg_error)?).map_err(|_| "bind! expects symbol atom as a token")?.name();
+        let atom = args.get(1).ok_or_else(arg_error)?.clone();
+
+        let token_regex = Regex::new(token).map_err(|err| format!("Could convert token {} into regex: {}", token, err))?;
+        self.tokenizer.borrow_mut().register_token(token_regex, move |_| { atom.clone() });
+        unit_result()
+    }
+}
+
+/// Implement trace! built-in.
+///
+/// It is equivalent to Idris or Haskell Trace, that is, it prints a
+/// message to stderr and pass a value along.
+///
+/// For instance
+/// ```metta
+/// !(trace! "Here?" 42)
+/// ```
+/// prints to stderr
+/// ```stderr
+/// Here?
+/// ```
+/// and returns
+/// ```metta
+/// [42]
+/// ```
+///
+/// Note that the first argument does not need to be a string, which
+/// makes `trace!` actually quite capable on its own.  For instance
+/// ```metta
+/// !(trace! ("Hello world!" (if True A B) 1 2 3) 42)
+/// ```
+/// prints to stderr
+/// ```stderr
+/// (Hello world! A 1 2 3)
+/// ```
+/// and returns
+/// ```metta
+/// [42]
+/// ```
+
+#[derive(Clone, Debug)]
+pub struct TraceOp {}
+
+grounded_op!(TraceOp, "trace!");
+
+impl Grounded for TraceOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_UNDEFINED, Atom::var("a"), Atom::var("a")])
+    }
+
+    fn as_execute(&self) -> Option<&dyn CustomExecute> {
+        Some(self)
+    }
+}
+
+impl CustomExecute for TraceOp {
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        let arg_error = || ExecError::from("trace! expects two atoms as arguments");
+        let val = args.get(1).ok_or_else(arg_error)?;
+        let msg = args.get(0).ok_or_else(arg_error)?;
+        eprintln!("{}", msg);
+        Ok(vec![val.clone()])
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PrintlnOp {}
+
+grounded_op!(PrintlnOp, "println!");
+
+impl Grounded for PrintlnOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_UNDEFINED, UNIT_TYPE])
+    }
+
+    fn as_execute(&self) -> Option<&dyn CustomExecute> {
+        Some(self)
+    }
+}
+
+impl CustomExecute for PrintlnOp {
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        let arg_error = || ExecError::from("println! expects single atom as an argument");
+        let atom = args.get(0).ok_or_else(arg_error)?;
+        println!("{}", atom_to_string(atom));
+        unit_result()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct FormatArgsOp {}
+
+grounded_op!(FormatArgsOp, "format-args");
+
+use dyn_fmt::AsStrFormatExt;
+
+impl Grounded for FormatArgsOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_ATOM, ATOM_TYPE_EXPRESSION, ATOM_TYPE_ATOM])
+    }
+
+    fn as_execute(&self) -> Option<&dyn CustomExecute> {
+        Some(self)
+    }
+}
+
+impl CustomExecute for FormatArgsOp {
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        let arg_error = || ExecError::from("format-args expects format string as a first argument and expression as a second argument");
+        let format = atom_to_string(args.get(0).ok_or_else(arg_error)?);
+        let args = TryInto::<&ExpressionAtom>::try_into(args.get(1).ok_or_else(arg_error)?)?;
+        let args: Vec<String> = args.children().iter()
+            .map(|atom| atom_to_string(atom))
+            .collect();
+        let res = format.format(args.as_slice());
+        Ok(vec![Atom::gnd(Str::from_string(res))])
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PrintAlternativesOp {}
+
+grounded_op!(PrintAlternativesOp, "print-alternatives!");
+
+impl Grounded for PrintAlternativesOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_ATOM, ATOM_TYPE_EXPRESSION, UNIT_TYPE])
+    }
+
+    fn as_execute(&self) -> Option<&dyn CustomExecute> {
+        Some(self)
+    }
+}
+
+impl CustomExecute for PrintAlternativesOp {
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        let arg_error = || ExecError::from("print-alternatives! expects format string as a first argument and expression as a second argument");
+        let atom = atom_to_string(args.get(0).ok_or_else(arg_error)?);
+        let args = TryInto::<&ExpressionAtom>::try_into(args.get(1).ok_or_else(arg_error)?)?;
+        let args: Vec<String> = args.children().iter()
+            .map(|atom| atom_to_string(atom))
+            .collect();
+        println!("{} {}:", args.len(), atom);
+        args.iter().for_each(|arg| println!("    {}", arg));
+        Ok(vec![UNIT_ATOM])
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct SealedOp {}
+
+grounded_op!(SealedOp, "sealed");
+
+impl Grounded for SealedOp {
+    fn type_(&self) -> Atom {
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_EXPRESSION, ATOM_TYPE_ATOM, ATOM_TYPE_ATOM])
+    }
+
+    fn as_execute(&self) -> Option<&dyn CustomExecute> {
+        Some(self)
+    }
+}
+
+impl CustomExecute for SealedOp {
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        let arg_error = || ExecError::from("sealed expects two arguments: var_list and expression");
+
+        let mut term_to_seal = args.get(1).ok_or_else(arg_error)?.clone();
+        let var_list = args.get(0).ok_or_else(arg_error)?.clone();
+
+        let mut local_var_mapper = CachingMapper::new(|var: &VariableAtom| var.clone().make_unique());
+
+        var_list.iter().filter_type::<&VariableAtom>()
+            .for_each(|var| { let _ = local_var_mapper.replace(var); });
+
+        term_to_seal.iter_mut().filter_type::<&mut VariableAtom>()
+            .for_each(|var| match local_var_mapper.mapping().get(var) {
+                Some(v) => *var = v.clone(),
+                None => {},
+            });
+
+        let result = vec![term_to_seal.clone()];
+        log::debug!("sealed::execute: var_list: {}, term_to_seal: {}, result: {:?}", var_list, term_to_seal, result);
+
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metta::text::SExprParser;
+    use crate::metta::runner::EnvBuilder;
+    use crate::common::test_utils::metta_space;
+
+    use std::convert::TryFrom;
+    use regex::Regex;
+
+    fn assert_runtime_error(actual: Result<Vec<Atom>, ExecError>, expected: Regex) {
+        match actual {
+            Err(ExecError::Runtime(msg)) => assert!(expected.is_match(msg.as_str()),
+                                                    "Incorrect error message:\nexpected: {:?}\n  actual: {:?}", expected.to_string(), msg),
+            _ => assert!(false, "Error is expected as result, {:?} returned", actual),
+        }
+    }
+
+    fn run_program(program: &str) -> Result<Vec<Vec<Atom>>, String> {
+        let metta = Metta::new(Some(EnvBuilder::test_env()));
+        metta.run(SExprParser::new(program))
+    }
+
+    #[test]
+    fn metta_assert_equal_op() {
+        let metta = Metta::new(Some(EnvBuilder::test_env()));
+        let assert = AssertEqualOp::new(metta.space().clone());
+        let program = "
+            (= (foo $x) $x)
+            (= (bar $x) $x)
+        ";
+        assert_eq!(metta.run(SExprParser::new(program)), Ok(vec![]));
+        assert_eq!(metta.run(SExprParser::new("!(assertEqual (foo A) (bar A))")), Ok(vec![
+            vec![UNIT_ATOM],
+        ]));
+        assert_eq!(metta.run(SExprParser::new("!(assertEqual (foo A) (bar B))")), Ok(vec![
+            vec![expr!("Error" ({assert.clone()} ("foo" "A") ("bar" "B")) "\nExpected: [B]\nGot: [A]\nMissed result: B")],
+        ]));
+        assert_eq!(metta.run(SExprParser::new("!(assertEqual (foo A) Empty)")), Ok(vec![
+            vec![expr!("Error" ({assert.clone()} ("foo" "A") "Empty") "\nExpected: []\nGot: [A]\nExcessive result: A")]
+        ]));
+    }
+
+    #[test]
+    fn metta_assert_equal_to_result_op() {
+        let metta = Metta::new(Some(EnvBuilder::test_env()));
+        let assert = AssertEqualToResultOp::new(metta.space().clone());
+        let program = "
+            (= (foo) A)
+            (= (foo) B)
+            (= (bar) C)
+            (= (baz) D)
+            (= (baz) D)
+        ";
+        assert_eq!(metta.run(SExprParser::new(program)), Ok(vec![]));
+        assert_eq!(metta.run(SExprParser::new("!(assertEqualToResult (foo) (A B))")), Ok(vec![
+            vec![UNIT_ATOM],
+        ]));
+        assert_eq!(metta.run(SExprParser::new("!(assertEqualToResult (bar) (A))")), Ok(vec![
+            vec![expr!("Error" ({assert.clone()} ("bar") ("A")) "\nExpected: [A]\nGot: [C]\nMissed result: A")],
+        ]));
+        assert_eq!(metta.run(SExprParser::new("!(assertEqualToResult (baz) (D))")), Ok(vec![
+            vec![expr!("Error" ({assert.clone()} ("baz") ("D")) "\nExpected: [D]\nGot: [D, D]\nExcessive result: D")]
+        ]));
+    }
+
+    #[test]
+    fn bind_new_space_op() {
+        let tokenizer = Shared::new(Tokenizer::new());
+
+        let bind_op = BindOp::new(tokenizer.clone());
+
+        assert_eq!(bind_op.execute(&mut vec![sym!("&my"), sym!("definition")]), unit_result());
+        let borrowed = tokenizer.borrow();
+        let constr = borrowed.find_token("&my");
+        assert!(constr.is_some());
+        assert_eq!(constr.unwrap()("&my"), Ok(sym!("definition")));
+    }
+
+    #[test]
+    fn trace_op() {
+        assert_eq!(TraceOp{}.execute(&mut vec![sym!("\"Here?\""), sym!("42")]),
+                   Ok(vec![sym!("42")]));
+    }
+
+    #[test]
+    fn println_op() {
+        assert_eq!(PrintlnOp{}.execute(&mut vec![sym!("A")]), unit_result());
+    }
+
+    #[test]
+    fn sealed_op_execute() {
+        let val = SealedOp{}.execute(&mut vec![expr!(x y), expr!("="(y z))]);
+        assert!(crate::atom::matcher::atoms_are_equivalent(&val.unwrap()[0], &expr!("="(y z))));
+    }
+
+    #[test]
+    fn assert_equal_op() {
+        let space = DynSpace::new(metta_space("
+            (= (foo) (A B))
+            (= (foo) (B C))
+            (= (bar) (B C))
+            (= (bar) (A B))
+            (= (err) (A B))
+        "));
+
+        let assert_equal_op = AssertEqualOp::new(space);
+
+        assert_eq!(assert_equal_op.execute(&mut vec![expr!(("foo")), expr!(("bar"))]), unit_result());
+
+        let actual = assert_equal_op.execute(&mut vec![expr!(("foo")), expr!(("err"))]);
+        let expected = Regex::new("\nExpected: \\[(A B)\\]\nGot: \\[\\((B C)|, |(A B)\\){3}\\]\nExcessive result: (B C)").unwrap();
+        assert_runtime_error(actual, expected);
+
+        let actual = assert_equal_op.execute(&mut vec![expr!(("err")), expr!(("foo"))]);
+        let expected = Regex::new("\nExpected: \\[\\((B C)|, |(A B)\\){3}\\]\nGot: \\[(A B)\\]\nMissed result: (B C)").unwrap();
+        assert_runtime_error(actual, expected);
+    }
+
+    #[test]
+    fn assert_equal_to_result_op() {
+        let space = DynSpace::new(metta_space("
+            (= (foo) (A B))
+            (= (foo) (B C))
+        "));
+        let assert_equal_to_result_op = AssertEqualToResultOp::new(space);
+
+        assert_eq!(assert_equal_to_result_op.execute(&mut vec![
+            expr!(("foo")), expr!(("B" "C") ("A" "B"))]),
+                   unit_result());
+    }
+
+    #[test]
+    fn metta_superpose() {
+        assert_eq_metta_results!(run_program("!(superpose (red yellow green))"),
+            Ok(vec![vec![expr!("red"), expr!("yellow"), expr!("green")]]));
+        let program = "
+            (= (foo) FOO)
+            (= (bar) BAR)
+            !(superpose ((foo) (bar) BAZ))
+        ";
+        assert_eq_metta_results!(run_program(program),
+            Ok(vec![vec![expr!("FOO"), expr!("BAR"), expr!("BAZ")]]));
+    }
+
+    #[test]
+    fn metta_collapse() {
+        let program = "
+            (= (color) red)
+            (= (color) green)
+            (= (color) blue)
+            !(collapse (color))
+        ";
+        let result = run_program(program).expect("Successful result is expected");
+        assert_eq!(result.len(), 1);
+        let result = result.get(0).unwrap();
+        assert_eq!(result.len(), 1);
+        let result = result.get(0).unwrap();
+        let actual = <&ExpressionAtom>::try_from(result)
+            .expect("Expression atom is expected").children();
+        assert_eq_no_order!(actual, vec![expr!("red"), expr!("green"), expr!("blue")]);
+    }
+
+    #[test]
+    fn metta_case_empty() {
+        let result = run_program("!(case Empty ( (ok ok) (Empty nok) ))");
+        assert_eq!(result, Ok(vec![vec![expr!("nok")]]));
+        let result = run_program("!(case (unify (C B) (C B) ok Empty) ( (ok ok) (Empty nok) ))");
+        assert_eq!(result, Ok(vec![vec![expr!("ok")]]));
+        let result = run_program("!(case (unify (B C) (C B) ok nok) ( (ok ok) (nok nok) ))");
+        assert_eq!(result, Ok(vec![vec![expr!("nok")]]));
+        let result = run_program("!(case (unify (B C) (C B) ok Empty) ( (ok ok) (Empty nok) ))");
+        assert_eq!(result, Ok(vec![vec![expr!("nok")]]));
+    }
+
+    #[test]
+    fn test_pragma_interpreter_bare_minimal() {
+        let program = "
+            (= (bar) baz)
+            (= (foo) (bar))
+            !(foo)
+            !(pragma! interpreter bare-minimal)
+            !(foo)
+            !(eval (foo))
+        ";
+
+        assert_eq_metta_results!(run_program(program),
+            Ok(vec![
+                vec![expr!("baz")],
+                vec![UNIT_ATOM],
+                vec![expr!(("foo"))],
+                vec![expr!(("bar"))],
+            ]));
+    }
+
+    #[test]
+    fn sealed_op_runner() {
+        let nested = run_program("!(sealed ($x) (sealed ($a $b) (quote (= ($a $x $c) ($b)))))");
+        let simple_replace = run_program("!(sealed ($x $y) (quote (= ($y $z))))");
+
+        assert!(crate::atom::matcher::atoms_are_equivalent(&nested.unwrap()[0][0], &expr!("quote" ("=" (a b c) (z)))));
+        assert!(crate::atom::matcher::atoms_are_equivalent(&simple_replace.unwrap()[0][0], &expr!("quote" ("=" (y z)))));
+    }
+
+    #[test]
+    fn use_sealed_to_make_scoped_variable() {
+        assert_eq!(run_program("!(let $x (input $x) (output $x))"), Ok(vec![vec![]]));
+        assert_eq!(run_program("!(let $x (input $y) (output $x))"), Ok(vec![vec![expr!("output" ("input" y))]]));
+        assert_eq!(run_program("!(let (quote ($sv $st)) (sealed ($x) (quote ($x (output $x))))
+               (let $sv (input $x) $st))"), Ok(vec![vec![expr!("output" ("input" x))]]));
+    }
+}


### PR DESCRIPTION
So, some modularity for stdlib is here. I've created two new modules for common tokens and runner tokens and extracted functions to those modules alongside with tests for those functions. 

I've also made run_program in stdlib_minimal/mod.rs::tests pub to use it in separate modules' tests instead of copy-pasting run_program to each new module. I'm not sure if this is right decision, but it seems more elegant to me.