### PR TITLE
Adding support for the `local_path` key in the catalog.json file, whe…

### DIFF
--- a/lib/src/metta/runner/pkg_mgmt/catalog.rs
+++ b/lib/src/metta/runner/pkg_mgmt/catalog.rs
@@ -860,6 +860,7 @@ mod tests {
                     git_branch: None, //Some("Hyperpose".to_string()),
                     git_subdir: None,
                     git_main_file: Some(PathBuf::from("mettamorph.metta")),
+                    local_path: None,
                 },
                 version_req: None,
             });


### PR DESCRIPTION
…n it's more convenient to bundle modules into the same repo with the catalog that references them.