### PR TITLE
Don't copy imported module to filter out its dependencies

### DIFF
--- a/c/src/space.rs
+++ b/c/src/space.rs
@@ -736,7 +736,7 @@ impl Space for CSpace {
             None
         }
     }
-    fn atom_iter(&self) -> Option<SpaceIter> {
+    fn atom_iter(&self) -> Option<Box<dyn Iterator<Item=&Atom> + '_>> {
         struct CSpaceIterator<'a>(&'a CSpace, *mut c_void);
         impl<'a> Iterator for CSpaceIterator<'a> {
             type Item = &'a Atom;
@@ -772,7 +772,7 @@ impl Space for CSpace {
                 None
             } else {
                 let new_iter = CSpaceIterator(self, ctx);
-                Some(SpaceIter::new(new_iter))
+                Some(Box::new(new_iter))
             }
         } else {
             None

--- a/c/src/space.rs
+++ b/c/src/space.rs
@@ -827,7 +827,7 @@ impl SpaceMut for CSpace {
         let from: atom_ref_t = from.into();
         (api.replace)(&self.params, &from, to.into())
     }
-    fn as_space(&self) -> &dyn Space {
+    fn as_space<'a>(&self) -> &(dyn Space + 'a) {
         self
     }
 }

--- a/c/src/space.rs
+++ b/c/src/space.rs
@@ -776,7 +776,7 @@ impl Space for CSpace {
     }
     fn visit(&self, v: &mut dyn SpaceVisitor) -> Result<(), ()> {
         self.atom_iter().map_or(Err(()), |iter| {
-            iter.fold((), |_, atom| { v.accept(Cow::Borrowed(atom)) });
+            iter.for_each(|atom| { v.accept(Cow::Borrowed(atom)) });
             Ok(())
         })
     }

--- a/lib/src/metta/runner/stdlib/module.rs
+++ b/lib/src/metta/runner/stdlib/module.rs
@@ -90,7 +90,7 @@ impl CustomExecute for ImportOp {
             }
             other_atom => {
                 match &other_atom {
-                    Atom::Grounded(_) if Atom::as_gnd::<DynSpace>(other_atom) == Some(context.module().space()) => {
+                    Atom::Grounded(_) if Atom::as_gnd::<DynSpace>(other_atom) == Some(&context.module().space()) => {
                         context.import_all_from_dependency(mod_id)?;
                     },
                     _ => {

--- a/lib/src/metta/runner/stdlib/space.rs
+++ b/lib/src/metta/runner/stdlib/space.rs
@@ -161,8 +161,9 @@ impl CustomExecute for GetAtomsOp {
         let space = args.get(0).ok_or_else(arg_error)?;
         let space = Atom::as_gnd::<DynSpace>(space).ok_or("get-atoms expects a space as its argument")?;
         let mut result = Vec::new();
-        space.borrow().as_space().visit(&mut |atom: &Atom| result.push(make_variables_unique(atom.clone())))
-            .map_or(Err(ExecError::Runtime("Unsupported Operation. Can't traverse atoms in this space".to_string())), |_| Ok(result))
+        space.borrow().as_space().visit(&mut |atom: std::borrow::Cow<Atom>| {
+            result.push(make_variables_unique(atom.into_owned()))
+        }).map_or(Err(ExecError::Runtime("Unsupported Operation. Can't traverse atoms in this space".to_string())), |_| Ok(result))
     }
 }
 

--- a/lib/src/metta/runner/stdlib/space.rs
+++ b/lib/src/metta/runner/stdlib/space.rs
@@ -260,6 +260,13 @@ mod tests {
         assert_eq!(result[2], vec![Atom::gnd(stdlib_space)]);
     }
 
+    fn collect_atoms(space: &dyn Space) -> Vec<Atom> {
+        let mut atoms = Vec::new();
+        space.visit(&mut |atom: std::borrow::Cow<Atom>| atoms.push(atom.into_owned()))
+            .expect("Space::visit is not implemented");
+        atoms
+    }
+
     #[test]
     fn remove_atom_op() {
         let space = DynSpace::new(metta_space("
@@ -270,7 +277,7 @@ mod tests {
         let res = RemoveAtomOp{}.execute(&mut vec![satom, expr!(("foo" "bar"))]).expect("No result returned");
         // REM: can return Bool in future
         assert_eq!(res, vec![UNIT_ATOM]);
-        let space_atoms: Vec<Atom> = space.borrow().as_space().atom_iter().unwrap().cloned().collect();
+        let space_atoms = collect_atoms(space.borrow().as_space());
         assert_eq_no_order!(space_atoms, vec![expr!(("bar" "foo"))]);
     }
 
@@ -282,7 +289,7 @@ mod tests {
         "));
         let satom = Atom::gnd(space.clone());
         let res = GetAtomsOp{}.execute(&mut vec![satom]).expect("No result returned");
-        let space_atoms: Vec<Atom> = space.borrow().as_space().atom_iter().unwrap().cloned().collect();
+        let space_atoms = collect_atoms(space.borrow().as_space());
         assert_eq_no_order!(res, space_atoms);
         assert_eq_no_order!(res, vec![expr!(("foo" "bar")), expr!(("bar" "foo"))]);
     }
@@ -292,7 +299,7 @@ mod tests {
         let res = NewSpaceOp{}.execute(&mut vec![]).expect("No result returned");
         let space = res.get(0).expect("Result is empty");
         let space = space.as_gnd::<DynSpace>().expect("Result is not space");
-        let space_atoms: Vec<Atom> = space.borrow().as_space().atom_iter().unwrap().cloned().collect();
+        let space_atoms = collect_atoms(space.borrow().as_space());
         assert_eq_no_order!(space_atoms, Vec::<Atom>::new());
     }
 
@@ -302,7 +309,7 @@ mod tests {
         let satom = Atom::gnd(space.clone());
         let res = AddAtomOp{}.execute(&mut vec![satom, expr!(("foo" "bar"))]).expect("No result returned");
         assert_eq!(res, vec![UNIT_ATOM]);
-        let space_atoms: Vec<Atom> = space.borrow().as_space().atom_iter().unwrap().cloned().collect();
+        let space_atoms = collect_atoms(space.borrow().as_space());
         assert_eq_no_order!(space_atoms, vec![expr!(("foo" "bar"))]);
     }
 

--- a/lib/src/metta/runner/stdlib/space.rs
+++ b/lib/src/metta/runner/stdlib/space.rs
@@ -160,9 +160,9 @@ impl CustomExecute for GetAtomsOp {
         let arg_error = || ExecError::from("get-atoms expects one argument: space");
         let space = args.get(0).ok_or_else(arg_error)?;
         let space = Atom::as_gnd::<DynSpace>(space).ok_or("get-atoms expects a space as its argument")?;
-        space.borrow().as_space().atom_iter()
-            .map(|iter| iter.cloned().map(|a| make_variables_unique(a)).collect())
-            .ok_or(ExecError::Runtime("Unsupported Operation. Can't traverse atoms in this space".to_string()))
+        let mut result = Vec::new();
+        space.borrow().as_space().visit(&mut |atom: &Atom| result.push(make_variables_unique(atom.clone())))
+            .map_or(Err(ExecError::Runtime("Unsupported Operation. Can't traverse atoms in this space".to_string())), |_| Ok(result))
     }
 }
 

--- a/lib/src/space/grounding.rs
+++ b/lib/src/space/grounding.rs
@@ -291,8 +291,8 @@ impl GroundingSpace {
     }
 
     /// Returns the iterator over content of the space.
-    pub fn iter(&self) -> SpaceIter {
-        SpaceIter::new(GroundingSpaceIter::new(self))
+    fn iter(&self) -> GroundingSpaceIter<'_> {
+        GroundingSpaceIter::new(self)
     }
 
     /// Sets the name property for the `GroundingSpace` which can be useful for debugging
@@ -316,8 +316,8 @@ impl Space for GroundingSpace {
     fn atom_count(&self) -> Option<usize> {
         Some(self.iter().count())
     }
-    fn atom_iter(&self) -> Option<SpaceIter> {
-        Some(self.iter())
+    fn atom_iter(&self) -> Option<Box<dyn Iterator<Item=&Atom> + '_>> {
+        Some(Box::new(self.iter()))
     }
     fn as_any(&self) -> Option<&dyn std::any::Any> {
         Some(self)

--- a/lib/src/space/grounding.rs
+++ b/lib/src/space/grounding.rs
@@ -337,7 +337,7 @@ impl SpaceMut for GroundingSpace {
     fn replace(&mut self, from: &Atom, to: Atom) -> bool {
         GroundingSpace::replace(self, from, to)
     }
-    fn as_space(&self) -> &dyn Space {
+    fn as_space<'a>(&self) -> &(dyn Space + 'a) {
         self
     }
 }

--- a/lib/src/space/grounding.rs
+++ b/lib/src/space/grounding.rs
@@ -320,7 +320,7 @@ impl Space for GroundingSpace {
         Some(Box::new(self.iter()))
     }
     fn visit(&self, v: &mut dyn SpaceVisitor) -> Result<(), ()> {
-        Ok(self.iter().fold((), |_, atom| v.accept(Cow::Borrowed(atom))))
+        Ok(self.iter().for_each(|atom| v.accept(Cow::Borrowed(atom))))
     }
     fn as_any(&self) -> Option<&dyn std::any::Any> {
         Some(self)

--- a/lib/src/space/grounding.rs
+++ b/lib/src/space/grounding.rs
@@ -316,9 +316,6 @@ impl Space for GroundingSpace {
     fn atom_count(&self) -> Option<usize> {
         Some(self.iter().count())
     }
-    fn atom_iter(&self) -> Option<Box<dyn Iterator<Item=&Atom> + '_>> {
-        Some(Box::new(self.iter()))
-    }
     fn visit(&self, v: &mut dyn SpaceVisitor) -> Result<(), ()> {
         Ok(self.iter().for_each(|atom| v.accept(Cow::Borrowed(atom))))
     }

--- a/lib/src/space/grounding.rs
+++ b/lib/src/space/grounding.rs
@@ -319,6 +319,9 @@ impl Space for GroundingSpace {
     fn atom_iter(&self) -> Option<Box<dyn Iterator<Item=&Atom> + '_>> {
         Some(Box::new(self.iter()))
     }
+    fn visit(&self, v: &mut dyn SpaceVisitor) -> Result<(), ()> {
+        Ok(self.iter().fold((), |_, atom| v.accept(atom)))
+    }
     fn as_any(&self) -> Option<&dyn std::any::Any> {
         Some(self)
     }

--- a/lib/src/space/grounding.rs
+++ b/lib/src/space/grounding.rs
@@ -320,7 +320,7 @@ impl Space for GroundingSpace {
         Some(Box::new(self.iter()))
     }
     fn visit(&self, v: &mut dyn SpaceVisitor) -> Result<(), ()> {
-        Ok(self.iter().fold((), |_, atom| v.accept(atom)))
+        Ok(self.iter().fold((), |_, atom| v.accept(Cow::Borrowed(atom))))
     }
     fn as_any(&self) -> Option<&dyn std::any::Any> {
         Some(self)

--- a/lib/src/space/mod.rs
+++ b/lib/src/space/mod.rs
@@ -7,6 +7,7 @@ pub mod module;
 use std::fmt::Display;
 use std::rc::{Rc, Weak};
 use std::cell::{RefCell, Ref, RefMut};
+use std::ops::Deref;
 
 use crate::common::FlexRef;
 use crate::atom::*;
@@ -324,13 +325,44 @@ impl Space for DynSpace {
         self.0.borrow().atom_count()
     }
     fn atom_iter(&self) -> Option<Box<dyn Iterator<Item=&Atom> + '_>> {
-        None
+        DynSpaceIter::new(self)
     }
     fn as_any(&self) -> Option<&dyn std::any::Any> {
         None
     }
     fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
         None
+    }
+}
+
+struct DynSpaceIter<'a> {
+    space_ref: Ref<'a, dyn Space>,
+    space_iter: Option<Box<dyn Iterator<Item=&'a Atom> + 'a>>,
+}
+
+impl<'a> DynSpaceIter<'a> {
+    fn new(space: &'a DynSpace) -> Option<Box<dyn Iterator<Item=&Atom> + 'a>> {
+        let space_ref = Ref::map(space.borrow(), SpaceMut::as_space);
+        let mut iter = Self{
+            space_ref,
+            space_iter: None,
+        };
+        let space_ptr = iter.space_ref.deref() as *const dyn Space;
+        match unsafe{ (*space_ptr).atom_iter() } {
+            Some(it) => {
+                iter.space_iter = Some(it);
+                Some(Box::new(iter))
+            },
+            None => None,
+        }
+    }
+}
+
+impl<'a> Iterator for DynSpaceIter<'a> {
+    type Item=&'a Atom;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.space_iter.as_mut().unwrap().next()
     }
 }
 

--- a/lib/src/space/mod.rs
+++ b/lib/src/space/mod.rs
@@ -2,6 +2,7 @@
 //! This module is intended to keep different space implementations.
 
 pub mod grounding;
+pub mod module;
 
 use std::fmt::Display;
 use std::rc::{Rc, Weak};
@@ -282,6 +283,9 @@ pub trait SpaceMut: Space {
 pub struct DynSpace(Rc<RefCell<dyn SpaceMut>>);
 
 impl DynSpace {
+    pub fn with_rc(space: Rc<RefCell<dyn SpaceMut>>) -> Self {
+        Self(space)
+    }
     pub fn new<T: SpaceMut + 'static>(space: T) -> Self {
         let shared = Rc::new(RefCell::new(space));
         DynSpace(shared)

--- a/lib/src/space/mod.rs
+++ b/lib/src/space/mod.rs
@@ -88,25 +88,6 @@ impl<T: SpaceObserver> From<Rc<RefCell<T>>> for SpaceObserverRef<T> {
     }
 }
 
-/// Space iterator.
-pub struct SpaceIter<'a> {
-    iter: Box<dyn Iterator<Item=&'a Atom> + 'a>
-}
-
-impl<'a> SpaceIter<'a> {
-    pub fn new<I: Iterator<Item=&'a Atom> + 'a>(iter: I) -> Self {
-        Self{ iter: Box::new(iter) }
-    }
-}
-
-impl<'a> Iterator for SpaceIter<'a> {
-    type Item = &'a Atom;
-
-    fn next(&mut self) -> Option<&'a Atom> {
-        self.iter.next()
-    }
-}
-
 /// A common object that needs to be maintained by all objects implementing the Space trait
 #[derive(Default)]
 pub struct SpaceCommon {
@@ -204,7 +185,7 @@ pub trait Space: std::fmt::Debug + std::fmt::Display {
     }
 
     /// Returns an iterator over every atom in the space, or None if that is not possible
-    fn atom_iter(&self) -> Option<SpaceIter> {
+    fn atom_iter(&self) -> Option<Box<dyn Iterator<Item=&Atom> + '_>> {
         None
     }
 
@@ -342,7 +323,7 @@ impl Space for DynSpace {
     fn atom_count(&self) -> Option<usize> {
         self.0.borrow().atom_count()
     }
-    fn atom_iter(&self) -> Option<SpaceIter> {
+    fn atom_iter(&self) -> Option<Box<dyn Iterator<Item=&Atom> + '_>> {
         None
     }
     fn as_any(&self) -> Option<&dyn std::any::Any> {
@@ -388,7 +369,7 @@ impl<T: Space> Space for &T {
     fn atom_count(&self) -> Option<usize> {
         T::atom_count(*self)
     }
-    fn atom_iter(&self) -> Option<SpaceIter> {
+    fn atom_iter(&self) -> Option<Box<dyn Iterator<Item=&Atom> + '_>> {
         T::atom_iter(*self)
     }
     fn as_any(&self) -> Option<&dyn std::any::Any> {

--- a/lib/src/space/mod.rs
+++ b/lib/src/space/mod.rs
@@ -198,11 +198,6 @@ pub trait Space: std::fmt::Debug + std::fmt::Display {
         None
     }
 
-    /// Returns an iterator over every atom in the space, or None if that is not possible
-    fn atom_iter(&self) -> Option<Box<dyn Iterator<Item=&Atom> + '_>> {
-        None
-    }
-
     /// Visit each atom of the space and call [SpaceVisitor::accept] method.
     /// This method is optional. Return `Err(())` if method is not implemented.
     /// `Cow<Atom>` is used to allow passing both references and values. First
@@ -345,9 +340,6 @@ impl Space for DynSpace {
     fn atom_count(&self) -> Option<usize> {
         self.0.borrow().atom_count()
     }
-    fn atom_iter(&self) -> Option<Box<dyn Iterator<Item=&Atom> + '_>> {
-        None
-    }
     fn visit(&self, v: &mut dyn SpaceVisitor) -> Result<(), ()> {
         self.0.borrow().visit(v)
     }
@@ -393,9 +385,6 @@ impl<T: Space> Space for &T {
     }
     fn atom_count(&self) -> Option<usize> {
         T::atom_count(*self)
-    }
-    fn atom_iter(&self) -> Option<Box<dyn Iterator<Item=&Atom> + '_>> {
-        T::atom_iter(*self)
     }
     fn visit(&self, v: &mut dyn SpaceVisitor) -> Result<(), ()> {
         T::visit(*self, v)

--- a/lib/src/space/mod.rs
+++ b/lib/src/space/mod.rs
@@ -257,7 +257,7 @@ pub trait SpaceMut: Space {
 
     /// Turn a &dyn SpaceMut into an &dyn Space.  Obsolete when Trait Upcasting is stabilized.
     /// [Rust issue #65991](https://github.com/rust-lang/rust/issues/65991)  Any month now.
-    fn as_space(&self) -> &dyn Space;
+    fn as_space<'a>(&self) -> &(dyn Space + 'a);
 }
 
 #[derive(Clone)]
@@ -305,7 +305,7 @@ impl SpaceMut for DynSpace {
     fn replace(&mut self, from: &Atom, to: Atom) -> bool {
         self.0.borrow_mut().replace(from, to)
     }
-    fn as_space(&self) -> &dyn Space {
+    fn as_space<'a>(&self) -> &(dyn Space + 'a) {
         self
     }
 }

--- a/lib/src/space/module.rs
+++ b/lib/src/space/module.rs
@@ -84,7 +84,7 @@ impl SpaceMut for ModuleSpace {
     fn replace(&mut self, from: &Atom, to: Atom) -> bool {
         self.main.replace(from, to)
     }
-    fn as_space(&self) -> &dyn Space {
+    fn as_space<'a>(&self) -> &(dyn Space + 'a) {
         self
     }
 }

--- a/lib/src/space/module.rs
+++ b/lib/src/space/module.rs
@@ -66,6 +66,9 @@ impl Space for ModuleSpace {
     fn atom_iter(&self) -> Option<Box<dyn Iterator<Item=&Atom> + '_>> {
         self.main.atom_iter()
     }
+    fn visit(&self, v: &mut dyn SpaceVisitor) -> Result<(), ()> {
+        self.main.visit(v)
+    }
     fn as_any(&self) -> Option<&dyn std::any::Any> {
         Some(self)
     }

--- a/lib/src/space/module.rs
+++ b/lib/src/space/module.rs
@@ -63,9 +63,6 @@ impl Space for ModuleSpace {
     fn atom_count(&self) -> Option<usize> {
         self.main.atom_count()
     }
-    fn atom_iter(&self) -> Option<Box<dyn Iterator<Item=&Atom> + '_>> {
-        self.main.atom_iter()
-    }
     fn visit(&self, v: &mut dyn SpaceVisitor) -> Result<(), ()> {
         self.main.visit(v)
     }

--- a/lib/src/space/module.rs
+++ b/lib/src/space/module.rs
@@ -63,7 +63,7 @@ impl Space for ModuleSpace {
     fn atom_count(&self) -> Option<usize> {
         self.main.atom_count()
     }
-    fn atom_iter(&self) -> Option<SpaceIter> {
+    fn atom_iter(&self) -> Option<Box<dyn Iterator<Item=&Atom> + '_>> {
         self.main.atom_iter()
     }
     fn as_any(&self) -> Option<&dyn std::any::Any> {

--- a/lib/src/space/module.rs
+++ b/lib/src/space/module.rs
@@ -1,0 +1,91 @@
+use super::*;
+
+use std::fmt::Debug;
+
+pub struct ModuleSpace {
+    main: Box<dyn SpaceMut>,
+    deps: Vec<DynSpace>,
+}
+
+impl Display for ModuleSpace {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self.main, f)
+    }
+}
+
+impl Debug for ModuleSpace {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Debug::fmt(&self.main, f)
+    }
+}
+
+impl ModuleSpace {
+    pub fn new<T: SpaceMut + 'static>(space: T) -> Self {
+        Self { main: Box::new(space), deps: Vec::new() }
+    }
+
+    pub fn query(&self, query: &Atom) -> BindingsSet {
+        let mut results = self.main.query(query);
+        for dep in &self.deps {
+            if let Some(space) = dep.borrow().as_any() {
+                if let Some(space) = space.downcast_ref::<Self>()  {
+                    results.extend(space.query_no_deps(query));
+                } else {
+                    panic!("Only ModuleSpace is expected inside dependencies collection");
+                }
+            } else {
+                panic!("Cannot get space as Any inside ModuleSpace dependencies: {}", dep);
+            }
+        }
+        results
+    }
+
+    fn query_no_deps(&self, query: &Atom) -> BindingsSet {
+        self.main.query(query)
+    }
+
+    pub fn add_dep(&mut self, space: DynSpace) {
+        self.deps.push(space)
+    }
+
+    pub fn deps(&self) -> &Vec<DynSpace> {
+        &self.deps
+    }
+}
+
+impl Space for ModuleSpace {
+    fn common(&self) -> FlexRef<SpaceCommon> {
+        self.main.common()
+    }
+    fn query(&self, query: &Atom) -> BindingsSet {
+        ModuleSpace::query(self, query)
+    }
+    fn atom_count(&self) -> Option<usize> {
+        self.main.atom_count()
+    }
+    fn atom_iter(&self) -> Option<SpaceIter> {
+        self.main.atom_iter()
+    }
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        Some(self)
+    }
+    fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
+        Some(self)
+    }
+}
+
+impl SpaceMut for ModuleSpace {
+    fn add(&mut self, atom: Atom) {
+        self.main.add(atom)
+    }
+    fn remove(&mut self, atom: &Atom) -> bool {
+        self.main.remove(atom)
+    }
+    fn replace(&mut self, from: &Atom, to: Atom) -> bool {
+        self.main.replace(from, to)
+    }
+    fn as_space(&self) -> &dyn Space {
+        self
+    }
+}
+

--- a/python/tests/scripts/f1_imports.metta
+++ b/python/tests/scripts/f1_imports.metta
@@ -3,14 +3,16 @@
 ;  are separate modules, but in no python mode there is no Python stdlib
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-; Even at the very beginning of the script `(get-atoms &self)`
-; returns two atoms.  One is from the imported stdlib, and the other
-; is corelib, which was a dependency of stdlib that has been promoted
-; These atoms are both wrapped spaces, as is `&self`
+; At the very beginning of the script `(get-atoms &self)`
+; returns no atoms. In fact it imports one or two libraries:
+; corelib is a necessary core library and stdlib if Python is enabled.
+; But these libraries are considered to be a part of the space content.
+; TODO: if get-deps is implemented we could check it returns corelib and stdlib
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;!(assertEqual
-  ;((let $x (get-atoms &self) (get-type $x)))
-  ;(superpose (((get-type &self)) ((get-type &self)))))
+!(assertEqualToResult
+  ((let $x (get-atoms &self) (get-type $x)))
+  ())
+
 
 ; stdlib is already loaded
 !(assertEqual
@@ -36,16 +38,11 @@
 (= (is-space $atom)
    (let* (($type (get-type $atom)) ($space (get-type &self))) (== $type $space)))
 
-; It's first atom is a space
-;!(assertEqual
-  ;(let $x (collapse (get-atoms &m)) (contains $x is-space))
-  ;True)
-
-; FIXME: It is the `stdlib` atom but equality check doesn't work
-;!(import! &stdlib top:stdlib)
-;!(assertEqual
-  ;(let $x (collapse (get-atoms &m)) (car-atom $x))
-  ;&stdlib)
+; It is not returned by get-atoms as well
+; TODO: after implementing get-deps we can check new dependency is added
+!(assertEqual
+  (let $x (collapse (get-atoms &m)) (contains $x is-space))
+  False)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -61,8 +58,6 @@
   (g 3))
 
 ; Importing the same space into `&self` should break nothing
-; TODO? If stdlib space would be in `&m`, which should check that it is not
-; there anymore since in should be removed after importing it to `&self`
 !(import! &self f1_moduleA)
 
 ; Now indirectly imported `g` works and `f` fully works
@@ -75,10 +70,6 @@
 ; - moduleA itself, which is the same as &m
 ; - moduleC imported by moduleA and removed from A after its import to &self
 
-; Check whether atom is &m
-(: is-m (-> Atom Bool))
-(= (is-m $atom) (== $atom &m))
-
 ; Assert that the &self space contains the same space as &m, which we imported from moduleA
 ; TODO: Comparing spaces like this doesn't work because the source module is the same, but a specialized
 ;   clone of the dependent space without transitive-dependencies was created during the import process.
@@ -86,17 +77,21 @@
 ;   spaces will work again.  But, In my opinion comparing spaces is not a good way to check to see if a
 ;   module has been loaded.  I believe a better solution is accessor operations for loaded & imported modules
 ;
+; Check whether atom is &m
+;(: is-m (-> Atom Bool))
+;(= (is-m $atom) (== $atom &m))
 ;!(assertEqual
-;  (let $a (collapse (get-atoms &self)) (contains $a is-m))
+;  (let $a (collapse (get-deps &self)) (contains $a is-m))
 ;  True)
 
 ; Check that the &self space contains the corelib child space
 ; Note: corelib doesn't import any modules into itself, so no space copy is needed
-!(import! &corelib top:corelib)
-(: is-corelib (-> Atom Bool))
-(= (is-corelib $atom) (== $atom &corelib))
+; TODO: this should be possible after implementing get-deps
+;!(import! &corelib top:corelib)
+;(: is-corelib (-> Atom Bool))
+;(= (is-corelib $atom) (== $atom &corelib))
 ;!(assertEqual
-  ;(let $a (collapse (get-atoms &self)) (contains $a is-corelib))
+  ;(let $a (collapse (get-deps &self)) (contains $a is-corelib))
   ;True)
 
 ; Let's check that `if` from stdlib is not duplicated and gives only one result

--- a/python/tests/scripts/f1_imports.metta
+++ b/python/tests/scripts/f1_imports.metta
@@ -8,9 +8,9 @@
 ; is corelib, which was a dependency of stdlib that has been promoted
 ; These atoms are both wrapped spaces, as is `&self`
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-!(assertEqual
-  ((let $x (get-atoms &self) (get-type $x)))
-  (superpose (((get-type &self)) ((get-type &self)))))
+;!(assertEqual
+  ;((let $x (get-atoms &self) (get-type $x)))
+  ;(superpose (((get-type &self)) ((get-type &self)))))
 
 ; stdlib is already loaded
 !(assertEqual
@@ -37,9 +37,9 @@
    (let* (($type (get-type $atom)) ($space (get-type &self))) (== $type $space)))
 
 ; It's first atom is a space
-!(assertEqual
-  (let $x (collapse (get-atoms &m)) (contains $x is-space))
-  True)
+;!(assertEqual
+  ;(let $x (collapse (get-atoms &m)) (contains $x is-space))
+  ;True)
 
 ; FIXME: It is the `stdlib` atom but equality check doesn't work
 ;!(import! &stdlib top:stdlib)
@@ -95,9 +95,9 @@
 !(import! &corelib top:corelib)
 (: is-corelib (-> Atom Bool))
 (= (is-corelib $atom) (== $atom &corelib))
-!(assertEqual
-  (let $a (collapse (get-atoms &self)) (contains $a is-corelib))
-  True)
+;!(assertEqual
+  ;(let $a (collapse (get-atoms &self)) (contains $a is-corelib))
+  ;True)
 
 ; Let's check that `if` from stdlib is not duplicated and gives only one result
 !(assertEqual


### PR DESCRIPTION
This PR is replacement of #776 without issue which were caused by old interpreter implementation. New commits start from https://github.com/trueagi-io/hyperon-experimental/commit/4277146f621100f3f408bb3bfae724617a57a226

In this PR `ModuleSpace` is introduced which keeps main space and its dependencies separately. This allows querying them separately and when dependent space is queried it doesn't queried recursively. Thus all transitive dependencies are queried only once from the top level space.

For example if we have space `A` which imports space `B` and `C` and `D` is imported from `B` and `C` then `A` contains `B`, `C` and `D` as dependencies in a separate collection. Query to `A` goes through its atoms first then goes to `B`, `C` and `D` but dependencies of these spaces are not queried.

`ModuleSpace::atom_iter()` iterates through main atomspace only. This breaks tests in `f1_imports.metta` which are disabled in this change. There are two ways of solving this: (1) adding dependency spaces as atoms into `ModuleSpace` iterator which resembles previous behavior, (2) add separate function which gets dependencies from space. I would like to implement solution after discussing a way. Option (2) is not possible with current `DynSpace` used internally as space representation may be it can be implemented after additional refactoring.

New `Space::visit` method is added because it is impossible to implement `Space::atom_iter` for `DynSpace` safely (see @luketpeterson  comment https://github.com/trueagi-io/hyperon-experimental/pull/776#issuecomment-2375449225). Internal usages of `Space::atom_iter` are replaced by `Space::visit` usages.