### PR TITLE
Downgrade urllib3 library to be compatible with cibuildwheel environment

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -7,28 +7,28 @@ Python packages are released using
 it. Usually it means setup docker and install the package from PyPi (see [setup
 instructions](https://cibuildwheel.pypa.io/en/stable/setup/#local)).
 
-There are additional preparations to be made before running it. First of all
-`libhyperonc` library should be built and installed in a build environment. By
-default library downloads and install version from the `main` branch of the
-`trueagi-io/hyperon-experimental` repository. If one need to use the custom
-branch then it is done by passing custom parameters to the
-`install-hyperonc.sh` script which is called using
+There are additional preparations to be made. First of all it is needed to
+allow building and installing `libhyperonc` library on a build environment.
+`cibuildwheel` uses isolated docker container for each kind of platform it
+supports. Only code of the Python package is copied into container
+automatically. Code of the `libhyperonc` library should be downloaded from
+outside. It means one need to have the code in some repo accessible from the
+container before starting release. The simplest way is to push the changes in
+your GitHub repo fork.
+
+By default library downloads and installs version from the `main` branch of the
+`trueagi-io/hyperon-experimental` repository. Using a custom branch is done by
+passing custom parameters to the `install-hyperonc.sh` script through
 [CIBW_BEFORE_ALL](https://cibuildwheel.pypa.io/en/stable/options/#before-all)
 environment variable:
 ```
 export CIBW_BEFORE_ALL='sh -c "./python/install-hyperonc.sh -u <git-repo-url> -r <git-branch>"'
 ```
-
 One should replace `<git-repo-url>` and `<git-branch>` by the repo URL and
-branch which are used in release. It is required because `cibuildwheel` uses
-isolated docker container for each kind of platform it supports. Only code of
-the Python package is copied into container automatically. Code of the
-`libhyperonc` library should be downloaded from outside. It means one need to
-have the code in some repo accessible from the container before starting
-release. The simplest way is to push the changes in your GitHub repo fork.
+branch which are used in release.
 
-Also one can start from building the only platform to quickly check whether
-release works. This can be done using
+Also it is possible to start from building the only platform to quickly check
+whether release works. This can be done using
 [CIBW_BUILD](https://cibuildwheel.pypa.io/en/stable/options/#build-skip)
 variable:
 ```
@@ -36,7 +36,7 @@ export CIBW_BUILD=cp37-manylinux_x86_64
 ```
 
 After exporting the variables above one can start release by executing
-`cibuildwheel` from the `./python` directory of the repo. See [cibuildwheel
+`cibuildwheel ./python` from the root directory of the repo. See [cibuildwheel
 documentation](https://cibuildwheel.pypa.io/en/stable/) for details.
 
 ## How to update the version

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,7 +1,8 @@
 [build-system]
 # setuptools >68.0.0 is incompatible with macos-13
 # setuptools_scm >7.1.0 is incompatible with Python 3.7
-requires = ["setuptools==68.0.0", "conan==2.13.0", "cmake==3.24", "setuptools_scm[toml]==7.1.0"]
+# urllib3 >=2.0.0 is incompatible with OpenSSL <1.1.1+ which is used by cp37-manylinux_x86_64 wheel
+requires = ["setuptools==68.0.0", "conan==2.13.0", "urllib3==1.26.20", "cmake==3.24", "setuptools_scm[toml]==7.1.0"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
After Conan upgrade to 2.13.0 the latest urllib3 library version which is used became 2.0.0+. It is incompatible with OpenSSL <1.1.1+ which is used by cibuildwheel manylinux environment. This commit freezes urllib3 version to 1.26.20 which is compatible with both Conan 2.13.0 and OpenSSL <1.1.1+.