### PR TITLE
Add builtin module example

### DIFF
--- a/lib/src/atom/gnd.rs
+++ b/lib/src/atom/gnd.rs
@@ -1,0 +1,135 @@
+use std::rc::Rc;
+
+use super::*;
+use crate::common::collections::ImmutableString;
+
+/// Grounded function abstraction.
+pub trait GroundedFunction {
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError>;
+}
+
+impl<T: Fn(&[Atom]) -> Result<Vec<Atom>, ExecError>>  GroundedFunction for T {
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        (*self)(args)
+    }
+}
+
+/// Structure to wrap [GroundedFunction] instance to make an [Atom::Grounded].
+pub struct GroundedFunctionAtom<T: GroundedFunction>(Rc<GroundedFunctionAtomContent<T>>);
+
+struct GroundedFunctionAtomContent<T: GroundedFunction> {
+    name: ImmutableString,
+    typ: Atom,
+    func: T,
+}
+
+impl<T: GroundedFunction> GroundedFunctionAtom<T> {
+    /// Constructs new [GroundedFunctionAtom] instance.
+    /// Name also is used to register grounded atom token, see [MettaMod::register_method].
+    pub fn new(name: ImmutableString, typ: Atom, func: T) -> Self {
+        Self(Rc::new(GroundedFunctionAtomContent{ name, typ, func }))
+    }
+
+    /// Returns name of the grounded function to register it as a token.
+    pub fn name(&self) -> &str {
+        self.0.name.as_str()
+    }
+}
+
+impl<T: GroundedFunction> PartialEq for GroundedFunctionAtom<T> {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+impl<T: GroundedFunction> std::fmt::Display for GroundedFunctionAtom<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0.name)
+    }
+}
+
+impl<T: GroundedFunction> std::fmt::Debug for GroundedFunctionAtom<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "GroundedFunctionAtom[name={}, typ={:?}]", self.0.name, self.0.typ)
+    }
+}
+
+impl<T: GroundedFunction> Clone for GroundedFunctionAtom<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<T: GroundedFunction> Grounded for GroundedFunctionAtom<T> {
+    fn type_(&self) -> Atom {
+        self.0.typ.clone()
+    }
+
+    fn as_execute(&self) -> Option<&dyn CustomExecute> {
+        Some(self)
+    }
+}
+
+impl<T: GroundedFunction> CustomExecute for GroundedFunctionAtom<T> {
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        match self.0.func.execute(args) {
+            Err(ExecError::Runtime(msg)) => Err(ExecError::Runtime(format!("{}: {}", self, msg))),
+            Err(err) => Err(err),
+            Ok(res) => Ok(res),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use crate::metta::runner::*;
+
+    fn execute_expr(expr: Atom) -> Result<Vec<Vec<Atom>>, String> {
+        let metta = Metta::new(Some(EnvBuilder::test_env()));
+        metta.run([Atom::sym("!"), expr].as_slice())
+    }
+
+    #[test]
+    fn test_lambda_into_grounded_atom() {
+        let f = move |_args: &[Atom]| -> Result<Vec<Atom>, ExecError> {
+            Ok(vec![Atom::sym("some-symbol")])
+        };
+
+        let op = GroundedFunctionAtom::new("get-some-symbol".into(), expr!("->" "%Undefined%"), f);
+
+        assert_eq!(execute_expr(Atom::expr([Atom::gnd(op)])),
+            Ok(vec![vec![Atom::sym("some-symbol")]]));
+    }
+
+    #[test]
+    fn test_function_into_grounded_atom() {
+        fn f(_args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+            Ok(vec![Atom::sym("some-symbol")])
+        }
+
+        let op = GroundedFunctionAtom::new("get-some-symbol".into(), expr!("->" "%Undefined%"), f);
+
+        assert_eq!(execute_expr(Atom::expr([Atom::gnd(op)])),
+            Ok(vec![vec![Atom::sym("some-symbol")]]));
+    }
+
+    #[test]
+    fn test_method_into_grounded_atom() {
+        struct S {
+            sym: ImmutableString,
+        }
+
+        impl GroundedFunction for S {
+            fn execute(&self, _args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+                Ok(vec![Atom::sym(self.sym.as_str())])
+            }
+        }
+
+        let op = GroundedFunctionAtom::new("get-some-symbol".into(), expr!("->" "%Undefined%"), S{ sym: "some-symbol".into() });
+
+        assert_eq!(execute_expr(Atom::expr([Atom::gnd(op)])),
+            Ok(vec![vec![Atom::sym("some-symbol")]]));
+    }
+}

--- a/lib/src/atom/mod.rs
+++ b/lib/src/atom/mod.rs
@@ -118,6 +118,7 @@ pub mod matcher;
 pub mod subexpr;
 mod iter;
 pub mod serial;
+pub mod gnd;
 
 pub use iter::*;
 

--- a/lib/src/metta/runner/builtin_mods/catalog_mods.rs
+++ b/lib/src/metta/runner/builtin_mods/catalog_mods.rs
@@ -58,14 +58,14 @@ impl ModuleLoader for CatalogModLoader {
         context.init_self_module(space, None);
 
         let metta = context.metta();
-        let mut tref = context.module().tokenizer().borrow_mut();
+        let module = context.module();
 
         let catalog_list_op = Atom::gnd(CatalogListOp::new(metta.clone()));
-        tref.register_token(regex(r"catalog-list!"), move |_| { catalog_list_op.clone() });
+        module.register_token(regex(r"catalog-list!"), move |_| { catalog_list_op.clone() });
         let catalog_update_op = Atom::gnd(CatalogUpdateOp::new(metta.clone()));
-        tref.register_token(regex(r"catalog-update!"), move |_| { catalog_update_op.clone() });
+        module.register_token(regex(r"catalog-update!"), move |_| { catalog_update_op.clone() });
         let catalog_clear_op = Atom::gnd(CatalogClearOp::new(metta.clone()));
-        tref.register_token(regex(r"catalog-clear!"), move |_| { catalog_clear_op.clone() });
+        module.register_token(regex(r"catalog-clear!"), move |_| { catalog_clear_op.clone() });
 
         Ok(())
     }

--- a/lib/src/metta/runner/builtin_mods/mod.rs
+++ b/lib/src/metta/runner/builtin_mods/mod.rs
@@ -1,11 +1,15 @@
 
 use crate::metta::runner::Metta;
 
+/// Skeleton of the built-in module
+mod skel;
 /// Op atoms for working with catalogs
 #[cfg(feature = "pkg_mgmt")]
 pub mod catalog_mods;
 
 pub fn load_builtin_mods(metta: &Metta) -> Result<(), String> {
+    // Built-in modules are loaded on the MeTTa initialization stage but not imported automatically
+    let _mod_id = metta.load_module_direct(Box::new(skel::SkelModLoader), "skel").map_err(|e| format!("error loading builtin \"catalog\" module: {e}"))?;
     #[cfg(feature = "pkg_mgmt")]
     let _mod_id = metta.load_module_direct(Box::new(catalog_mods::CatalogModLoader), "catalog").map_err(|e| format!("error loading builtin \"catalog\" module: {e}"))?;
 

--- a/lib/src/metta/runner/builtin_mods/skel.metta
+++ b/lib/src/metta/runner/builtin_mods/skel.metta
@@ -1,0 +1,14 @@
+(@doc skel-swap-pair
+  (@desc "Swap atoms of the pair")
+  (@params (
+    (@param "Pair of atoms") ))
+  (@return "Pair with original atoms swapped") )
+(: skel-swap-pair (-> ($ta $tb) ($tb $ta)))
+(= (skel-swap-pair ($a $b))
+   ($b $a))
+
+(@doc skel-swap-pair-native
+  (@desc "Swap atoms of the pair in Rust")
+  (@params (
+    (@param "Pair of atoms") ))
+  (@return "Pair with original atoms swapped") )

--- a/lib/src/metta/runner/builtin_mods/skel.metta
+++ b/lib/src/metta/runner/builtin_mods/skel.metta
@@ -1,11 +1,14 @@
+(: PairType (-> $ta $tb Type))
+(: Pair (-> $ta $tb (PairType $ta $tb)))
+
 (@doc skel-swap-pair
   (@desc "Swap atoms of the pair")
   (@params (
     (@param "Pair of atoms") ))
   (@return "Pair with original atoms swapped") )
-(: skel-swap-pair (-> ($ta $tb) ($tb $ta)))
-(= (skel-swap-pair ($a $b))
-   ($b $a))
+(: skel-swap-pair (-> (PairType $ta $tb) (PairType $tb $ta)))
+(= (skel-swap-pair (Pair $a $b))
+   (Pair $b $a))
 
 (@doc skel-swap-pair-native
   (@desc "Swap atoms of the pair in Rust")

--- a/lib/src/metta/runner/builtin_mods/skel.rs
+++ b/lib/src/metta/runner/builtin_mods/skel.rs
@@ -17,10 +17,8 @@ impl ModuleLoader for SkelModLoader {
         context.init_self_module(space, None);
 
         // Load module's tokens
-        let mut tref = context.module().tokenizer().borrow_mut();
         let skel_swap_pair_native = Atom::gnd(SkelSwapPairNativeOp{});
-        tref.register_token(regex(r"skel-swap-pair-native"), move |_| { skel_swap_pair_native.clone() });
-        drop(tref);
+        context.module().register_token(regex(r"skel-swap-pair-native"), move |_| { skel_swap_pair_native.clone() });
 
         // Parse MeTTa code of the module
         let parser = SExprParser::new(SKEL_METTA);

--- a/lib/src/metta/runner/builtin_mods/skel.rs
+++ b/lib/src/metta/runner/builtin_mods/skel.rs
@@ -58,3 +58,23 @@ impl CustomExecute for SkelSwapPairNativeOp {
         Ok(vec![pair])
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::metta::*;
+    use crate::metta::runner::run_program;
+
+    #[test]
+    fn test_import_skel() {
+        let program = "
+            !(import! &self skel)
+            !(skel-swap-pair (a b))
+            !(skel-swap-pair-native (a b))
+        ";
+        assert_eq!(run_program(program), Ok(vec![
+                vec![UNIT_ATOM],
+                vec![expr!("b" "a")],
+                vec![expr!("b" "a")],
+        ]));
+    }
+}

--- a/lib/src/metta/runner/builtin_mods/skel.rs
+++ b/lib/src/metta/runner/builtin_mods/skel.rs
@@ -1,0 +1,60 @@
+use std::fmt::{Display, Formatter};
+use crate::metta::*;
+use crate::space::grounding::GroundingSpace;
+use crate::metta::text::SExprParser;
+use crate::metta::runner::{ModuleLoader, RunContext, DynSpace};
+use crate::metta::runner::stdlib::regex;
+
+pub static SKEL_METTA: &'static str = include_str!("skel.metta");
+
+#[derive(Debug)]
+pub(crate) struct SkelModLoader;
+
+impl ModuleLoader for SkelModLoader {
+    fn load(&self, context: &mut RunContext) -> Result<(), String> {
+        // Initialize module's space
+        let space = DynSpace::new(GroundingSpace::new());
+        context.init_self_module(space, None);
+
+        // Load module's tokens
+        let mut tref = context.module().tokenizer().borrow_mut();
+        let skel_swap_pair_native = Atom::gnd(SkelSwapPairNativeOp{});
+        tref.register_token(regex(r"skel-swap-pair-native"), move |_| { skel_swap_pair_native.clone() });
+        drop(tref);
+
+        // Parse MeTTa code of the module
+        let parser = SExprParser::new(SKEL_METTA);
+        context.push_parser(Box::new(parser));
+
+        Ok(())
+    }
+
+}
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct SkelSwapPairNativeOp{}
+
+impl Display for SkelSwapPairNativeOp {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "skel-swap-pair-native")
+    }
+}
+
+impl Grounded for SkelSwapPairNativeOp {
+    fn type_(&self) -> Atom {
+        expr!("->" (ta tb) (tb ta))
+    }
+
+    fn as_execute(&self) -> Option<&dyn CustomExecute> {
+        Some(self)
+    }
+}
+
+impl CustomExecute for SkelSwapPairNativeOp {
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+        let arg_error = || ExecError::from("skel-swap-pair-native expects single pair as argument");
+        let pair = TryInto::<&ExpressionAtom>::try_into(args.get(0).ok_or_else(arg_error)?)?;
+        let pair = Atom::expr([pair.children()[1].clone(), pair.children()[0].clone()]) ;
+        Ok(vec![pair])
+    }
+}

--- a/lib/src/metta/runner/builtin_mods/skel.rs
+++ b/lib/src/metta/runner/builtin_mods/skel.rs
@@ -40,7 +40,7 @@ impl Display for SkelSwapPairNativeOp {
 
 impl Grounded for SkelSwapPairNativeOp {
     fn type_(&self) -> Atom {
-        expr!("->" (ta tb) (tb ta))
+        expr!("->" ("PairType" ta tb) ("PairType" tb ta))
     }
 
     fn as_execute(&self) -> Option<&dyn CustomExecute> {
@@ -52,7 +52,7 @@ impl CustomExecute for SkelSwapPairNativeOp {
     fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
         let arg_error = || ExecError::from("skel-swap-pair-native expects single pair as argument");
         let pair = TryInto::<&ExpressionAtom>::try_into(args.get(0).ok_or_else(arg_error)?)?;
-        let pair = Atom::expr([pair.children()[1].clone(), pair.children()[0].clone()]) ;
+        let pair = Atom::expr([pair.children()[0].clone(), pair.children()[2].clone(), pair.children()[1].clone()]) ;
         Ok(vec![pair])
     }
 }
@@ -66,13 +66,13 @@ mod tests {
     fn test_import_skel() {
         let program = "
             !(import! &self skel)
-            !(skel-swap-pair (a b))
-            !(skel-swap-pair-native (a b))
+            !(skel-swap-pair (Pair a b))
+            !(skel-swap-pair-native (Pair a b))
         ";
         assert_eq!(run_program(program), Ok(vec![
                 vec![UNIT_ATOM],
-                vec![expr!("b" "a")],
-                vec![expr!("b" "a")],
+                vec![expr!("Pair" "b" "a")],
+                vec![expr!("Pair" "b" "a")],
         ]));
     }
 }

--- a/lib/src/metta/runner/mod.rs
+++ b/lib/src/metta/runner/mod.rs
@@ -1221,6 +1221,12 @@ fn wrap_atom_by_metta_interpreter(space: DynSpace, atom: Atom) -> Atom {
 // *-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*
 
 #[cfg(test)]
+pub fn run_program(program: &str) -> Result<Vec<Vec<Atom>>, String> {
+    let metta = Metta::new(Some(EnvBuilder::test_env()));
+    metta.run(SExprParser::new(program))
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use super::bool::Bool;

--- a/lib/src/metta/runner/modules/mod.rs
+++ b/lib/src/metta/runner/modules/mod.rs
@@ -310,6 +310,13 @@ impl MettaMod {
         Ok(())
     }
 
+    // TODO: This method is hotfix before proper method of loading module's tokens is
+    // implemented.
+    pub fn register_token<C: 'static + for<'a> Fn(&'a str) -> Atom>(&self, regex: Regex, constr: C) {
+        let constr = Rc::new(move |token: &str| -> Result<Atom, String> { Ok(constr(token)) });
+        self.tokenizer.borrow_mut().register_token_with_func_ptr(regex.clone(), constr.clone());
+        self.own_tokenizer.borrow_mut().register_token_with_func_ptr(regex, constr);
+    }
 }
 
 /// ModuleInitState is a smart-pointer to a state that contains some objects to be merged

--- a/lib/src/metta/runner/modules/mod.rs
+++ b/lib/src/metta/runner/modules/mod.rs
@@ -5,6 +5,7 @@ use std::cell::RefCell;
 use crate::metta::*;
 use crate::metta::runner::*;
 use crate::space::module::ModuleSpace;
+use crate::gnd::*;
 
 use regex::Regex;
 
@@ -314,6 +315,15 @@ impl MettaMod {
     // implemented.
     pub fn register_token<C: 'static + for<'a> Fn(&'a str) -> Atom>(&self, regex: Regex, constr: C) {
         let constr = Rc::new(move |token: &str| -> Result<Atom, String> { Ok(constr(token)) });
+        self.tokenizer.borrow_mut().register_token_with_func_ptr(regex.clone(), constr.clone());
+        self.own_tokenizer.borrow_mut().register_token_with_func_ptr(regex, constr);
+    }
+
+    // TODO: This method is hotfix before proper method of loading module's tokens is
+    // implemented.
+    pub fn register_method<T: GroundedFunction + 'static>(&self, method: GroundedFunctionAtom<T>) {
+        let regex = Regex::new(method.name()).unwrap();
+        let constr = Rc::new(move |_token: &str| -> Result<Atom, String> { Ok(Atom::gnd(method.clone())) });
         self.tokenizer.borrow_mut().register_token_with_func_ptr(regex.clone(), constr.clone());
         self.own_tokenizer.borrow_mut().register_token_with_func_ptr(regex, constr);
     }

--- a/lib/src/metta/runner/stdlib/atom.rs
+++ b/lib/src/metta/runner/stdlib/atom.rs
@@ -476,7 +476,7 @@ mod tests {
     use crate::metta::runner::EnvBuilder;
     use crate::metta::runner::str::Str;
     use crate::common::test_utils::metta_space;
-    use crate::metta::runner::stdlib::tests::run_program;
+    use crate::metta::runner::run_program;
     use crate::metta::runner::Metta;
     use crate::metta::runner::stdlib::arithmetics::*;
 

--- a/lib/src/metta/runner/stdlib/core.rs
+++ b/lib/src/metta/runner/stdlib/core.rs
@@ -396,7 +396,7 @@ pub(super) fn register_context_dependent_tokens(tref: &mut Tokenizer, space: &Dy
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::metta::runner::stdlib::tests::run_program;
+    use crate::metta::runner::run_program;
     use crate::matcher::atoms_are_equivalent;
     use crate::common::test_utils::metta_space;
     use crate::metta::runner::number::Number;

--- a/lib/src/metta/runner/stdlib/debug.rs
+++ b/lib/src/metta/runner/stdlib/debug.rs
@@ -329,7 +329,7 @@ mod tests {
     use super::*;
     use crate::metta::runner::{Metta, EnvBuilder, SExprParser};
     use crate::common::test_utils::metta_space;
-    use crate::metta::runner::stdlib::tests::run_program;
+    use crate::metta::runner::run_program;
 
     use regex::Regex;
 

--- a/lib/src/metta/runner/stdlib/math.rs
+++ b/lib/src/metta/runner/stdlib/math.rs
@@ -447,7 +447,7 @@ pub(super) fn register_context_independent_tokens(tref: &mut Tokenizer) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::metta::runner::stdlib::tests::run_program;
+    use crate::metta::runner::run_program;
 
     #[test]
     fn metta_pow_math() {

--- a/lib/src/metta/runner/stdlib/mod.rs
+++ b/lib/src/metta/runner/stdlib/mod.rs
@@ -151,14 +151,10 @@ mod tests {
     use crate::common::Operation;
     use crate::metta::runner::bool::Bool;
     use crate::metta::runner::number::Number;
+    use crate::metta::runner::run_program;
 
     use std::fmt::Display;
     use regex::Regex;
-
-    pub fn run_program(program: &str) -> Result<Vec<Vec<Atom>>, String> {
-        let metta = Metta::new(Some(EnvBuilder::test_env()));
-        metta.run(SExprParser::new(program))
-    }
 
     #[test]
     fn metta_switch() {

--- a/lib/src/metta/runner/stdlib/random.rs
+++ b/lib/src/metta/runner/stdlib/random.rs
@@ -248,7 +248,7 @@ pub(super) fn register_context_independent_tokens(tref: &mut Tokenizer) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::metta::runner::stdlib::tests::run_program;
+    use crate::metta::runner::run_program;
 
     #[test]
     fn metta_random() {


### PR DESCRIPTION
Built-in module named "skel" is added as an example of the native module. One should import module before using it, for example:
```
            !(import! &self skel)
            !(skel-swap-pair (Pair a b))
            !(skel-swap-pair-native (Pair a b))
```

Also the `GroundedFunctionAtom` structure is added to easily add new grounded operations into Rust libraries. It allows wrapping functions, lambdas or structures which implement `GroundedFunction` trait. For lambdas and functions with specific signature this trait is implemented automatically.

This PR fixes incorrect `catalog` module behavior which was introduced by https://github.com/trueagi-io/hyperon-experimental/pull/894 (see https://github.com/trueagi-io/hyperon-experimental/pull/913/commits/22066446a055602edeaa6559934d89d65d5476da and https://github.com/trueagi-io/hyperon-experimental/pull/913/commits/18fbdfaf76b83edf3eb3c118b2a0aecc5001c534) but it is more likely a hotfix. Proper fix requires adding a new method into `ModuleLoader` which registers tokens exported by the module.