### PR TITLE
changes to git_catalog_direct_test

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -79,6 +79,10 @@ jobs:
         shell: bash
         run: RUST_LOG=hyperon=debug cargo test
 
+      - name: Test Rust build with online feature
+        shell: bash
+        run: RUST_LOG=hyperon=debug cargo test --features "git online-test"
+
       - name: Print environment
         shell: bash
         run: |

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -39,5 +39,6 @@ default = ["pkg_mgmt"]
 # See https://doc.rust-lang.org/cargo/reference/features.html#the-features-section
 variable_operation = [] # enables evaluation of the expressions which have
                         # a variable on the first position
+online-test = []
 git = ["git2", "pkg_mgmt"]
 pkg_mgmt = ["xxhash-rust", "serde", "serde_json", "semver"]

--- a/lib/src/metta/runner/pkg_mgmt/git_catalog.rs
+++ b/lib/src/metta/runner/pkg_mgmt/git_catalog.rs
@@ -351,14 +351,14 @@ impl ModuleLoader for GitModLoader {
 /// This test is similar to `git_remote_catalog_fetch_test` in [crate::metta::runner::pkg_mgmt::catalog],
 /// but tests the `GitCatalog` without a `LocalCatalog` and also loads a local catalog so
 /// the test can run without a network connection.
-#[ignore] //NOTE: Ignored until we settle on how and where to commit the test repo(s)
+
 #[test]
+#[cfg(feature="online-test")]
 fn git_catalog_direct_test() {
-    let _ = env_logger::builder().is_test(true).try_init();
-    let gitcat = GitCatalog::new(&std::env::temp_dir(), EnvBuilder::test_env().build().fs_mod_formats, "git_catalog", "file:///Users/admin/rustProjects/local-metta-catalog/",0).unwrap();
+    let gitcat = GitCatalog::new(&std::env::temp_dir(), EnvBuilder::test_env().build().fs_mod_formats, "metta-catalog", "https://github.com/trueagi-io/metta-catalog/",0).unwrap();
     let runner = Metta::new(Some(EnvBuilder::test_env().push_module_catalog(gitcat).set_caches_dir(&std::env::temp_dir().join("hyperon-test"))));
 
-    let result = runner.run(SExprParser::new("!(import! &self factorial)"));
+    let result = runner.run(SExprParser::new("!(import! &self example)"));
     assert_eq!(result, Ok(vec![vec![expr!()]]));
 
     runner.display_loaded_modules();
@@ -366,3 +366,4 @@ fn git_catalog_direct_test() {
     let result = runner.run(SExprParser::new("!(fact 5)"));
     assert_eq!(result, Ok(vec![vec![expr!({crate::metta::runner::number::Number::Integer(120)})]]));
 }
+


### PR DESCRIPTION
So, I've changed a bit git_catalog_direct_test as Vitaly asked. Currently it is not working till [this PR](https://github.com/trueagi-io/metta-catalog/pull/1) is in work .
