### PR TITLE
Separate Debug and Display trait implementations for Atom

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -13,6 +13,7 @@ im = "15.1.0"
 rand = "0.8.5"
 bitset = "0.1.2"
 dyn-fmt = "0.4.0"
+itertools = "0.13.0"
 
 # pkg_mgmt deps
 xxhash-rust = {version="0.8.7", features=["xxh3"], optional=true }

--- a/lib/src/atom/mod.rs
+++ b/lib/src/atom/mod.rs
@@ -784,7 +784,7 @@ impl Clone for Box<dyn GroundedAtom> {
 
 /// Atoms are main components of the atomspace. There are four meta-types of
 /// atoms: symbol, expression, variable and grounded.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub enum Atom {
     /// Symbol represents some idea or concept. Two symbols having
     /// the same name are considered equal and representing the same concept.
@@ -1080,12 +1080,6 @@ impl Display for Atom {
             Atom::Variable(var) => Display::fmt(var, f),
             Atom::Grounded(gnd) => Display::fmt(gnd, f),
         }
-    }
-}
-
-impl Debug for Atom {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        Display::fmt(self, f)
     }
 }
 

--- a/lib/src/common/assert.rs
+++ b/lib/src/common/assert.rs
@@ -1,5 +1,6 @@
 use super::collections::{ListMap, Equality, DefaultEquality};
 
+use std::fmt::{Debug, Display, Formatter};
 use itertools::Itertools;
 
 pub fn compare_vec_no_order<'a, T, A, B, E>(actual: A, expected: B, _cmp: E) -> VecDiff<'a, T, E>
@@ -29,30 +30,56 @@ pub struct VecDiff<'a, T, E: Equality<&'a T>> {
     diff: ListMap<&'a T, Count, E>,
 }
 
-impl<'a, T: std::fmt::Debug, E: Equality<&'a T>> VecDiff<'a, T, E> {
+struct FormatAsDebug<T: Debug>(T);
+impl<T: Debug> Display for FormatAsDebug<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Debug::fmt(&self.0, f)
+    }
+}
+
+struct FormatAsDisplay<T: Display>(T);
+impl<T: Display> Display for FormatAsDisplay<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self.0, f)
+    }
+}
+
+impl<'a, T, E: Equality<&'a T>> VecDiff<'a, T, E> {
     pub fn has_diff(&self) -> bool {
         !self.diff.is_empty()
     }
 
-    pub fn as_string(&self) -> Option<String> {
+    pub fn as_display(&self) -> Option<String> where T: Display {
+        self.as_string(FormatAsDisplay)
+    }
+
+    pub fn as_debug(&self) -> Option<String> where T: Debug {
+        self.as_string(FormatAsDebug)
+    }
+    
+    fn as_string<F, I: Display>(&self, f: F) -> Option<String>
+        where F: Fn(&'a T) -> I
+    {
         let mut diff = String::new();
         if self.has_diff() {
             let mut missed = self.diff.iter()
                 .filter(|(_v, c)| c.actual < c.expected)
                 .flat_map(|(v, c)| std::iter::repeat_n(v, c.expected - c.actual))
+                .map(|v| f(v))
                 .peekable();
             let mut excessive = self.diff.iter()
                 .filter(|(_v, c)| c.actual > c.expected)
                 .flat_map(|(v, c)| std::iter::repeat_n(v, c.actual - c.expected))
+                .map(|v| f(v))
                 .peekable();
             if missed.peek().is_some() {
-                diff.push_str(format!("Missed results: {:?}", missed.format(", ")).as_str());
+                diff.push_str(format!("Missed results: {}", missed.format(", ")).as_str());
             }
             if excessive.peek().is_some() {
                 if !diff.is_empty() {
                     diff.push_str("\n");
                 }
-                diff.push_str(format!("Excessive results: {:?}", excessive.format(", ")).as_str());
+                diff.push_str(format!("Excessive results: {}", excessive.format(", ")).as_str());
             }
             Some(diff)
         } else {
@@ -66,7 +93,7 @@ macro_rules! assert_eq_no_order {
     ($actual:expr, $expected:expr) => {
         {
             let diff = $crate::common::assert::compare_vec_no_order($actual.iter(), $expected.iter(),
-                $crate::common::collections::DefaultEquality{}).as_string();
+                $crate::common::collections::DefaultEquality{}).as_debug();
             assert!(diff.is_none(),
                 "(actual != expected)\nActual: {:?}\nExpected: {:?}\n{}",
                     $actual, $expected, diff.unwrap());
@@ -74,7 +101,7 @@ macro_rules! assert_eq_no_order {
     }
 }
 
-pub fn metta_results_eq<T: PartialEq + std::fmt::Debug>(
+pub fn metta_results_eq<T: PartialEq>(
     actual: &Result<Vec<Vec<T>>, String>, expected: &Result<Vec<Vec<T>>, String>) -> bool
 {
     match (actual, expected) {

--- a/lib/src/common/collections.rs
+++ b/lib/src/common/collections.rs
@@ -1,4 +1,5 @@
 use std::fmt::Display;
+use itertools::Itertools;
 
 pub trait Equality<T> {
     fn eq(a: &T, b: &T) -> bool;
@@ -285,6 +286,14 @@ impl<T: Clone> Into<Vec<T>> for CowArray<T> {
 impl<'a, T> Into<&'a [T]> for &'a CowArray<T> {
     fn into(self) -> &'a [T] {
         self.as_slice()
+    }
+}
+
+pub struct VecDisplay<'a, T: 'a + Display>(pub &'a Vec<T>);
+
+impl<'a, T: 'a + Display> Display for VecDisplay<'a, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[{}]", self.0.iter().format(", "))
     }
 }
 

--- a/lib/src/metta/runner/stdlib/debug.rs
+++ b/lib/src/metta/runner/stdlib/debug.rs
@@ -9,11 +9,12 @@ use crate::metta::runner::stdlib::{grounded_op, atom_to_string, regex, interpret
 use crate::metta::runner::bool::*;
 
 use std::convert::TryInto;
+use itertools::Itertools;
 
 
 fn assert_results_equal(actual: &Vec<Atom>, expected: &Vec<Atom>) -> Result<Vec<Atom>, ExecError> {
-    let report = format!("\nExpected: {:?}\nGot: {:?}", expected, actual);
-    match compare_vec_no_order(actual.iter(), expected.iter(), DefaultEquality{}).as_string() {
+    let report = format!("\nExpected: [{}]\nGot: [{}]", expected.iter().format(", "), actual.iter().format(", "));
+    match compare_vec_no_order(actual.iter(), expected.iter(), DefaultEquality{}).as_display() {
         None => unit_result(),
         Some(diff) => Err(ExecError::Runtime(format!("{}\n{}", report, diff)))
     }
@@ -114,9 +115,9 @@ impl Equality<&Atom> for AlphaEquality {
 }
 
 fn assert_alpha_equal(actual: &Vec<Atom>, expected: &Vec<Atom>) -> Result<Vec<Atom>, ExecError> {
-    let report = format!("\nExpected: {:?}\nGot: {:?}", expected, actual);
+    let report = format!("\nExpected: [{}]\nGot: [{}]", expected.iter().format(", "), actual.iter().format(", "));
     let res = compare_vec_no_order(actual.iter(), expected.iter(), AlphaEquality{});
-    match res.as_string() {
+    match res.as_display() {
         None => unit_result(),
         Some(diff) => Err(ExecError::Runtime(format!("{}\n{}", report, diff)))
     }

--- a/lib/src/metta/runner/stdlib/debug.rs
+++ b/lib/src/metta/runner/stdlib/debug.rs
@@ -2,8 +2,8 @@ use crate::*;
 use crate::metta::*;
 use crate::metta::text::Tokenizer;
 use crate::space::*;
-use crate::common::collections::Equality;
-use crate::common::assert::{vec_eq_no_order, compare_vec_no_order};
+use crate::common::collections::{Equality, DefaultEquality};
+use crate::common::assert::compare_vec_no_order;
 use crate::atom::matcher::atoms_are_equivalent;
 use crate::metta::runner::stdlib::{grounded_op, atom_to_string, regex, interpret_no_error, unit_result};
 use crate::metta::runner::bool::*;
@@ -13,7 +13,7 @@ use std::convert::TryInto;
 
 fn assert_results_equal(actual: &Vec<Atom>, expected: &Vec<Atom>) -> Result<Vec<Atom>, ExecError> {
     let report = format!("\nExpected: {:?}\nGot: {:?}", expected, actual);
-    match vec_eq_no_order(actual.iter(), expected.iter()) {
+    match compare_vec_no_order(actual.iter(), expected.iter(), DefaultEquality{}).as_string() {
         None => unit_result(),
         Some(diff) => Err(ExecError::Runtime(format!("{}\n{}", report, diff)))
     }

--- a/lib/src/metta/runner/stdlib/debug.rs
+++ b/lib/src/metta/runner/stdlib/debug.rs
@@ -2,18 +2,16 @@ use crate::*;
 use crate::metta::*;
 use crate::metta::text::Tokenizer;
 use crate::space::*;
-use crate::common::collections::{Equality, DefaultEquality};
+use crate::common::collections::{VecDisplay, Equality, DefaultEquality};
 use crate::common::assert::compare_vec_no_order;
 use crate::atom::matcher::atoms_are_equivalent;
 use crate::metta::runner::stdlib::{grounded_op, atom_to_string, regex, interpret_no_error, unit_result};
 use crate::metta::runner::bool::*;
 
 use std::convert::TryInto;
-use itertools::Itertools;
-
 
 fn assert_results_equal(actual: &Vec<Atom>, expected: &Vec<Atom>) -> Result<Vec<Atom>, ExecError> {
-    let report = format!("\nExpected: [{}]\nGot: [{}]", expected.iter().format(", "), actual.iter().format(", "));
+    let report = format!("\nExpected: {}\nGot: {}", VecDisplay(expected), VecDisplay(actual));
     match compare_vec_no_order(actual.iter(), expected.iter(), DefaultEquality{}).as_display() {
         None => unit_result(),
         Some(diff) => Err(ExecError::Runtime(format!("{}\n{}", report, diff)))
@@ -115,7 +113,7 @@ impl Equality<&Atom> for AlphaEquality {
 }
 
 fn assert_alpha_equal(actual: &Vec<Atom>, expected: &Vec<Atom>) -> Result<Vec<Atom>, ExecError> {
-    let report = format!("\nExpected: [{}]\nGot: [{}]", expected.iter().format(", "), actual.iter().format(", "));
+    let report = format!("\nExpected: {}\nGot: {}", VecDisplay(expected), VecDisplay(actual));
     let res = compare_vec_no_order(actual.iter(), expected.iter(), AlphaEquality{});
     match res.as_display() {
         None => unit_result(),

--- a/lib/src/metta/runner/stdlib/debug.rs
+++ b/lib/src/metta/runner/stdlib/debug.rs
@@ -353,10 +353,10 @@ mod tests {
             vec![UNIT_ATOM],
         ]));
         assert_eq!(metta.run(SExprParser::new("!(assertEqual (foo A) (bar B))")), Ok(vec![
-            vec![expr!("Error" ({assert.clone()} ("foo" "A") ("bar" "B")) "\nExpected: [B]\nGot: [A]\nMissed result: B")],
+            vec![expr!("Error" ({assert.clone()} ("foo" "A") ("bar" "B")) "\nExpected: [B]\nGot: [A]\nMissed results: B\nExcessive results: A")],
         ]));
         assert_eq!(metta.run(SExprParser::new("!(assertEqual (foo A) Empty)")), Ok(vec![
-            vec![expr!("Error" ({assert.clone()} ("foo" "A") "Empty") "\nExpected: []\nGot: [A]\nExcessive result: A")]
+            vec![expr!("Error" ({assert.clone()} ("foo" "A") "Empty") "\nExpected: []\nGot: [A]\nExcessive results: A")]
         ]));
     }
 
@@ -373,10 +373,10 @@ mod tests {
             vec![UNIT_ATOM],
         ]));
         assert_eq!(metta.run(SExprParser::new("!(assertAlphaEqual (foo A) (bar B))")), Ok(vec![
-            vec![expr!("Error" ({assert.clone()} ("foo" "A") ("bar" "B")) "\nExpected: [B]\nGot: [A]\nMissed result: B")],
+            vec![expr!("Error" ({assert.clone()} ("foo" "A") ("bar" "B")) "\nExpected: [B]\nGot: [A]\nMissed results: B\nExcessive results: A")],
         ]));
         assert_eq!(metta.run(SExprParser::new("!(assertAlphaEqual (foo A) Empty)")), Ok(vec![
-            vec![expr!("Error" ({assert.clone()} ("foo" "A") "Empty") "\nExpected: []\nGot: [A]\nExcessive result: A")]
+            vec![expr!("Error" ({assert.clone()} ("foo" "A") "Empty") "\nExpected: []\nGot: [A]\nExcessive results: A")]
         ]));
     }
 
@@ -396,16 +396,17 @@ mod tests {
             (= (bar) C)
             (= (baz) D)
             (= (baz) D)
+            (= (baz) D)
         ";
         assert_eq!(metta.run(SExprParser::new(program)), Ok(vec![]));
         assert_eq!(metta.run(SExprParser::new("!(assertEqualToResult (foo) (A B))")), Ok(vec![
             vec![UNIT_ATOM],
         ]));
         assert_eq!(metta.run(SExprParser::new("!(assertEqualToResult (bar) (A))")), Ok(vec![
-            vec![expr!("Error" ({assert.clone()} ("bar") ("A")) "\nExpected: [A]\nGot: [C]\nMissed result: A")],
+            vec![expr!("Error" ({assert.clone()} ("bar") ("A")) "\nExpected: [A]\nGot: [C]\nMissed results: A\nExcessive results: C")],
         ]));
         assert_eq!(metta.run(SExprParser::new("!(assertEqualToResult (baz) (D))")), Ok(vec![
-            vec![expr!("Error" ({assert.clone()} ("baz") ("D")) "\nExpected: [D]\nGot: [D, D]\nExcessive result: D")]
+            vec![expr!("Error" ({assert.clone()} ("baz") ("D")) "\nExpected: [D]\nGot: [D, D, D]\nExcessive results: D, D")]
         ]));
     }
 
@@ -416,6 +417,7 @@ mod tests {
         let program = "
             (= (foo) $x)
             (= (bar) C)
+            (= (baz) D)
             (= (baz) D)
             (= (baz) D)
         ";
@@ -433,10 +435,10 @@ mod tests {
         assert_eq!(res.get(0).unwrap().len(), 1);
 
         assert_eq!(metta.run(SExprParser::new("!(assertAlphaEqualToResult (bar) (A))")), Ok(vec![
-            vec![expr!("Error" ({assert.clone()} ("bar") ("A")) "\nExpected: [A]\nGot: [C]\nMissed result: A")],
+            vec![expr!("Error" ({assert.clone()} ("bar") ("A")) "\nExpected: [A]\nGot: [C]\nMissed results: A\nExcessive results: C")],
         ]));
         assert_eq!(metta.run(SExprParser::new("!(assertAlphaEqualToResult (baz) (D))")), Ok(vec![
-            vec![expr!("Error" ({assert.clone()} ("baz") ("D")) "\nExpected: [D]\nGot: [D, D]\nExcessive result: D")]
+            vec![expr!("Error" ({assert.clone()} ("baz") ("D")) "\nExpected: [D]\nGot: [D, D, D]\nExcessive results: D, D")]
         ]));
     }
 

--- a/repl/Cargo.toml
+++ b/repl/Cargo.toml
@@ -14,6 +14,7 @@ signal-hook = "0.3.17"
 pyo3 = { version = "0.19.2", features = ["auto-initialize"], optional = true }
 pep440_rs = { version = "0.3.11", optional = true }
 hyperon = { workspace = true, optional = true } #TODO: We can only link Hyperon directly or through Python, but not both at the same time.  The right fix is to allow HyperonPy to be built within Hyperon, See https://github.com/trueagi-io/hyperon-experimental/issues/283
+itertools = "0.13.0"
 
 [[bin]]
 name = "metta-repl"

--- a/repl/Cargo.toml
+++ b/repl/Cargo.toml
@@ -14,7 +14,6 @@ signal-hook = "0.3.17"
 pyo3 = { version = "0.19.2", features = ["auto-initialize"], optional = true }
 pep440_rs = { version = "0.3.11", optional = true }
 hyperon = { workspace = true, optional = true } #TODO: We can only link Hyperon directly or through Python, but not both at the same time.  The right fix is to allow HyperonPy to be built within Hyperon, See https://github.com/trueagi-io/hyperon-experimental/issues/283
-itertools = "0.13.0"
 
 [[bin]]
 name = "metta-repl"

--- a/repl/src/metta_shim.rs
+++ b/repl/src/metta_shim.rs
@@ -38,6 +38,7 @@ pub mod metta_interface_mod {
     use pyo3::prelude::*;
     use pyo3::types::{PyTuple, PyString, PyBool, PyList, PyDict};
     use super::{strip_quotes, exec_state_prepare, exec_state_should_break};
+    use itertools::Itertools;
 
     /// Load the hyperon module, and get the "__version__" attribute
     pub fn get_hyperonpy_version() -> Result<String, String> {
@@ -166,7 +167,7 @@ pub mod metta_interface_mod {
             Python::with_gil(|py| -> PyResult<()> {
                 for result_vec in self.result.iter() {
                     let result_vec: Vec<&PyAny> = result_vec.iter().map(|atom| atom.as_ref(py)).collect();
-                    println!("{result_vec:?}");
+                    println!("[{}]", result_vec.iter().format(", "));
                 }
                 Ok(())
             }).unwrap()
@@ -319,6 +320,7 @@ pub mod metta_interface_mod {
     use hyperon::Atom;
     use hyperon::metta::runner::{Metta, RunnerState, Environment, EnvBuilder};
     use super::{strip_quotes, exec_state_prepare, exec_state_should_break};
+    use itertools::Itertools;
 
     pub use hyperon::metta::text::SyntaxNodeType as SyntaxNodeType;
 
@@ -418,7 +420,7 @@ pub mod metta_interface_mod {
 
         pub fn print_result(&self) {
             for result in self.result.iter() {
-                println!("{result:?}");
+                println!("[{}]", result.iter().format(", "));
             }
         }
 

--- a/repl/src/metta_shim.rs
+++ b/repl/src/metta_shim.rs
@@ -37,8 +37,8 @@ pub mod metta_interface_mod {
     use pep440_rs::{parse_version_specifiers, Version};
     use pyo3::prelude::*;
     use pyo3::types::{PyTuple, PyString, PyBool, PyList, PyDict};
+    use hyperon::common::collections::VecDisplay;
     use super::{strip_quotes, exec_state_prepare, exec_state_should_break};
-    use itertools::Itertools;
 
     /// Load the hyperon module, and get the "__version__" attribute
     pub fn get_hyperonpy_version() -> Result<String, String> {
@@ -167,7 +167,7 @@ pub mod metta_interface_mod {
             Python::with_gil(|py| -> PyResult<()> {
                 for result_vec in self.result.iter() {
                     let result_vec: Vec<&PyAny> = result_vec.iter().map(|atom| atom.as_ref(py)).collect();
-                    println!("[{}]", result_vec.iter().format(", "));
+                    println!("{}", VecDisplay(&result_vec));
                 }
                 Ok(())
             }).unwrap()
@@ -319,8 +319,8 @@ pub mod metta_interface_mod {
     use hyperon::ExpressionAtom;
     use hyperon::Atom;
     use hyperon::metta::runner::{Metta, RunnerState, Environment, EnvBuilder};
+    use hyperon::common::collections::VecDisplay;
     use super::{strip_quotes, exec_state_prepare, exec_state_should_break};
-    use itertools::Itertools;
 
     pub use hyperon::metta::text::SyntaxNodeType as SyntaxNodeType;
 
@@ -420,7 +420,7 @@ pub mod metta_interface_mod {
 
         pub fn print_result(&self) {
             for result in self.result.iter() {
-                println!("[{}]", result.iter().format(", "));
+                println!("{}", VecDisplay(result));
             }
         }
 


### PR DESCRIPTION
Use `Display` to show atoms in REPL and logs. Use `Debug` in unit test implementations.
@DaddyWesker FYI