### PR TITLE
Add add-reducts

### DIFF
--- a/lib/src/metta/runner/stdlib/atom.rs
+++ b/lib/src/metta/runner/stdlib/atom.rs
@@ -548,7 +548,23 @@ mod tests {
         assert_eq!(run_program("!(eval (foldl-atom (1 2 3) 0 $a $b (eval (+ $a $b))))"), Ok(vec![vec![expr!({Number::Integer(6)})]]));
     }
 
+    #[test]
+    fn metta_add_reducts() {
+        assert_eq!(run_program(&format!("!(chain (eval (new-space)) $newspace (add-reducts key1))")), Ok(vec![vec![expr!("Error" ("add-reducts" "key1") "IncorrectNumberOfArguments")]]));
 
+        assert_eq!(run_program(&format!("!(chain (eval (new-space)) $newspace
+                                                 (assertEqual
+                                                     (add-reducts $newspace ((key1 value1) (key2 value2) (key3 value3)))
+                                                     ()))")),
+                   Ok(vec![vec![UNIT_ATOM]]));
+
+        assert_eq!(run_program(&format!("!(chain (eval (new-space)) $newspace
+                                                    (let $f (add-reducts $newspace ((k1 v1) (k2 v2) (k3 v3)))
+                                                        (assertEqual
+                                                            (match $newspace (k1 $v) $v)
+                                                            v1)))")),
+                   Ok(vec![vec![UNIT_ATOM]]));
+    }
 
     #[test]
     fn size_atom_op() {

--- a/lib/src/metta/runner/stdlib/atom.rs
+++ b/lib/src/metta/runner/stdlib/atom.rs
@@ -550,11 +550,11 @@ mod tests {
 
     #[test]
     fn metta_add_reducts() {
-        assert_eq!(run_program(&format!("!(chain (eval (new-space)) $newspace (add-reducts key1))")), Ok(vec![vec![expr!("Error" ("add-reducts" "key1") "IncorrectNumberOfArguments")]]));
+        assert_eq!(run_program(&format!("!(chain (eval (new-space)) $newspace (add-reducts k1))")), Ok(vec![vec![expr!("Error" ("add-reducts" "k1") "IncorrectNumberOfArguments")]]));
 
         assert_eq!(run_program(&format!("!(chain (eval (new-space)) $newspace
                                                  (assertEqual
-                                                     (add-reducts $newspace ((key1 value1) (key2 value2) (key3 value3)))
+                                                     (add-reducts $newspace ((k1 v1) (k2 v2) (k3 v3)))
                                                      ()))")),
                    Ok(vec![vec![UNIT_ATOM]]));
 
@@ -563,6 +563,44 @@ mod tests {
                                                         (assertEqual
                                                             (match $newspace (k1 $v) $v)
                                                             v1)))")),
+                   Ok(vec![vec![UNIT_ATOM]]));
+
+        assert_eq!(run_program(&format!("(= (pair1) (k1 v1))
+                                                 (= (pair2) (k2 v2))
+                                                 (= (pair3) (k3 v3))
+                                                 !(chain (eval (new-space)) $newspace
+                                                    (let $f (add-reducts $newspace ((pair1) (pair2) (pair3)))
+                                                        (assertEqual
+                                                            (match $newspace (k1 $v) $v)
+                                                            v1)))")),
+                   Ok(vec![vec![UNIT_ATOM]]));
+    }
+
+    #[test]
+    fn metta_add_atoms() {
+        assert_eq!(run_program(&format!("!(chain (eval (new-space)) $newspace (add-atoms k1))")), Ok(vec![vec![expr!("Error" ("add-atoms" "k1") "IncorrectNumberOfArguments")]]));
+
+        assert_eq!(run_program(&format!("!(chain (eval (new-space)) $newspace
+                                                 (assertEqual
+                                                     (add-atoms $newspace ((k1 v1) (k2 v2) (k3 v3)))
+                                                     ()))")),
+                   Ok(vec![vec![UNIT_ATOM]]));
+
+        assert_eq!(run_program(&format!("!(chain (eval (new-space)) $newspace
+                                                    (let $f (add-atoms $newspace ((k1 v1) (k2 v2) (k3 v3)))
+                                                        (assertEqual
+                                                            (match $newspace (k1 $v) $v)
+                                                            v1)))")),
+                   Ok(vec![vec![UNIT_ATOM]]));
+
+        assert_eq!(run_program(&format!("(= (pair1) (k1 v1))
+                                                 (= (pair2) (k2 v2))
+                                                 (= (pair3) (k3 v3))
+                                                 !(chain (eval (new-space)) $newspace
+                                                    (let $f (add-atoms $newspace ((pair1) (pair2) (pair3)))
+                                                        (assertEqual
+                                                            (match $newspace (k1 $v) $v)
+                                                            (empty))))")),
                    Ok(vec![vec![UNIT_ATOM]]));
     }
 

--- a/lib/src/metta/runner/stdlib/atom.rs
+++ b/lib/src/metta/runner/stdlib/atom.rs
@@ -549,62 +549,6 @@ mod tests {
     }
 
     #[test]
-    fn metta_add_reducts() {
-        assert_eq!(run_program(&format!("!(chain (eval (new-space)) $newspace (add-reducts k1))")), Ok(vec![vec![expr!("Error" ("add-reducts" "k1") "IncorrectNumberOfArguments")]]));
-
-        assert_eq!(run_program(&format!("!(chain (eval (new-space)) $newspace
-                                                 (assertEqual
-                                                     (add-reducts $newspace ((k1 v1) (k2 v2) (k3 v3)))
-                                                     ()))")),
-                   Ok(vec![vec![UNIT_ATOM]]));
-
-        assert_eq!(run_program(&format!("!(chain (eval (new-space)) $newspace
-                                                    (let $f (add-reducts $newspace ((k1 v1) (k2 v2) (k3 v3)))
-                                                        (assertEqual
-                                                            (match $newspace (k1 $v) $v)
-                                                            v1)))")),
-                   Ok(vec![vec![UNIT_ATOM]]));
-
-        assert_eq!(run_program(&format!("(= (pair1) (k1 v1))
-                                                 (= (pair2) (k2 v2))
-                                                 (= (pair3) (k3 v3))
-                                                 !(chain (eval (new-space)) $newspace
-                                                    (let $f (add-reducts $newspace ((pair1) (pair2) (pair3)))
-                                                        (assertEqual
-                                                            (match $newspace (k1 $v) $v)
-                                                            v1)))")),
-                   Ok(vec![vec![UNIT_ATOM]]));
-    }
-
-    #[test]
-    fn metta_add_atoms() {
-        assert_eq!(run_program(&format!("!(chain (eval (new-space)) $newspace (add-atoms k1))")), Ok(vec![vec![expr!("Error" ("add-atoms" "k1") "IncorrectNumberOfArguments")]]));
-
-        assert_eq!(run_program(&format!("!(chain (eval (new-space)) $newspace
-                                                 (assertEqual
-                                                     (add-atoms $newspace ((k1 v1) (k2 v2) (k3 v3)))
-                                                     ()))")),
-                   Ok(vec![vec![UNIT_ATOM]]));
-
-        assert_eq!(run_program(&format!("!(chain (eval (new-space)) $newspace
-                                                    (let $f (add-atoms $newspace ((k1 v1) (k2 v2) (k3 v3)))
-                                                        (assertEqual
-                                                            (match $newspace (k1 $v) $v)
-                                                            v1)))")),
-                   Ok(vec![vec![UNIT_ATOM]]));
-
-        assert_eq!(run_program(&format!("(= (pair1) (k1 v1))
-                                                 (= (pair2) (k2 v2))
-                                                 (= (pair3) (k3 v3))
-                                                 !(chain (eval (new-space)) $newspace
-                                                    (let $f (add-atoms $newspace ((pair1) (pair2) (pair3)))
-                                                        (assertEqual
-                                                            (match $newspace (k1 $v) $v)
-                                                            (empty))))")),
-                   Ok(vec![vec![UNIT_ATOM]]));
-    }
-
-    #[test]
     fn size_atom_op() {
         let res = SizeAtomOp{}.execute(&mut vec![expr!({Number::Integer(5)} {Number::Integer(4)} {Number::Integer(3)} {Number::Integer(2)} {Number::Integer(1)})]).expect("No result returned");
         assert_eq!(res, vec![expr!({Number::Integer(5)})]);

--- a/lib/src/metta/runner/stdlib/mod.rs
+++ b/lib/src/metta/runner/stdlib/mod.rs
@@ -335,6 +335,61 @@ mod tests {
         assert_eq!(run_program(&format!("{header} !(unquote (bar (quote (foo))))")), Ok(vec![vec![expr!("A")]]), "unquote after call");
     }
 
+    #[test]
+    fn metta_add_reducts() {
+        assert_eq!(run_program(&format!("!(let $newspace (new-space) (add-reducts k1))")), Ok(vec![vec![expr!("Error" ("add-reducts" "k1") "IncorrectNumberOfArguments")]]));
+
+        assert_eq!(run_program(&format!("!(let $newspace (new-space)
+                                                 (assertEqual
+                                                     (add-reducts $newspace ((k1 v1) (k2 v2) (k3 v3)))
+                                                     ()))")),
+                   Ok(vec![vec![UNIT_ATOM]]));
+
+        assert_eq!(run_program(&format!("!(let $newspace (new-space)
+                                                    (let $f (add-reducts $newspace ((k1 v1) (k2 v2) (k3 v3)))
+                                                        (assertEqual
+                                                            (match $newspace (k1 $v) $v)
+                                                            v1)))")),
+                   Ok(vec![vec![UNIT_ATOM]]));
+
+        assert_eq!(run_program(&format!("(= (pair1) (k1 v1))
+                                                 (= (pair2) (k2 v2))
+                                                 (= (pair3) (k3 v3))
+                                                 !(let $newspace (new-space)
+                                                    (let $f (add-reducts $newspace ((pair1) (pair2) (pair3)))
+                                                        (assertEqual
+                                                            (match $newspace (k1 $v) $v)
+                                                            v1)))")),
+                   Ok(vec![vec![UNIT_ATOM]]));
+    }
+
+    #[test]
+    fn metta_add_atoms() {
+        assert_eq!(run_program(&format!("!(let $newspace (new-space) (add-atoms k1))")), Ok(vec![vec![expr!("Error" ("add-atoms" "k1") "IncorrectNumberOfArguments")]]));
+
+        assert_eq!(run_program(&format!("!(let $newspace (new-space)
+                                                 (assertEqual
+                                                     (add-atoms $newspace ((k1 v1) (k2 v2) (k3 v3)))
+                                                     ()))")),
+                   Ok(vec![vec![UNIT_ATOM]]));
+
+        assert_eq!(run_program(&format!("!(let $newspace (new-space)
+                                                    (let $f (add-atoms $newspace ((k1 v1) (k2 v2) (k3 v3)))
+                                                        (assertEqual
+                                                            (match $newspace (k1 $v) $v)
+                                                            v1)))")),
+                   Ok(vec![vec![UNIT_ATOM]]));
+
+        assert_eq!(run_program(&format!("(= (pair1) (k1 v1))
+                                                 (= (pair2) (k2 v2))
+                                                 (= (pair3) (k3 v3))
+                                                 !(let $newspace (new-space)
+                                                    (let $f (add-atoms $newspace ((pair1) (pair2) (pair3)))
+                                                        (assertEqual
+                                                            (match $newspace (k1 $v) $v)
+                                                            (empty))))")),
+                   Ok(vec![vec![UNIT_ATOM]]));
+    }
 
     #[test]
     fn test_frog_reasoning() {

--- a/lib/src/metta/runner/stdlib/stdlib.metta
+++ b/lib/src/metta/runner/stdlib/stdlib.metta
@@ -668,20 +668,20 @@
      (let $u (subtraction-atom $c1 $c2) (superpose $u)))))
 
 (@doc add-reducts
-  (@desc "Function takes space and expression which contains key-value pairs, reduces them and adds result into given space")
+  (@desc "Function takes space and expression, evaluates atoms in it and adds them into given space")
   (@params (
     (@param "Space")
-    (@param "Key-value pairs in form of expression")))
+    (@param "Expression")))
   (@return "Unit atom"))
 (: add-reducts (-> Grounded %Undefined% (->)))
 (= (add-reducts $space $tuple)
     (foldl-atom $tuple () $a $b (eval (add-atom $space $b))))
 
 (@doc add-atoms
-  (@desc "Function takes space and expression which contains key-value pairs and adds them into given space. No reducing")
+  (@desc "Function takes space and expression and adds atoms in Expression into given space without reducing them")
   (@params (
     (@param "Space")
-    (@param "Key-value pairs in form of expression")))
+    (@param "Expression")))
   (@return "Unit atom"))
 (: add-atoms (-> Grounded Expression (->)))
 (= (add-atoms $space $tuple)

--- a/lib/src/metta/runner/stdlib/stdlib.metta
+++ b/lib/src/metta/runner/stdlib/stdlib.metta
@@ -667,6 +667,16 @@
    (let $c1 (collapse $arg1) (let $c2 (collapse $arg2)
      (let $u (subtraction-atom $c1 $c2) (superpose $u)))))
 
+(@doc add-reducts
+  (@desc "Function takes space and expression which contains key-value pairs and adds them into given space")
+  (@params (
+    (@param "Space")
+    (@param "Key-value pairs in form of expression")))
+  (@return "Unit atom"))
+(: add-reducts (-> Grounded %Undefined% (->)))
+(= (add-reducts $space $tuple)
+    (foldl-atom $tuple () $a $b (eval (add-atom $space $b))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Documentation formatting functions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/lib/src/metta/runner/stdlib/stdlib.metta
+++ b/lib/src/metta/runner/stdlib/stdlib.metta
@@ -668,13 +668,23 @@
      (let $u (subtraction-atom $c1 $c2) (superpose $u)))))
 
 (@doc add-reducts
-  (@desc "Function takes space and expression which contains key-value pairs and adds them into given space")
+  (@desc "Function takes space and expression which contains key-value pairs, reduces them and adds result into given space")
   (@params (
     (@param "Space")
     (@param "Key-value pairs in form of expression")))
   (@return "Unit atom"))
 (: add-reducts (-> Grounded %Undefined% (->)))
 (= (add-reducts $space $tuple)
+    (foldl-atom $tuple () $a $b (eval (add-atom $space $b))))
+
+(@doc add-atoms
+  (@desc "Function takes space and expression which contains key-value pairs and adds them into given space. No reducing")
+  (@params (
+    (@param "Space")
+    (@param "Key-value pairs in form of expression")))
+  (@return "Unit atom"))
+(: add-atoms (-> Grounded Expression (->)))
+(= (add-atoms $space $tuple)
     (foldl-atom $tuple () $a $b (eval (add-atom $space $b))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
So, new pr. I've added add-reducts function after discussing with @Necr0x0Der which uses foldl-atom in it's core. Usage:

```
!(bind! &newspace (new-space))

!(add-reducts &newspace ((k1 v1) (k2 v2) (k3 v3)))

!(assertEqual
    (match &newspace (k1 $v) $v)
    v1)
```

I've also added doc and tests (@vsbogd please check if tests are in right place, I'm not sure). 

Strange thing I've noticed when I was writing tests. This one works:
```
!(chain (eval (new-space)) $newspace
      (let $f (add-reducts $newspace ((k1 v1) (k2 v2) (k3 v3)))
          (assertEqual
              (match $newspace (k1 $v) $v)
              v1)))
```

This one - not:
```
!(chain (eval (new-space)) $newspace
    (chain (eval (add-reducts $newspace ((k1 v1) (k2 v2) (k3 v3)))) $f
        (assertEqual
            (match $newspace (k1 $v) $v)
            v1)))
```

I can't quite understand why...