### PR TITLE
Fix repr unit test in Python to check escaping

### DIFF
--- a/python/tests/test_grounded_type.py
+++ b/python/tests/test_grounded_type.py
@@ -46,7 +46,8 @@ class GroundedTypeTest(unittest.TestCase):
 
     def test_string_repr(self):
         metta = MeTTa(env_builder=Environment.test_env())
-        self.assertEqual(metta.run('!(repr "A")')[0][0].get_object(), ValueObject("\"A\""))
+        self.assertEqual(metta.run('!(repr "A\n\tBB\x1b\u130A9")')[0][0].get_object(),
+                         ValueObject("\"A\\n\\tBB\\x1b\u130A9\""))
 
     def test_meta_types(self):
         metta = MeTTa(env_builder=Environment.test_env())


### PR DESCRIPTION
See https://github.com/trueagi-io/hyperon-experimental/issues/841#issuecomment-2624320069