### PR TITLE
Improve handling of inline comments

### DIFF
--- a/lib/src/metta/text.rs
+++ b/lib/src/metta/text.rs
@@ -491,7 +491,7 @@ impl<'a> SExprParser<'a> {
         let start_idx = self.cur_idx();
 
         while let Some((_idx, c)) = self.it.peek() {
-            if c.is_whitespace() || *c == '(' || *c == ')' {
+            if c.is_whitespace() || *c == '(' || *c == ')' || *c == ';' {
                 break;
             }
             token.push(*c);

--- a/python/tests/test_run_metta.py
+++ b/python/tests/test_run_metta.py
@@ -60,6 +60,15 @@ class MeTTaTest(HyperonTestCase):
         self.assertEqual('[[5]]', repr(result))
 
         program = '''
+                (a; 4)
+                  5)
+                !(match &self (a $W) $W)
+            '''
+
+        result = MeTTa(env_builder=Environment.test_env()).run(program)
+        self.assertEqual('[[5]]', repr(result))
+
+        program = '''
                (a  1);
                !(match
                         &self (a $W) $W)


### PR DESCRIPTION
Break the word parsing loop when encountering a semicolon. This change disallows semicolons in symbols.
Additional test cases have been added to validate this behavior.