### PR TITLE
Limit recursion depth

### DIFF
--- a/lib/src/atom/mod.rs
+++ b/lib/src/atom/mod.rs
@@ -784,7 +784,7 @@ impl Clone for Box<dyn GroundedAtom> {
 
 /// Atoms are main components of the atomspace. There are four meta-types of
 /// atoms: symbol, expression, variable and grounded.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub enum Atom {
     /// Symbol represents some idea or concept. Two symbols having
     /// the same name are considered equal and representing the same concept.
@@ -1079,6 +1079,17 @@ impl Display for Atom {
             Atom::Expression(expr) => Display::fmt(expr, f),
             Atom::Variable(var) => Display::fmt(var, f),
             Atom::Grounded(gnd) => Display::fmt(gnd, f),
+        }
+    }
+}
+
+impl Debug for Atom {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Atom::Symbol(sym) => Display::fmt(sym, f),
+            Atom::Expression(expr) => Display::fmt(expr, f),
+            Atom::Variable(var) => Display::fmt(var, f),
+            Atom::Grounded(gnd) => write!(f, "{{{}}}", gnd),
         }
     }
 }

--- a/lib/src/metta/mod.rs
+++ b/lib/src/metta/mod.rs
@@ -24,7 +24,7 @@ pub const ERROR_SYMBOL : Atom = sym!("Error");
 pub const BAD_TYPE_SYMBOL : Atom = sym!("BadType");
 pub const INCORRECT_NUMBER_OF_ARGUMENTS_SYMBOL : Atom = sym!("IncorrectNumberOfArguments");
 pub const NOT_REDUCIBLE_SYMBOL : Atom = sym!("NotReducible");
-pub const NO_VALID_ALTERNATIVES : Atom = sym!("NoValidAlternatives");
+pub const STACK_OVERFLOW_SYMBOL : Atom = sym!("StackOverflow");
 
 pub const EMPTY_SYMBOL : Atom = sym!("Empty");
 
@@ -70,7 +70,7 @@ pub fn atom_is_error(atom: &Atom) -> bool {
 
 /// Returns a message string from an error expression
 ///
-/// NOTE: this function will panic if the suppoed atom is not a valid error expression
+/// NOTE: this function will panic if the supported atom is not a valid error expression
 pub fn atom_error_message(atom: &Atom) -> &str {
     const PANIC_STR: &str = "Atom is not error expression";
     match atom {

--- a/lib/src/metta/runner/mod.rs
+++ b/lib/src/metta/runner/mod.rs
@@ -1095,6 +1095,10 @@ impl<'input> RunContext<'_, 'input> {
                                     wrap_atom_by_metta_interpreter(self.module().space().clone(), atom)
                                 };
                                 self.i_wrapper.interpreter_state = Some(interpret_init(self.module().space().clone(), &atom));
+                                if let Some(depth) = self.metta.settings().get_string("max-stack-depth") {
+                                    let depth = depth.parse::<usize>().unwrap();
+                                    self.i_wrapper.interpreter_state.as_mut().map(|state| state.set_max_stack_depth(depth));
+                                }
                             }
                         },
                         MettaRunnerMode::TERMINATE => {

--- a/lib/src/metta/runner/mod.rs
+++ b/lib/src/metta/runner/mod.rs
@@ -114,6 +114,27 @@ impl PartialEq for Metta {
     }
 }
 
+#[derive(Clone, Debug)]
+pub struct PragmaSettings(Shared<HashMap<String, Atom>>);
+
+impl PragmaSettings {
+    pub fn new() -> Self {
+        Self(Shared::new(HashMap::new()))
+    }
+
+    pub fn set(&self, key: String, value: Atom) {
+        self.0.borrow_mut().insert(key, value);
+    }
+
+    pub fn get(&self, key: &str) -> Option<Atom> {
+        self.0.borrow().get(key).cloned()
+    }
+
+    pub fn get_string(&self, key: &str) -> Option<String> {
+        self.0.borrow().get(key).map(|a| a.to_string())
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct MettaContents {
     /// All the runner's loaded modules
@@ -136,7 +157,7 @@ pub(crate) struct MettaContents {
     /// The ModId of the extended stdlib to import into some modules loaded into the runner
     stdlib_mod: OnceLock<ModId>,
     /// The runner's pragmas, affecting runner-wide behavior
-    settings: Shared<HashMap<String, Atom>>,
+    settings: PragmaSettings,
     /// The runner's Environment
     environment: Arc<Environment>,
     //TODO-HACK: This is a terrible horrible ugly hack that should not be merged.  Delete this field
@@ -225,7 +246,7 @@ impl Metta {
             Some(space) => space,
             None => DynSpace::new(GroundingSpace::new())
         };
-        let settings = Shared::new(HashMap::new());
+        let settings = PragmaSettings::new();
         let environment = match env_builder {
             Some(env_builder) => Arc::new(env_builder.build()),
             None => Environment::common_env_arc()
@@ -428,20 +449,12 @@ impl Metta {
         &self.0.top_mod_tokenizer
     }
 
-    pub fn settings(&self) -> &Shared<HashMap<String, Atom>> {
+    pub fn settings(&self) -> &PragmaSettings {
         &self.0.settings
     }
 
-    pub fn set_setting(&self, key: String, value: Atom) {
-        self.0.settings.borrow_mut().insert(key, value);
-    }
-
-    pub fn get_setting(&self, key: &str) -> Option<Atom> {
-        self.0.settings.borrow().get(key).cloned()
-    }
-
     pub fn get_setting_string(&self, key: &str) -> Option<String> {
-        self.0.settings.borrow().get(key).map(|a| a.to_string())
+        self.0.settings.get(key).map(|a| a.to_string())
     }
 
     pub fn run(&self, parser: impl Parser) -> Result<Vec<Vec<Atom>>, String> {
@@ -469,7 +482,7 @@ impl Metta {
     }
 
     fn type_check_is_enabled(&self) -> bool {
-        self.get_setting_string("type-check").map_or(false, |val| val == "auto")
+        self.settings().get_string("type-check").map_or(false, |val| val == "auto")
     }
 
 }
@@ -1102,7 +1115,7 @@ impl<'input> RunContext<'_, 'input> {
 }
 
 fn is_bare_minimal_interpreter(metta: &Metta) -> bool {
-    metta.get_setting_string("interpreter") == Some("bare-minimal".into())
+    metta.settings().get_string("interpreter") == Some("bare-minimal".into())
 }
 
 // *-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*
@@ -1235,7 +1248,7 @@ mod tests {
         ";
 
         let metta = Metta::new_core(None, Some(EnvBuilder::test_env()));
-        metta.set_setting("type-check".into(), sym!("auto"));
+        metta.settings().set("type-check".into(), sym!("auto"));
         let result = metta.run(SExprParser::new(program));
         assert_eq!(result, Ok(vec![vec![expr!("Error" ("foo" "b") "BadType")]]));
     }
@@ -1249,7 +1262,7 @@ mod tests {
         ";
 
         let metta = Metta::new_core(None, Some(EnvBuilder::test_env()));
-        metta.set_setting("type-check".into(), sym!("auto"));
+        metta.settings().set("type-check".into(), sym!("auto"));
         let result = metta.run(SExprParser::new(program));
         assert_eq!(result, Ok(vec![vec![expr!("Error" ("foo" "b") "BadType")]]));
     }
@@ -1301,7 +1314,7 @@ mod tests {
         ";
 
         let metta = Metta::new_core(None, Some(EnvBuilder::test_env()));
-        metta.set_setting("type-check".into(), sym!("auto"));
+        metta.settings().set("type-check".into(), sym!("auto"));
         let result = metta.run(SExprParser::new(program));
         assert_eq!(result, Ok(vec![vec![expr!("Error" ("foo" "b") "BadType")]]));
     }

--- a/lib/src/metta/runner/stdlib/core.rs
+++ b/lib/src/metta/runner/stdlib/core.rs
@@ -2,25 +2,24 @@ use crate::*;
 use crate::space::*;
 use crate::metta::*;
 use crate::metta::text::Tokenizer;
-use crate::common::shared::Shared;
 use crate::common::CachingMapper;
 use crate::metta::runner::Metta;
+use crate::metta::runner::PragmaSettings;
 use crate::metta::runner::bool::*;
 
 use std::convert::TryInto;
-use std::collections::HashMap;
 
 use super::{interpret_no_error, grounded_op, unit_result, regex, interpret};
 
 #[derive(Clone, Debug)]
 pub struct PragmaOp {
-    settings: Shared<HashMap<String, Atom>>,
+    settings: PragmaSettings,
 }
 
 grounded_op!(PragmaOp, "pragma!");
 
 impl PragmaOp {
-    pub fn new(settings: Shared<HashMap<String, Atom>>) -> Self {
+    pub fn new(settings: PragmaSettings) -> Self {
         Self{ settings }
     }
 }
@@ -40,7 +39,7 @@ impl CustomExecute for PragmaOp {
         let arg_error = || ExecError::from("pragma! expects key and value as arguments");
         let key = <&SymbolAtom>::try_from(args.get(0).ok_or_else(arg_error)?).map_err(|_| "pragma! expects symbol atom as a key")?.name();
         let value = args.get(1).ok_or_else(arg_error)?;
-        self.settings.borrow_mut().insert(key.into(), value.clone());
+        self.settings.set(key.into(), value.clone());
         unit_result()
     }
 }
@@ -192,13 +191,14 @@ impl CustomExecute for IfEqualOp {
 #[derive(Clone, Debug)]
 pub struct SuperposeOp {
     space: DynSpace,
+    settings: PragmaSettings,
 }
 
 grounded_op!(SuperposeOp, "superpose");
 
 impl SuperposeOp {
-    fn new(space: DynSpace) -> Self {
-        Self{ space }
+    fn new(space: DynSpace, settings: PragmaSettings) -> Self {
+        Self{ space, settings }
     }
 }
 
@@ -223,7 +223,7 @@ impl CustomExecute for SuperposeOp {
         } else {
             let mut superposed = Vec::new();
             for atom in expr.children() {
-                match interpret_no_error(self.space.clone(), atom) {
+                match interpret_no_error(self.space.clone(), atom, self.settings.clone()) {
                     Ok(results) => { superposed.extend(results); },
                     Err(message) => { return Err(format!("Error: {}", message).into()) },
                 }
@@ -236,13 +236,14 @@ impl CustomExecute for SuperposeOp {
 #[derive(Clone, Debug)]
 pub struct CollapseOp {
     space: DynSpace,
+    settings: PragmaSettings,
 }
 
 grounded_op!(CollapseOp, "collapse");
 
 impl CollapseOp {
-    pub fn new(space: DynSpace) -> Self {
-        Self{ space }
+    pub fn new(space: DynSpace, settings: PragmaSettings) -> Self {
+        Self{ space, settings }
     }
 }
 
@@ -263,7 +264,7 @@ impl CustomExecute for CollapseOp {
 
         // TODO: Calling interpreter inside the operation is not too good
         // Could it be done via returning atom for the further interpretation?
-        let result = interpret_no_error(self.space.clone(), atom)?;
+        let result = interpret_no_error(self.space.clone(), atom, self.settings.clone())?;
 
         Ok(vec![Atom::expr(result)])
     }
@@ -272,13 +273,14 @@ impl CustomExecute for CollapseOp {
 #[derive(Clone, Debug)]
 pub struct CaptureOp {
     space: DynSpace,
+    settings: PragmaSettings, 
 }
 
 grounded_op!(CaptureOp, "capture");
 
 impl CaptureOp {
-    pub fn new(space: DynSpace) -> Self {
-        Self{ space }
+    pub fn new(space: DynSpace, settings: PragmaSettings) -> Self {
+        Self{ space, settings }
     }
 }
 
@@ -296,20 +298,21 @@ impl CustomExecute for CaptureOp {
     fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
         let arg_error = || ExecError::from("capture expects one argument");
         let atom = args.get(0).ok_or_else(arg_error)?;
-        interpret(self.space.clone(), &atom).map_err(|e| ExecError::from(e))
+        interpret(self.space.clone(), &atom, self.settings.clone()).map_err(|e| ExecError::from(e))
     }
 }
 
 #[derive(Clone, Debug)]
 pub struct CaseOp {
     space: DynSpace,
+    settings: PragmaSettings,
 }
 
 grounded_op!(CaseOp, "case");
 
 impl CaseOp {
-    pub fn new(space: DynSpace) -> Self {
-        Self{ space }
+    pub fn new(space: DynSpace, settings: PragmaSettings) -> Self {
+        Self{ space, settings }
     }
 }
 
@@ -345,7 +348,7 @@ impl CustomExecute for CaseOp {
         // `%Undefined%`. Another way is to introduce "call" level. Thus if function called
         // returned the result to the `chain` it should stop reducing it and insert it into the
         // last argument.
-        let results = interpret(self.space.clone(), atom);
+        let results = interpret(self.space.clone(), atom, self.settings.clone());
         log::debug!("CaseOp::execute: atom results: {:?}", results);
         let results = match results {
             Ok(results) if results.is_empty() =>
@@ -372,13 +375,13 @@ pub(super) fn register_context_independent_tokens(tref: &mut Tokenizer) {
 }
 
 pub(super) fn register_context_dependent_tokens(tref: &mut Tokenizer, space: &DynSpace, metta: &Metta) {
-    let superpose_op = Atom::gnd(SuperposeOp::new(space.clone()));
+    let superpose_op = Atom::gnd(SuperposeOp::new(space.clone(), metta.settings().clone()));
     tref.register_token(regex(r"superpose"), move |_| { superpose_op.clone() });
-    let collapse_op = Atom::gnd(CollapseOp::new(space.clone()));
+    let collapse_op = Atom::gnd(CollapseOp::new(space.clone(), metta.settings().clone()));
     tref.register_token(regex(r"collapse"), move |_| { collapse_op.clone() });
-    let case_op = Atom::gnd(CaseOp::new(space.clone()));
+    let case_op = Atom::gnd(CaseOp::new(space.clone(), metta.settings().clone()));
     tref.register_token(regex(r"case"), move |_| { case_op.clone() });
-    let capture_op = Atom::gnd(CaptureOp::new(space.clone()));
+    let capture_op = Atom::gnd(CaptureOp::new(space.clone(), metta.settings().clone()));
     tref.register_token(regex(r"capture"), move |_| { capture_op.clone() });
     let pragma_op = Atom::gnd(PragmaOp::new(metta.settings().clone()));
     tref.register_token(regex(r"pragma!"), move |_| { pragma_op.clone() });

--- a/lib/src/metta/runner/stdlib/mod.rs
+++ b/lib/src/metta/runner/stdlib/mod.rs
@@ -57,9 +57,15 @@ pub fn interpret_no_error(space: DynSpace, expr: &Atom, settings: PragmaSettings
     }
 }
 
-pub fn interpret(space: DynSpace, expr: &Atom, _settings: PragmaSettings) -> Result<Vec<Atom>, String> {
+pub fn interpret(space: DynSpace, expr: &Atom, settings: PragmaSettings) -> Result<Vec<Atom>, String> {
     let expr = Atom::expr([METTA_SYMBOL, expr.clone(), ATOM_TYPE_UNDEFINED, Atom::gnd(space.clone())]);
     let mut state = crate::metta::interpreter::interpret_init(space, &expr);
+    
+    if let Some(depth) = settings.get_string("max-stack-depth") {
+        let depth = depth.parse::<usize>().unwrap();
+        state.set_max_stack_depth(depth);
+    }
+
     while state.has_next() {
         state = crate::metta::interpreter::interpret_step(state);
     }

--- a/lib/src/metta/runner/stdlib/mod.rs
+++ b/lib/src/metta/runner/stdlib/mod.rs
@@ -16,7 +16,7 @@ use crate::space::*;
 use crate::metta::*;
 use crate::metta::text::{Tokenizer, SExprParser};
 use crate::common::shared::Shared;
-use crate::metta::runner::{Metta, RunContext, ModuleLoader};
+use crate::metta::runner::{Metta, RunContext, ModuleLoader, PragmaSettings};
 
 use regex::Regex;
 
@@ -48,8 +48,8 @@ pub(crate) fn regex(regex: &str) -> Regex {
 
 // TODO: remove hiding errors completely after making it possible passing
 // them to the user
-pub fn interpret_no_error(space: DynSpace, expr: &Atom) -> Result<Vec<Atom>, String> {
-    let result = interpret(space, &expr);
+pub fn interpret_no_error(space: DynSpace, expr: &Atom, settings: PragmaSettings) -> Result<Vec<Atom>, String> {
+    let result = interpret(space, &expr, settings);
     log::debug!("interpret_no_error: interpretation expr: {}, result {:?}", expr, result);
     match result {
         Ok(result) => Ok(result),
@@ -57,10 +57,13 @@ pub fn interpret_no_error(space: DynSpace, expr: &Atom) -> Result<Vec<Atom>, Str
     }
 }
 
-pub fn interpret(space: DynSpace, expr: &Atom) -> Result<Vec<Atom>, String> {
+pub fn interpret(space: DynSpace, expr: &Atom, _settings: PragmaSettings) -> Result<Vec<Atom>, String> {
     let expr = Atom::expr([METTA_SYMBOL, expr.clone(), ATOM_TYPE_UNDEFINED, Atom::gnd(space.clone())]);
-    let result = crate::metta::interpreter::interpret(space, &expr);
-    result
+    let mut state = crate::metta::interpreter::interpret_init(space, &expr);
+    while state.has_next() {
+        state = crate::metta::interpreter::interpret_step(state);
+    }
+    state.into_result()
 }
 
 //TODO: The additional arguments are a temporary hack on account of the way the operation atoms store references
@@ -69,7 +72,7 @@ fn register_context_dependent_tokens(tref: &mut Tokenizer, tokenizer: Shared<Tok
 
     atom::register_context_dependent_tokens(tref, space);
     core::register_context_dependent_tokens(tref, space, metta);
-    debug::register_context_dependent_tokens(tref, space);
+    debug::register_context_dependent_tokens(tref, space, metta);
     module::register_context_dependent_tokens(tref, tokenizer.clone(), metta);
     #[cfg(feature = "pkg_mgmt")]
     package::register_context_dependent_tokens(tref, metta);

--- a/lib/src/metta/runner/stdlib/stdlib.metta
+++ b/lib/src/metta/runner/stdlib/stdlib.metta
@@ -1066,7 +1066,10 @@
   (@return "Function"))
 
 (@doc pragma!
-  (@desc "Changes global key's (first argument) value to a new one (second argument)")
+  (@desc "Changes global key's (first argument) value to a new one (second argument).
+Possible pragmas:
+  (pragma! type-check auto) - check type of the atom before evaluation
+  (pragma! interpreter bare-minimal) - use minimal MeTTa semantics when evaluating atom")
   (@params (
     (@param "Key's name")
     (@param "New value")))

--- a/lib/src/metta/runner/stdlib/stdlib.metta
+++ b/lib/src/metta/runner/stdlib/stdlib.metta
@@ -1069,7 +1069,8 @@
   (@desc "Changes global key's (first argument) value to a new one (second argument).
 Possible pragmas:
   (pragma! type-check auto) - check type of the atom before evaluation
-  (pragma! interpreter bare-minimal) - use minimal MeTTa semantics when evaluating atom")
+  (pragma! interpreter bare-minimal) - use minimal MeTTa semantics when evaluating atom
+  (pragma! max-stack-depth <number>) - limit depth of the interpreter's stack, 0 - no limit (default behavior)")
   (@params (
     (@param "Key's name")
     (@param "New value")))


### PR DESCRIPTION
Return error if stack depth limit is reached.

Current implementation has the following pecularities:

1. The stack depth is calculated in terms of the minimal MeTTa instructions not MeTTa instructions thus the actual stack depth can be bigger than expected as minimal MeTTa instructions are more detailed.

2. Execution is interrupted and returns error only on the next MeTTa function call. This is required to correctly return error from the
minimal MeTTa stack when MeTTa program is executed.

3. Case/capture/superpose/collapse/assert operations call interpreter from the interpreter stack and it leads to the creation of the new stack. Thus if `case` (or other similar operation) is used the limit counter is started from the beginning for the nested expression. In stack where `case` calls `case` the limit is not reached.