### PR TITLE
Calling help! without parameters shows list of stdlib functions

### DIFF
--- a/lib/src/metta/runner/stdlib/stdlib.metta
+++ b/lib/src/metta/runner/stdlib/stdlib.metta
@@ -816,7 +816,7 @@
         (@doc-formal (@item $atom) (@kind atom) (@type $type) (@desc "No documentation")) )))))
 
 (@doc help!
-  (@desc "Function prints documentation for the input atom.")
+  (@desc "Function prints documentation for the input atom. Without parameters prints the list of the stdlib functions.")
   (@params (
     (@param "Input to get documentation for")))
   (@return "Unit atom"))
@@ -838,6 +838,16 @@
       (let () (println! (format-args "Atom {}: {} {}" ($item $type $descr)))
       () ))
     ($other (Error $other "Cannot match @doc-formal structure") ))))
+
+(: help! (-> (->)))
+(= (help!) (let $top-space (mod-space! top)
+    (unify $top-space (@doc $name (@desc $desc) $params $ret)
+      (let () (println! (format-args "{}\n\t{}" ($name $desc))) Empty)
+      Empty)))
+(= (help!) (let $top-space (mod-space! top)
+    (unify $top-space (@doc $name (@desc $desc))
+      (let () (println! (format-args "{}\n\t{}" ($name $desc))) Empty)
+      Empty)))
 
 (@doc help-param!
   (@desc "Function used by function help! to output parameters using println!")

--- a/repl/src/main.rs
+++ b/repl/src/main.rs
@@ -137,6 +137,9 @@ fn start_interactive_mode(repl_params: ReplParams, mut metta: MettaShim) -> rust
         }
     }
 
+    println!("Visit https://metta-lang.dev/ for tutorials.");
+    println!("Execute !(help!) to get list of the standard library functions.");
+
     //The Interpreter Loop
     loop {
 

--- a/repl/src/main.rs
+++ b/repl/src/main.rs
@@ -93,6 +93,11 @@ fn main() -> Result<()> {
     }
 }
 
+fn show_welcome_message() {
+    println!("Visit https://metta-lang.dev/ for tutorials.");
+    println!("Execute !(help!) to get list of the standard library functions.");
+}
+
 // To debug rustyline:
 // RUST_LOG=rustyline=debug cargo run --example example 2> debug.log
 fn start_interactive_mode(repl_params: ReplParams, mut metta: MettaShim) -> rustyline::Result<()> {
@@ -137,8 +142,7 @@ fn start_interactive_mode(repl_params: ReplParams, mut metta: MettaShim) -> rust
         }
     }
 
-    println!("Visit https://metta-lang.dev/ for tutorials.");
-    println!("Execute !(help!) to get list of the standard library functions.");
+    show_welcome_message();
 
     //The Interpreter Loop
     loop {


### PR DESCRIPTION
Fixes #815 
`!(help!)` shows the list of stdlib functions. Add REPL banner to inform user about website and `!(help!)`.