### PR TITLE
Fix evaluate atom

### DIFF
--- a/lib/src/space/module.rs
+++ b/lib/src/space/module.rs
@@ -9,13 +9,13 @@ pub struct ModuleSpace {
 
 impl Display for ModuleSpace {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        Display::fmt(&self.main, f)
+        write!(f, "ModuleSpace({})", &self.main)
     }
 }
 
 impl Debug for ModuleSpace {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        Debug::fmt(&self.main, f)
+        write!(f, "ModuleSpace({:?})", &self.main)
     }
 }
 
@@ -25,6 +25,7 @@ impl ModuleSpace {
     }
 
     pub fn query(&self, query: &Atom) -> BindingsSet {
+        log::debug!("ModuleSpace::query: {}", query);
         let mut results = self.main.query(query);
         for dep in &self.deps {
             if let Some(space) = dep.borrow().as_any() {
@@ -41,6 +42,7 @@ impl ModuleSpace {
     }
 
     fn query_no_deps(&self, query: &Atom) -> BindingsSet {
+        log::debug!("ModuleSpace::query_no_deps: {}", query);
         self.main.query(query)
     }
 

--- a/python/tests/test_metta.py
+++ b/python/tests/test_metta.py
@@ -98,3 +98,15 @@ class MettaTest(unittest.TestCase):
 
         self.assertEqual([[]], result)
 
+    def test_metta_evaluate_atom_using_stdlib(self):
+        program = '''
+            (= (f) (let ($x $y) (A B) $x))
+        '''
+        runner = MeTTa(env_builder=Environment.test_env())
+        runner.run(program)
+
+        result = runner.run('!(f)')
+        self.assertEqual([[S('A')]], result)
+
+        result = runner.evaluate_atom(E(S('f')))
+        self.assertEqual([S('A')], result)


### PR DESCRIPTION
Fix #834. Root cause is that top module space is different from space which is passed to the `Metta` constructor. Module space additionally wrapped by `ModuleSpace` which contains dependencies and know how to work with them. `evaluate_atom` used original space instead of modules space it is why it cannot use dependencies. Fix is to get top module space instead.