### PR TITLE
Allow direct tokens loading into importing module

### DIFF
--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -5,3 +5,4 @@ pub mod atom;
 pub mod space;
 pub mod metta;
 pub mod serial;
+pub mod module;

--- a/c/src/metta.rs
+++ b/c/src/metta.rs
@@ -831,41 +831,6 @@ pub extern "C" fn metta_new() -> metta_t {
 
 /// @brief Creates a new top-level MeTTa Runner, with the specified `stdlib` module loaded
 /// @ingroup interpreter_group
-/// @param[in]  space  A pointer to a handle for the Space for use in the Runner's top-level module
-/// @param[in]  environment  An `env_builder_t` handle to configure the environment to use
-/// @param[in]  loader_callback  The `mod_loader_callback_t` for a function to load the stdlib, if it is
-///     not already loaded.  Pass NULL to use the default `stdlib`
-/// @param[in]  callback_context  A pointer to a caller-defined structure that will be passed to the
-///     `loader_callback` function
-/// @return A `metta_t` handle to the newly created Runner
-/// @note The caller must take ownership responsibility for the returned `metta_t`, and free it with `metta_free()`
-/// @note Most callers can simply call `metta_new`.  This function is provided to support languages
-///     with their own stdlib, that needs to be loaded before the init.metta file is run
-///
-#[no_mangle]
-pub extern "C" fn metta_new_with_space_environment_and_stdlib(space: *mut space_t,
-    env_builder: env_builder_t, loader_callback: mod_loader_callback_t, callback_context: *mut c_void) -> metta_t
-{
-    let dyn_space = unsafe{ &*space }.borrow();
-    let env_builder = if env_builder.is_default() {
-        None
-    } else {
-        Some(env_builder.into_inner())
-    };
-    let loader = match loader_callback {
-        Some(callback) => {
-            Some(Box::new(CModLoaderWrapper{ callback, callback_context }) as Box<dyn ModuleLoader>)
-        },
-        None => None
-    };
-
-    let metta = Metta::new_with_stdlib_loader(loader, Some(dyn_space.clone()), env_builder);
-    metta.into()
-}
-
-
-/// @brief Creates a new top-level MeTTa Runner, with the specified `stdlib` module loaded
-/// @ingroup interpreter_group
 /// @param[in]  space_ref  A pointer to a handle for the Space for use in the Runner's top-level module
 /// @param[in]  env_builder_mov  An `env_builder_t` handle to configure the environment to use
 /// @param[in]  stdlib_loader_mov  Stdlib loader implemented in C code. Pass NULL to use the default `stdlib`

--- a/c/src/metta.rs
+++ b/c/src/metta.rs
@@ -6,8 +6,7 @@ use hyperon::metta::text::*;
 use hyperon::metta::interpreter;
 use hyperon::metta::interpreter::InterpreterState;
 use hyperon::metta::runner::{Metta, RunContext, RunnerState, Environment, EnvBuilder};
-use hyperon::metta::runner::modules::{ModuleLoader, ModId, ResourceKey, Resource};
-use hyperon::metta::runner::pkg_mgmt::{FsModuleFormat, ModuleDescriptor};
+use hyperon::metta::runner::modules::{ModuleLoader, ModId};
 use hyperon::atom::*;
 
 use crate::util::*;
@@ -16,7 +15,7 @@ use crate::space::*;
 use crate::module::*;
 
 use std::os::raw::*;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::io;
 
 use regex::Regex;
@@ -1192,7 +1191,7 @@ pub struct run_context_t {
 // to invlid memory access
 
 impl run_context_t {
-    fn take_err_string(&mut self) -> Option<String> {
+    pub fn take_err_string(&mut self) -> Option<String> {
         if !self.err_string.is_null() {
             let return_string = unsafe{ std::ffi::CString::from_raw(self.err_string) }.to_str().expect("UTF-8 error").to_string();
             self.err_string = core::ptr::null_mut();
@@ -1684,309 +1683,12 @@ pub extern "C" fn env_builder_push_fs_module_format(builder: *mut env_builder_t,
 // Module Interface
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
-/// @brief Identifies the properties on a specific module, including its name and version
-/// @ingroup module_group
-/// @note `module_descriptor_t` objects must be freed with `module_descriptor_free` or passed to
-///    a function that assumes responsibility for freeing them
-///
-#[repr(C)]
-pub struct module_descriptor_t {
-    /// Internal.  Should not be accessed directly
-    descriptor: *mut RustModuleDescriptor,
-}
-
-#[derive(Clone)]
-#[allow(dead_code)] //LP-TODO-NEXT.  Currently we don't do much with module_descriptor_t, but that will change when I make C bindings for the catalog API
-enum RustModuleDescriptor {
-    Descriptor(ModuleDescriptor),
-    Err(String)
-}
-
-impl From<ModuleDescriptor> for module_descriptor_t {
-    fn from(descriptor: ModuleDescriptor) -> Self {
-        Self{ descriptor: Box::into_raw(Box::new(RustModuleDescriptor::Descriptor(descriptor))) }
-    }
-}
-
-//LP-TODO-NEXT.  The "interpreter" documentation group is bloating.  Should break out a separate "runner" group
-//LP-TODO-NEXT.  The Error pathway of the module_descriptor_t is no longer used.  So I can simplify this type
-//LP-TODO-NEXT.  Add an error pathway to run_context_t, that mirrors the error pathway in metta_t, so calls where a run_context_t is passed can propagate errors back to the caller
-//LP-TODO-Next.  Add an error-status result to the callbacks.  At a conceptual level, this error type fundamentally the same exec_error_t / ExecError
-
-impl module_descriptor_t {
-    fn new_err(err: String) -> Self {
-        Self{ descriptor: Box::into_raw(Box::new(RustModuleDescriptor::Err(err))) }
-    }
-    fn new_from_enum(rust_enum: RustModuleDescriptor) -> Self {
-        Self{ descriptor: Box::into_raw(Box::new(rust_enum)) }
-    }
-    fn into_rust_enum(self) -> RustModuleDescriptor {
-        unsafe{ *Box::from_raw(self.descriptor) }
-    }
-    fn borrow_rust_enum(&self) -> &RustModuleDescriptor {
-        unsafe{ &*self.descriptor }
-    }
-    //LP-TODO-NEXT: probably dead code.  Delete soon
-    // fn borrow(&self) -> &ModuleDescriptor {
-    //     match unsafe{ &*self.descriptor } {
-    //         RustModuleDescriptor::Descriptor(desc) => desc,
-    //         RustModuleDescriptor::Err(_err) => panic!("Fatal error.  Attempt to access Error module_descriptor_t")
-    //     }
-    // }
-}
-
-/// @brief Identifies a loaded module inside a specific `metta_t` MeTTa runner
-/// @ingroup module_group
-/// @note It is not necessary to free `module_id_t` types
-///
-#[repr(C)]
-pub struct module_id_t {
-    /// Internal.  Should not be accessed directly
-    id: usize,
-}
-
-impl From<ModId> for module_id_t {
-    fn from(mod_id: ModId) -> Self {
-        module_id_t{ id: mod_id.0 }
-    }
-}
-
-impl module_id_t {
-    fn into_inner(self) -> ModId {
-        ModId(self.id)
-    }
-}
-
-/// @brief Returns `true` is a module_id_t is valid, otherwise returns `false`
-/// @ingroup module_group
-/// @param[in]  mod_id  A pointer to the `module_id_t` to test for validity
-/// @return `true` if the module_id_t is valid, otherwise returns `false`
-///
-#[no_mangle]
-pub extern "C" fn module_id_is_valid(mod_id: *const module_id_t) -> bool {
-    let mod_id = unsafe{ &*mod_id };
-    ModId(mod_id.id) != ModId::INVALID
-}
-
-/// @brief Creates a new module_descriptor_t with the specified name
-/// @ingroup module_group
-/// @param[in]  name  A C-style string containing the name of the module
-/// @return The new `module_descriptor_t`
-/// @note The returned `module_descriptor_t` must be freed with `module_descriptor_free()`
-///
-#[no_mangle]
-pub extern "C" fn module_descriptor_new(name: *const c_char) -> module_descriptor_t {
-    //TODO-NEXT: We should probably take a version string, and parse it into a semver version
-    ModuleDescriptor::new(cstr_as_str(name).to_string(), None, None).into()
-}
-
-/// @brief Creates a new module_descriptor_t that represents the error attempting to interpret a module
-/// @ingroup module_group
-/// @param[in]  err_str  A C-style string containing the error message
-/// @return The new error `module_descriptor_t`
-///
-#[no_mangle]
-pub extern "C" fn module_descriptor_error(err_str: *const c_char) -> module_descriptor_t {
-    module_descriptor_t::new_err(cstr_as_str(err_str).to_string()).into()
-}
-
-/// @brief Creates a new module_descriptor_t that is a clone of the argument passed
-/// @ingroup module_group
-/// @param[in]  descriptor  The `module_descriptor_t` to clone
-/// @return The new `module_descriptor_t`
-/// @note The returned `module_descriptor_t` must be freed with `module_descriptor_free()`
-///
-#[no_mangle]
-pub extern "C" fn module_descriptor_clone(descriptor: *const module_descriptor_t) -> module_descriptor_t {
-    let rust_enum = unsafe{ &*descriptor }.borrow_rust_enum();
-    module_descriptor_t::new_from_enum(rust_enum.clone())
-}
-
-/// @brief Frees a module_descriptor_t
-/// @ingroup module_group
-/// @param[in]  descriptor  The `module_descriptor_t` to free
-///
-#[no_mangle]
-pub extern "C" fn module_descriptor_free(descriptor: module_descriptor_t) {
-    let descriptor = descriptor.into_rust_enum();
-    drop(descriptor);
-}
-
 /// @brief A callback to loads a module into a runner, by making calls into the `run_context_t`
 /// @ingroup module_group
 /// @param[in]  run_context  The `run_context_t` to provide access to the MeTTa run interface
 /// @param[in]  callback_context  The state pointer initially passed to the upstream function
 ///
 pub type mod_loader_callback_t = Option<extern "C" fn(run_context: *mut run_context_t, callback_context: *mut c_void)>;
-
-/// @struct mod_file_fmt_api_t
-/// @brief A table of functions to load MeTTa modules from an arbitrary format
-/// @ingroup module_group
-/// @warning All of the functions in this interface may be called from threads outside the main
-///    thread, and may be called concurrently.  Therefore these functions must be fully reentrant.
-///
-#[repr(C)]
-pub struct mod_file_fmt_api_t {
-
-    /// @brief Constructs a path for a module with a given name that resides in a parent directory
-    /// @param[in]  payload  The payload passed to `env_builder_push_fs_module_format` when the
-    ///    format was initialized.  This function must not modify the payload
-    /// @param[in]  parent_dir  A NULL-terminated string, representing the path to the parent directory
-    ///    in the file system
-    /// @param[in]  mod_name  A NULL-terminated string, representing the name of the module
-    /// @param[out]  dst_buf  The buffer into which to write the output path, followed by a NULL character
-    /// @param[in]  buf_size  The size of the allocated dst_buf.  This function must not overwrite the
-    ///    output buffer
-    /// @return the number of bytes written into the `dst_buf` by the function, including a NULL terminator
-    ///    character.  If the path does not fit in the `dst_buf`, then this function should return 0
-    /// @note The implementation does not need to check the validity of the returned path.  Results from
-    ///    this method will be passed to `try_path` to perform validity checking
-    ///
-    //QUESTION: The Rust interface allows for a single module loader to check multiple path variations.
-    //    That could be implemented here in the C interface but it would complicate the API functions
-    //    by requiring multiple buffers to be returned, and currently it's not needed.
-    path_for_name: extern "C" fn(payload: *const c_void, parent_dir: *const c_char, mod_name: *const c_char, dst_buf: *mut c_char, buf_size: usize) -> usize,
-
-    /// @brief Tests a path in the file system to determine if a valid module resides at the path
-    /// @param[in]  payload  The payload passed to `env_builder_push_fs_module_format` when the
-    ///    format was initialized.  This function must not modify the payload
-    /// @param[in]  path  A NULL-terminated string, representing a path in the file system to test
-    /// @param[in]  mod_name  A NULL-terminated string, representing the name of the module
-    /// @return any non-NULL value if the `path` contains a valid module in the format, otherwise NULL.
-    ///    If a non-NULL value is returned from this function, it may be passed to the `load` function
-    ///    as the `callback_context` argument.  If a non-NULL value is returned, it will eventually
-    ///    trigger a call to `free_callback_context` so the returned value can be an allocated pointer.
-    ///
-    //TODO: This function will also be responsible for returning a module version, through an [out] arg,
-    // when I add versions in the near future
-    try_path: extern "C" fn(payload: *const c_void, path: *const c_char, mod_name: *const c_char) -> *mut c_void,
-
-    /// @brief Loads the module into the runner, by making calls into the `run_context_t`
-    /// @param[in]  payload  The payload passed to `env_builder_push_fs_module_format` when the
-    ///    format was initialized.  This function must not modify the payload
-    /// @param[in]  run_context  The `run_context_t` to provide access to the MeTTa run interface
-    /// @param[in]  callback_context  The state pointer initially passed to the upstream function
-    ///
-    ///QUESTION: What should the error reporting pathway look like?
-    ///QUESTION: Is it worth trying to unify this function prototype with the `mod_loader_callback_t` type?
-    ///   The argument in favor is that they're fundamentally doing the same thing, but the function params
-    ///   are different on account of having a payload, and removing the `payload` argument complicates the
-    ///   API as it becomes necessary to repackage the payload inside the `callback_context`
-    load: extern "C" fn(payload: *const c_void, run_context: *mut run_context_t, callback_context: *mut c_void),
-
-    /// @brief Frees a user-defined structure that may have been allocated in `try_path`.
-    /// @param[in]  callback_context  The value returned from `try_path`, if it was non-NULL
-    ///
-    free_callback_context: Option<extern "C" fn(callback_context: *mut c_void)>,
-}
-
-#[derive(Clone, Debug)]
-struct CFsModFmtLoader {
-    api: *const mod_file_fmt_api_t,
-    payload: *const c_void,
-    callback_context: *mut c_void,
-    fmt_id: u64,
-}
-
-impl CFsModFmtLoader {
-    fn new(api: *const mod_file_fmt_api_t, payload: *const c_void, fmt_id: u64) -> Self {
-        Self {api, payload, callback_context: core::ptr::null_mut(), fmt_id }
-    }
-}
-
-//QUESTION: What should our multi-thread cross-language API look like?  (I am seeing this as establishing
-//  a pattern we can also use for Grounded Atoms, Spaces, etc.)
-//
-//I see several possible approaches:
-// 1.) Let the C implementations ensure their own concurrency.  This preserves the option for optimal speed,
-//  but might invite problems with badly-behaved extensions.  Especially for host languages where the
-//  interpreter is bound to a specific thread such as Python or JavaScript.
-// 2.) Implement a single-threaded API where we transact all interactions with the host language through
-//  queues to a single interface thread.  This is less rope for the user to hang themselves, but will be
-//  a fundamental bottleneck, so I'd prefer not to go this route
-//
-//My strong opinion is we leave the C API unlimited (ie. Option 1).  Then we can implement the queueing
-//  & synchronization for Python within the hyperonpy layer.  My preference would be to undertake
-//  https://github.com/trueagi-io/hyperon-experimental/issues/283 before trying to implement the queueing &
-//  synchronization layer.  My reasoning is that the bug-surface-area will be a lot smaller in Rust than in C++
-unsafe impl Send for CFsModFmtLoader {}
-unsafe impl Sync for CFsModFmtLoader {}
-
-impl FsModuleFormat for CFsModFmtLoader {
-    fn paths_for_name(&self, parent_dir: &Path, mod_name: &str) -> Vec<PathBuf> {
-        let api = unsafe{ &*self.api };
-
-        let parent_dir_c_string = str_as_cstr(parent_dir.to_str().unwrap());
-        let mod_name_c_string = str_as_cstr(mod_name);
-        const BUF_SIZE: usize = 512;
-        let mut buffer = [0 as c_char; BUF_SIZE];
-
-        let bytes_written = (api.path_for_name)(
-            self.payload,
-            parent_dir_c_string.as_ptr(),
-            mod_name_c_string.as_ptr(),
-            buffer.as_mut_ptr(),
-            BUF_SIZE
-        );
-        if bytes_written > 0 {
-            vec![PathBuf::from(cstr_as_str(buffer[0..=bytes_written].as_ptr()))]
-        } else {
-            vec![]
-        }
-    }
-    fn try_path(&self, path: &Path, mod_name: Option<&str>) -> Option<(Box<dyn ModuleLoader>, ModuleDescriptor)> {
-        let api = unsafe{ &*self.api };
-        let path_c_string = str_as_cstr(path.to_str().unwrap());
-        let mod_name = match mod_name {
-            Some(mod_name) => mod_name,
-            None => path.file_stem().unwrap().to_str().unwrap()
-        };
-        let mod_name_c_string = str_as_cstr(mod_name);
-
-        let result_context = (api.try_path)(self.payload, path_c_string.as_ptr(), mod_name_c_string.as_ptr());
-        if !result_context.is_null() {
-            //TODO-NEXT.  We want to provide a way for the loader to support loading a PkgInfo, and also pass
-            // the version from that PkgInfo when the new descriptor is created
-
-            let descriptor = ModuleDescriptor::new_with_path_and_fmt_id(mod_name.to_string(), None, path, self.fmt_id);
-
-            let mut new_loader = self.clone();
-            new_loader.callback_context = result_context;
-            Some((Box::new(new_loader), descriptor))
-        } else {
-            None
-        }
-    }
-}
-
-impl ModuleLoader for CFsModFmtLoader {
-    fn load(&self, context: &mut RunContext) -> Result<(), String> {
-        let api = unsafe{ &*self.api };
-        let mut c_context = run_context_t::from(context);
-
-        (api.load)(self.payload, &mut c_context, self.callback_context);
-        match c_context.take_err_string() {
-            None => Ok(()),
-            Some(err_string) => Err(err_string),
-        }
-    }
-    fn get_resource(&self, _res_key: ResourceKey) -> Result<Resource, String> {
-        //TODO, add C API for providing resources
-        Err("resource not found".to_string())
-    }
-}
-
-impl Drop for CFsModFmtLoader {
-    fn drop(&mut self) {
-        let api = unsafe{ &*self.api };
-
-        if let Some(free_func) = api.free_callback_context {
-            if !self.callback_context.is_null() {
-                free_func(self.callback_context)
-            }
-        }
-    }
-}
 
 /// @brief Called within a module `loader` function to initialize the new module
 /// @ingroup module_group

--- a/c/src/metta.rs
+++ b/c/src/metta.rs
@@ -839,7 +839,7 @@ pub extern "C" fn metta_new() -> metta_t {
 ///     with their own stdlib, that needs to be loaded before the init.metta file is run
 ///
 #[no_mangle]
-pub extern "C" fn metta_new_with_space_environment_and_stdlib_2(space_ref: *mut space_t,
+pub extern "C" fn metta_new_with_space_environment_and_stdlib(space_ref: *mut space_t,
     env_builder_mov: env_builder_t, stdlib_loader_mov: *mut module_loader_t) -> metta_t
 {
     let dyn_space = unsafe{ &*space_ref }.borrow();
@@ -1274,12 +1274,6 @@ pub extern "C" fn run_context_get_space(run_context: *const run_context_t) -> sp
 pub extern "C" fn run_context_get_tokenizer(run_context: *const run_context_t) -> tokenizer_t {
     let context = unsafe{ &*run_context }.borrow();
     context.module().tokenizer().clone().into()
-}
-
-#[no_mangle]
-pub extern "C" fn run_context_get_own_tokenizer(run_context: *const run_context_t) -> tokenizer_t {
-    let context = unsafe{ &*run_context }.borrow();
-    context.module().own_tokenizer().clone().into()
 }
 
 /// @brief Sets a runtime error

--- a/c/src/metta.rs
+++ b/c/src/metta.rs
@@ -786,7 +786,7 @@ pub extern "C" fn step_get_result(step: step_result_t,
 #[repr(C)]
 pub struct metta_t {
     /// Internal.  Should not be accessed directly
-    metta: *mut RustMettaRunner,
+    metta: *mut RustMetta,
     err_string: *mut c_char,
 }
 
@@ -800,12 +800,12 @@ impl metta_t {
     }
 }
 
-struct RustMettaRunner(Metta);
+struct RustMetta(Metta);
 
 impl From<Metta> for metta_t {
     fn from(metta: Metta) -> Self {
         Self{
-            metta: Box::into_raw(Box::new(RustMettaRunner(metta))),
+            metta: Box::into_raw(Box::new(RustMetta(metta))),
             err_string: core::ptr::null_mut(),
         }
     }

--- a/c/src/metta.rs
+++ b/c/src/metta.rs
@@ -867,7 +867,7 @@ struct CModLoaderWrapper {
     callback_context: *mut c_void,
 }
 
-//FUTURE TODO.  See QUESTION around CFsModFmtLoader about whether we trust the C plugins to be reentrant
+//FUTURE TODO.  See QUESTION around CFsModuleFormat about whether we trust the C plugins to be reentrant
 unsafe impl Send for CModLoaderWrapper {}
 unsafe impl Sync for CModLoaderWrapper {}
 
@@ -1661,20 +1661,13 @@ pub extern "C" fn env_builder_push_include_path(builder: *mut env_builder_t, pat
 /// @brief Adds logic to interpret a foreign format for MeTTa modules loaded from the file system
 /// @ingroup environment_group
 /// @param[in]  builder  A pointer to the in-process environment builder state
-/// @param[in]  api  A pointer to the `mod_file_fmt_api_t` table of functions to define the behavior of the
-///    module format
-/// @param[in]  payload  A pointer to a user-defined structure to store information related to this format
-/// @param[in]  fmt_id  An arbitrary number to ensure modules identified by one format are not mistaken
-///    for another
-/// @warning The data referenced by both the `api` and the `payload` pointers must remain valid for the
-///    entire life of the environment.  In the case of the common_env, that is the entire life of the program
-/// @note Formats will be tried in the order they are added to the `env_builder_t``
+/// @param[in]  format  A pointer to a user-defined structure to store information related to this format
 ///
 #[no_mangle]
-pub extern "C" fn env_builder_push_fs_module_format(builder: *mut env_builder_t, api: *const mod_file_fmt_api_t, payload: *const c_void, fmt_id: u64) {
+pub extern "C" fn env_builder_push_fs_module_format(builder: *mut env_builder_t, format: *const fs_module_format_t) {
     let builder_arg_ref = unsafe{ &mut *builder };
     let builder = core::mem::replace(builder_arg_ref, env_builder_t::null()).into_inner();
-    let c_loader = CFsModFmtLoader::new(api, payload, fmt_id);
+    let c_loader = CFsModuleFormat::new(format);
     let builder = builder.push_fs_module_format(c_loader);
     *builder_arg_ref = builder.into();
 }

--- a/c/src/metta.rs
+++ b/c/src/metta.rs
@@ -790,16 +790,6 @@ pub struct metta_t {
     err_string: *mut c_char,
 }
 
-impl metta_t {
-    fn free_err_string(&mut self) {
-        if !self.err_string.is_null() {
-            let string = unsafe{ std::ffi::CString::from_raw(self.err_string) };
-            drop(string);
-            self.err_string = core::ptr::null_mut();
-        }
-    }
-}
-
 struct RustMetta(Metta);
 
 impl From<Metta> for metta_t {
@@ -812,6 +802,13 @@ impl From<Metta> for metta_t {
 }
 
 impl metta_t {
+    fn free_err_string(&mut self) {
+        if !self.err_string.is_null() {
+            let string = unsafe{ std::ffi::CString::from_raw(self.err_string) };
+            drop(string);
+            self.err_string = core::ptr::null_mut();
+        }
+    }
     fn borrow(&self) -> &Metta {
         &unsafe{ &*self.metta }.0
     }

--- a/c/src/metta.rs
+++ b/c/src/metta.rs
@@ -1036,37 +1036,6 @@ pub extern "C" fn metta_evaluate_atom(metta: *mut metta_t, atom: atom_t,
     }
 }
 
-/// @brief Loads a module directly into the runner using passed module loader
-/// @ingroup interpreter_group
-/// @param[in]  metta  A pointer to the handle specifying the runner into which to load the module
-/// @param[in]  name  A C-string specifying a name for the module
-/// @param[in]  mod_loader An instance of the module loader
-/// @return  The `module_id_t` for the loaded module, or `invalid` if there was an error
-/// @note  This function might be useful to provide MeTTa modules that are built-in as part of your
-///    application
-/// @note If this function encounters an error, the error may be accessed with `metta_err_str()`
-///
-#[no_mangle]
-pub extern "C" fn metta_load_module_direct(metta: *mut metta_t,
-        name: *const c_char,
-        mod_loader: *const module_loader_t) -> module_id_t {
-
-    let metta = unsafe{ &mut *metta };
-    metta.free_err_string();
-    let rust_metta = metta.borrow();
-    let name = cstr_as_str(name);
-    let loader = Box::new(CModuleLoader::new(mod_loader));
-
-    match rust_metta.load_module_direct(loader, name) {
-        Ok(mod_id) => mod_id.into(),
-        Err(err) => {
-            let err_cstring = std::ffi::CString::new(err).unwrap();
-            metta.err_string = err_cstring.into_raw();
-            ModId::INVALID.into()
-        }
-    }
-}
-
 /// @brief Loads a module directly into the runner, from a module_loader_t
 /// @ingroup interpreter_group
 /// @param[in]  metta_ref  A pointer to the handle specifying the runner into which to load the module
@@ -1078,7 +1047,7 @@ pub extern "C" fn metta_load_module_direct(metta: *mut metta_t,
 /// @note If this function encounters an error, the error may be accessed with `metta_err_str()`
 ///
 #[no_mangle]
-pub extern "C" fn metta_load_module_direct_2(metta_ref: *mut metta_t,
+pub extern "C" fn metta_load_module_direct(metta_ref: *mut metta_t,
         name_ref: *const c_char,
         loader_mov: *mut module_loader_t) -> module_id_t {
 

--- a/c/src/metta.rs
+++ b/c/src/metta.rs
@@ -839,8 +839,8 @@ pub extern "C" fn metta_new() -> metta_t {
 ///     with their own stdlib, that needs to be loaded before the init.metta file is run
 ///
 #[no_mangle]
-pub extern "C" fn metta_new_with_space_environment_and_stdlib(space_ref: *mut space_t,
-    env_builder_mov: env_builder_t, stdlib_loader_mov: *mut module_loader_t) -> metta_t
+pub extern "C" fn metta_new_with_stdlib_loader(stdlib_loader_mov: *mut module_loader_t,
+    space_ref: *mut space_t, env_builder_mov: env_builder_t, ) -> metta_t
 {
     let dyn_space = unsafe{ &*space_ref }.borrow();
     let env_builder_mov = if env_builder_mov.is_default() {

--- a/c/src/module.rs
+++ b/c/src/module.rs
@@ -1,0 +1,125 @@
+use hyperon::metta::runner::{Metta, RunContext};
+use hyperon::metta::runner::modules::{MettaMod, ModuleLoader};
+
+use crate::util::*;
+use crate::metta::*;
+
+use std::os::raw::*;
+
+/// @brief MettaMod C API wrapper
+/// @ingroup module_group
+///
+#[repr(C)]
+pub struct metta_mod_ref_t<'a> {
+    module: *const RustMettaMod<'a>,
+}
+
+#[allow(dead_code)]
+struct RustMettaMod<'a>(&'a MettaMod);
+
+impl<'a> From<&'a MettaMod> for metta_mod_ref_t<'a> {
+    fn from(module: &'a MettaMod) -> Self {
+        let module = Box::into_raw(Box::new(RustMettaMod(module)));
+        Self { module }
+    }
+}
+
+/// @brief A C representation of the Rust [ModuleLoader] interface. User can
+/// provide [ModuleLoader] methods implemented in C.
+/// @ingroup module_group
+///
+#[repr(C)] 
+pub struct module_loader_t {
+    /// @brief A function to load the module my making MeTTa API calls.
+    /// @param[in]  loader  The module loader self pointer
+    /// @param[in]  run_context  The `run_context_t` to provide access to the MeTTa run interface
+    /// @return 0 if success, non-zero otherwise; code should put the explanation text
+    /// to the `err` field.
+    load: Option<extern "C" fn(loader: *mut c_void, context: *mut run_context_t) -> isize>,
+    /// @brief Loads module's tokens into target module. This method is used for both
+    /// initial token loading and exporting module's tokens into importing
+    /// module.
+    /// @param[in]  loader  The module loader self pointer
+    /// @param[in]  target  The module to load tokens into
+    /// @param[in]  metta  The context MeTTa runner
+    /// @return 0 if success, non-zero otherwise; code should put the explanation text
+    /// to the `err` field.
+    load_tokens: Option<extern "C" fn(loader: *mut c_void, target: *const metta_mod_ref_t, metta: *const metta_t) -> isize>,
+    /// @brief Prints module loader content as a string, used for implementing
+    /// [std::fmt::Debug].
+    /// @param[in]  loader  The module loader self pointer
+    /// @param[in]  write  Object to write the text into
+    to_string: Option<extern "C" fn(loader: *mut c_void, write: write_t)>,
+    /// @brief Frees module loader and all associated memory
+    /// @param[in]  loader  The module loader self pointer
+    free: Option<extern "C" fn(loader: *mut c_void)>,
+    /// @brief Field which contains last happened error as UTF-8 string. This
+    /// memory should also be cleaned up by [free] function.
+    err: *const c_char,
+}
+
+/// The wrapper of the module_loader_t providing Rust API of the C implementation
+pub struct CModuleLoader {
+    ptr: *mut module_loader_t,
+}
+
+//FUTURE TODO.  See QUESTION around CFsModFmtLoader about whether we trust the C plugins to be reentrant
+unsafe impl Send for CModuleLoader {}
+unsafe impl Sync for CModuleLoader {}
+
+impl CModuleLoader {
+    /// Create new Rust API for the C module loader object
+    pub fn new(cloader: *mut module_loader_t) -> Self {
+        assert!(!cloader.is_null(), "ModuleLoader::load() implementation is required");
+        Self{ ptr: cloader }
+    }
+
+    fn result(&self, rc: isize) -> Result<(), String> {
+        if rc == 0 {
+            Ok(())
+        } else {
+            Err(cstr_into_string(self.cloader().err))
+        }
+    }
+    fn this(&self) -> *mut c_void {
+        self.ptr.cast()
+    }
+    fn cloader(&self) -> &module_loader_t {
+        unsafe{ &*self.ptr }
+    }
+}
+
+impl Drop for CModuleLoader {
+    fn drop(&mut self) {
+        match self.cloader().free {
+            Some(free) => free(self.this()),
+            None => {},
+        }
+    }
+}
+
+impl std::fmt::Debug for CModuleLoader {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self.cloader().to_string {
+            Some(to_string) => CWrite::new(f).with(|w| to_string(self.this(), w.into())),
+            None => write!(f, "CModuleLoader-{:?}", self.ptr),
+        }
+    }
+}
+
+impl ModuleLoader for CModuleLoader {
+    fn load(&self, context: &mut RunContext) -> Result<(), String> {
+        let rc = (self.cloader().load.unwrap())(self.this(), &mut context.into());
+        self.result(rc)
+    }
+
+    fn load_tokens(&self, target: &MettaMod, metta: Metta) -> Result<(), String> {
+        match self.cloader().load_tokens {
+            Some(load_tokens) => {
+                let rc = load_tokens(self.this(), &target.into(), &metta.into());
+                self.result(rc)
+            },
+            None => Ok(()),
+        }
+    }
+}

--- a/c/src/module.rs
+++ b/c/src/module.rs
@@ -1,10 +1,12 @@
 use hyperon::metta::runner::{Metta, RunContext};
-use hyperon::metta::runner::modules::{MettaMod, ModuleLoader};
+use hyperon::metta::runner::modules::{MettaMod, ModuleLoader, ModId, ResourceKey, Resource};
+use hyperon::metta::runner::pkg_mgmt::{FsModuleFormat, ModuleDescriptor};
 
 use crate::util::*;
 use crate::metta::*;
 
 use std::os::raw::*;
+use std::path::{Path, PathBuf};
 
 /// @brief MettaMod C API wrapper
 /// @ingroup module_group
@@ -141,3 +143,302 @@ impl ModuleLoader for CModuleLoader {
         }
     }
 }
+
+/// @brief Identifies the properties on a specific module, including its name and version
+/// @ingroup module_group
+/// @note `module_descriptor_t` objects must be freed with `module_descriptor_free` or passed to
+///    a function that assumes responsibility for freeing them
+///
+#[repr(C)]
+pub struct module_descriptor_t {
+    /// Internal.  Should not be accessed directly
+    descriptor: *mut RustModuleDescriptor,
+}
+
+#[derive(Clone)]
+#[allow(dead_code)] //LP-TODO-NEXT.  Currently we don't do much with module_descriptor_t, but that will change when I make C bindings for the catalog API
+enum RustModuleDescriptor {
+    Descriptor(ModuleDescriptor),
+    Err(String)
+}
+
+impl From<ModuleDescriptor> for module_descriptor_t {
+    fn from(descriptor: ModuleDescriptor) -> Self {
+        Self{ descriptor: Box::into_raw(Box::new(RustModuleDescriptor::Descriptor(descriptor))) }
+    }
+}
+
+//LP-TODO-NEXT.  The "interpreter" documentation group is bloating.  Should break out a separate "runner" group
+//LP-TODO-NEXT.  The Error pathway of the module_descriptor_t is no longer used.  So I can simplify this type
+//LP-TODO-NEXT.  Add an error pathway to run_context_t, that mirrors the error pathway in metta_t, so calls where a run_context_t is passed can propagate errors back to the caller
+//LP-TODO-Next.  Add an error-status result to the callbacks.  At a conceptual level, this error type fundamentally the same exec_error_t / ExecError
+
+impl module_descriptor_t {
+    fn new_err(err: String) -> Self {
+        Self{ descriptor: Box::into_raw(Box::new(RustModuleDescriptor::Err(err))) }
+    }
+    fn new_from_enum(rust_enum: RustModuleDescriptor) -> Self {
+        Self{ descriptor: Box::into_raw(Box::new(rust_enum)) }
+    }
+    fn into_rust_enum(self) -> RustModuleDescriptor {
+        unsafe{ *Box::from_raw(self.descriptor) }
+    }
+    fn borrow_rust_enum(&self) -> &RustModuleDescriptor {
+        unsafe{ &*self.descriptor }
+    }
+    //LP-TODO-NEXT: probably dead code.  Delete soon
+    // fn borrow(&self) -> &ModuleDescriptor {
+    //     match unsafe{ &*self.descriptor } {
+    //         RustModuleDescriptor::Descriptor(desc) => desc,
+    //         RustModuleDescriptor::Err(_err) => panic!("Fatal error.  Attempt to access Error module_descriptor_t")
+    //     }
+    // }
+}
+
+/// @brief Identifies a loaded module inside a specific `metta_t` MeTTa runner
+/// @ingroup module_group
+/// @note It is not necessary to free `module_id_t` types
+///
+#[repr(C)]
+pub struct module_id_t {
+    /// Internal.  Should not be accessed directly
+    id: usize,
+}
+
+impl From<ModId> for module_id_t {
+    fn from(mod_id: ModId) -> Self {
+        module_id_t{ id: mod_id.0 }
+    }
+}
+
+impl module_id_t {
+    pub fn into_inner(self) -> ModId {
+        ModId(self.id)
+    }
+}
+
+/// @brief Returns `true` is a module_id_t is valid, otherwise returns `false`
+/// @ingroup module_group
+/// @param[in]  mod_id  A pointer to the `module_id_t` to test for validity
+/// @return `true` if the module_id_t is valid, otherwise returns `false`
+///
+#[no_mangle]
+pub extern "C" fn module_id_is_valid(mod_id: *const module_id_t) -> bool {
+    let mod_id = unsafe{ &*mod_id };
+    ModId(mod_id.id) != ModId::INVALID
+}
+
+/// @brief Creates a new module_descriptor_t with the specified name
+/// @ingroup module_group
+/// @param[in]  name  A C-style string containing the name of the module
+/// @return The new `module_descriptor_t`
+/// @note The returned `module_descriptor_t` must be freed with `module_descriptor_free()`
+///
+#[no_mangle]
+pub extern "C" fn module_descriptor_new(name: *const c_char) -> module_descriptor_t {
+    //TODO-NEXT: We should probably take a version string, and parse it into a semver version
+    ModuleDescriptor::new(cstr_as_str(name).to_string(), None, None).into()
+}
+
+/// @brief Creates a new module_descriptor_t that represents the error attempting to interpret a module
+/// @ingroup module_group
+/// @param[in]  err_str  A C-style string containing the error message
+/// @return The new error `module_descriptor_t`
+///
+#[no_mangle]
+pub extern "C" fn module_descriptor_error(err_str: *const c_char) -> module_descriptor_t {
+    module_descriptor_t::new_err(cstr_as_str(err_str).to_string()).into()
+}
+
+/// @brief Creates a new module_descriptor_t that is a clone of the argument passed
+/// @ingroup module_group
+/// @param[in]  descriptor  The `module_descriptor_t` to clone
+/// @return The new `module_descriptor_t`
+/// @note The returned `module_descriptor_t` must be freed with `module_descriptor_free()`
+///
+#[no_mangle]
+pub extern "C" fn module_descriptor_clone(descriptor: *const module_descriptor_t) -> module_descriptor_t {
+    let rust_enum = unsafe{ &*descriptor }.borrow_rust_enum();
+    module_descriptor_t::new_from_enum(rust_enum.clone())
+}
+
+/// @brief Frees a module_descriptor_t
+/// @ingroup module_group
+/// @param[in]  descriptor  The `module_descriptor_t` to free
+///
+#[no_mangle]
+pub extern "C" fn module_descriptor_free(descriptor: module_descriptor_t) {
+    let descriptor = descriptor.into_rust_enum();
+    drop(descriptor);
+}
+
+
+/// @struct mod_file_fmt_api_t
+/// @brief A table of functions to load MeTTa modules from an arbitrary format
+/// @ingroup module_group
+/// @warning All of the functions in this interface may be called from threads outside the main
+///    thread, and may be called concurrently.  Therefore these functions must be fully reentrant.
+///
+#[repr(C)]
+pub struct mod_file_fmt_api_t {
+
+    /// @brief Constructs a path for a module with a given name that resides in a parent directory
+    /// @param[in]  payload  The payload passed to `env_builder_push_fs_module_format` when the
+    ///    format was initialized.  This function must not modify the payload
+    /// @param[in]  parent_dir  A NULL-terminated string, representing the path to the parent directory
+    ///    in the file system
+    /// @param[in]  mod_name  A NULL-terminated string, representing the name of the module
+    /// @param[out]  dst_buf  The buffer into which to write the output path, followed by a NULL character
+    /// @param[in]  buf_size  The size of the allocated dst_buf.  This function must not overwrite the
+    ///    output buffer
+    /// @return the number of bytes written into the `dst_buf` by the function, including a NULL terminator
+    ///    character.  If the path does not fit in the `dst_buf`, then this function should return 0
+    /// @note The implementation does not need to check the validity of the returned path.  Results from
+    ///    this method will be passed to `try_path` to perform validity checking
+    ///
+    //QUESTION: The Rust interface allows for a single module loader to check multiple path variations.
+    //    That could be implemented here in the C interface but it would complicate the API functions
+    //    by requiring multiple buffers to be returned, and currently it's not needed.
+    path_for_name: extern "C" fn(payload: *const c_void, parent_dir: *const c_char, mod_name: *const c_char, dst_buf: *mut c_char, buf_size: usize) -> usize,
+
+    /// @brief Tests a path in the file system to determine if a valid module resides at the path
+    /// @param[in]  payload  The payload passed to `env_builder_push_fs_module_format` when the
+    ///    format was initialized.  This function must not modify the payload
+    /// @param[in]  path  A NULL-terminated string, representing a path in the file system to test
+    /// @param[in]  mod_name  A NULL-terminated string, representing the name of the module
+    /// @return any non-NULL value if the `path` contains a valid module in the format, otherwise NULL.
+    ///    If a non-NULL value is returned from this function, it may be passed to the `load` function
+    ///    as the `callback_context` argument.  If a non-NULL value is returned, it will eventually
+    ///    trigger a call to `free_callback_context` so the returned value can be an allocated pointer.
+    ///
+    //TODO: This function will also be responsible for returning a module version, through an [out] arg,
+    // when I add versions in the near future
+    try_path: extern "C" fn(payload: *const c_void, path: *const c_char, mod_name: *const c_char) -> *mut c_void,
+
+    /// @brief Loads the module into the runner, by making calls into the `run_context_t`
+    /// @param[in]  payload  The payload passed to `env_builder_push_fs_module_format` when the
+    ///    format was initialized.  This function must not modify the payload
+    /// @param[in]  run_context  The `run_context_t` to provide access to the MeTTa run interface
+    /// @param[in]  callback_context  The state pointer initially passed to the upstream function
+    ///
+    ///QUESTION: What should the error reporting pathway look like?
+    ///QUESTION: Is it worth trying to unify this function prototype with the `mod_loader_callback_t` type?
+    ///   The argument in favor is that they're fundamentally doing the same thing, but the function params
+    ///   are different on account of having a payload, and removing the `payload` argument complicates the
+    ///   API as it becomes necessary to repackage the payload inside the `callback_context`
+    load: extern "C" fn(payload: *const c_void, run_context: *mut run_context_t, callback_context: *mut c_void),
+
+    /// @brief Frees a user-defined structure that may have been allocated in `try_path`.
+    /// @param[in]  callback_context  The value returned from `try_path`, if it was non-NULL
+    ///
+    free_callback_context: Option<extern "C" fn(callback_context: *mut c_void)>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct CFsModFmtLoader {
+    api: *const mod_file_fmt_api_t,
+    payload: *const c_void,
+    callback_context: *mut c_void,
+    fmt_id: u64,
+}
+
+impl CFsModFmtLoader {
+    pub fn new(api: *const mod_file_fmt_api_t, payload: *const c_void, fmt_id: u64) -> Self {
+        Self {api, payload, callback_context: core::ptr::null_mut(), fmt_id }
+    }
+}
+
+impl Drop for CFsModFmtLoader {
+    fn drop(&mut self) {
+        let api = unsafe{ &*self.api };
+
+        if let Some(free_func) = api.free_callback_context {
+            if !self.callback_context.is_null() {
+                free_func(self.callback_context)
+            }
+        }
+    }
+}
+
+//QUESTION: What should our multi-thread cross-language API look like?  (I am seeing this as establishing
+//  a pattern we can also use for Grounded Atoms, Spaces, etc.)
+//
+//I see several possible approaches:
+// 1.) Let the C implementations ensure their own concurrency.  This preserves the option for optimal speed,
+//  but might invite problems with badly-behaved extensions.  Especially for host languages where the
+//  interpreter is bound to a specific thread such as Python or JavaScript.
+// 2.) Implement a single-threaded API where we transact all interactions with the host language through
+//  queues to a single interface thread.  This is less rope for the user to hang themselves, but will be
+//  a fundamental bottleneck, so I'd prefer not to go this route
+//
+//My strong opinion is we leave the C API unlimited (ie. Option 1).  Then we can implement the queueing
+//  & synchronization for Python within the hyperonpy layer.  My preference would be to undertake
+//  https://github.com/trueagi-io/hyperon-experimental/issues/283 before trying to implement the queueing &
+//  synchronization layer.  My reasoning is that the bug-surface-area will be a lot smaller in Rust than in C++
+unsafe impl Send for CFsModFmtLoader {}
+unsafe impl Sync for CFsModFmtLoader {}
+
+impl FsModuleFormat for CFsModFmtLoader {
+    fn paths_for_name(&self, parent_dir: &Path, mod_name: &str) -> Vec<PathBuf> {
+        let api = unsafe{ &*self.api };
+
+        let parent_dir_c_string = str_as_cstr(parent_dir.to_str().unwrap());
+        let mod_name_c_string = str_as_cstr(mod_name);
+        const BUF_SIZE: usize = 512;
+        let mut buffer = [0 as c_char; BUF_SIZE];
+
+        let bytes_written = (api.path_for_name)(
+            self.payload,
+            parent_dir_c_string.as_ptr(),
+            mod_name_c_string.as_ptr(),
+            buffer.as_mut_ptr(),
+            BUF_SIZE
+        );
+        if bytes_written > 0 {
+            vec![PathBuf::from(cstr_as_str(buffer[0..=bytes_written].as_ptr()))]
+        } else {
+            vec![]
+        }
+    }
+    fn try_path(&self, path: &Path, mod_name: Option<&str>) -> Option<(Box<dyn ModuleLoader>, ModuleDescriptor)> {
+        let api = unsafe{ &*self.api };
+        let path_c_string = str_as_cstr(path.to_str().unwrap());
+        let mod_name = match mod_name {
+            Some(mod_name) => mod_name,
+            None => path.file_stem().unwrap().to_str().unwrap()
+        };
+        let mod_name_c_string = str_as_cstr(mod_name);
+
+        let result_context = (api.try_path)(self.payload, path_c_string.as_ptr(), mod_name_c_string.as_ptr());
+        if !result_context.is_null() {
+            //TODO-NEXT.  We want to provide a way for the loader to support loading a PkgInfo, and also pass
+            // the version from that PkgInfo when the new descriptor is created
+
+            let descriptor = ModuleDescriptor::new_with_path_and_fmt_id(mod_name.to_string(), None, path, self.fmt_id);
+
+            let mut new_loader = self.clone();
+            new_loader.callback_context = result_context;
+            Some((Box::new(new_loader), descriptor))
+        } else {
+            None
+        }
+    }
+}
+
+impl ModuleLoader for CFsModFmtLoader {
+    fn load(&self, context: &mut RunContext) -> Result<(), String> {
+        let api = unsafe{ &*self.api };
+        let mut c_context = run_context_t::from(context);
+
+        (api.load)(self.payload, &mut c_context, self.callback_context);
+        match c_context.take_err_string() {
+            None => Ok(()),
+            Some(err_string) => Err(err_string),
+        }
+    }
+    fn get_resource(&self, _res_key: ResourceKey) -> Result<Resource, String> {
+        //TODO, add C API for providing resources
+        Err("resource not found".to_string())
+    }
+}
+

--- a/c/src/module.rs
+++ b/c/src/module.rs
@@ -1,5 +1,5 @@
 use hyperon::metta::runner::{Metta, RunContext};
-use hyperon::metta::runner::modules::{MettaMod, ModuleLoader, ModId, ResourceKey, Resource};
+use hyperon::metta::runner::modules::{MettaMod, ModuleLoader, ModId};
 use hyperon::metta::runner::pkg_mgmt::{FsModuleFormat, ModuleDescriptor};
 
 use crate::util::*;
@@ -49,7 +49,7 @@ pub struct module_loader_t {
     /// @param[in]  run_context  The `run_context_t` to provide access to the MeTTa run interface
     /// @return 0 if success, non-zero otherwise; code should put the explanation text
     /// to the `err` field.
-    load: Option<extern "C" fn(payload: *mut c_void, context: *mut run_context_t) -> isize>,
+    load: Option<extern "C" fn(payload: *const c_void, context: *mut run_context_t) -> isize>,
     /// @brief Loads module's tokens into target module. This method is used for both
     /// initial token loading and exporting module's tokens into importing
     /// module.
@@ -58,12 +58,12 @@ pub struct module_loader_t {
     /// @param[in]  metta  The context MeTTa runner
     /// @return 0 if success, non-zero otherwise; code should put the explanation text
     /// to the `err` field.
-    load_tokens: Option<extern "C" fn(payload: *mut c_void, target: metta_mod_ref_t, metta: metta_t) -> isize>,
+    load_tokens: Option<extern "C" fn(payload: *const c_void, target: metta_mod_ref_t, metta: metta_t) -> isize>,
     /// @brief Prints module loader content as a string, used for implementing
     /// [std::fmt::Debug].
     /// @param[in]  payload  The module loader self pointer
     /// @param[in]  write  Object to write the text into
-    to_string: Option<extern "C" fn(payload: *mut c_void, write: write_t)>,
+    to_string: Option<extern "C" fn(payload: *const c_void, write: write_t)>,
     /// @brief Frees module loader and all associated memory
     /// @param[in]  payload  The module loader self pointer
     free: Option<extern "C" fn(payload: *mut c_void)>,
@@ -74,16 +74,16 @@ pub struct module_loader_t {
 
 /// The wrapper of the module_loader_t providing Rust API of the C implementation
 pub struct CModuleLoader {
-    payload: *mut module_loader_t,
+    payload: *const module_loader_t,
 }
 
-//FUTURE TODO.  See QUESTION around CFsModFmtLoader about whether we trust the C plugins to be reentrant
+//FUTURE TODO.  See QUESTION around CFsModuleFormat about whether we trust the C plugins to be reentrant
 unsafe impl Send for CModuleLoader {}
 unsafe impl Sync for CModuleLoader {}
 
 impl CModuleLoader {
     /// Create new Rust API for the C module loader object
-    pub fn new(cloader: *mut module_loader_t) -> Self {
+    pub fn new(cloader: *const module_loader_t) -> Self {
         assert!(!cloader.is_null(), "ModuleLoader::load() implementation is required");
         Self{ payload: cloader }
     }
@@ -93,14 +93,14 @@ impl CModuleLoader {
             Ok(())
         } else {
             if self.reference().err.is_null() {
-                Err("Unexpected error while loading tokens".into())
+                Err("Unexpected error while loading module".into())
             } else {
                 Err(cstr_into_string(self.reference().err))
             }
         }
     }
 
-    fn payload(&self) -> *mut c_void {
+    fn payload(&self) -> *const c_void {
         self.payload.cast()
     }
 
@@ -112,7 +112,7 @@ impl CModuleLoader {
 impl Drop for CModuleLoader {
     fn drop(&mut self) {
         match self.reference().free {
-            Some(free) => free(self.payload()),
+            Some(free) => free(self.payload().cast_mut()),
             None => {},
         }
     }
@@ -155,44 +155,67 @@ pub struct module_descriptor_t {
     descriptor: *mut RustModuleDescriptor,
 }
 
-#[derive(Clone)]
-#[allow(dead_code)] //LP-TODO-NEXT.  Currently we don't do much with module_descriptor_t, but that will change when I make C bindings for the catalog API
-enum RustModuleDescriptor {
-    Descriptor(ModuleDescriptor),
-    Err(String)
+struct RustModuleDescriptor(ModuleDescriptor);
+
+impl Default for module_descriptor_t {
+    fn default() -> Self {
+        Self{ descriptor: std::ptr::null_mut() }
+    }
 }
 
 impl From<ModuleDescriptor> for module_descriptor_t {
     fn from(descriptor: ModuleDescriptor) -> Self {
-        Self{ descriptor: Box::into_raw(Box::new(RustModuleDescriptor::Descriptor(descriptor))) }
+        Self{ descriptor: Box::into_raw(Box::new(RustModuleDescriptor(descriptor))) }
     }
 }
 
-//LP-TODO-NEXT.  The "interpreter" documentation group is bloating.  Should break out a separate "runner" group
-//LP-TODO-NEXT.  The Error pathway of the module_descriptor_t is no longer used.  So I can simplify this type
-//LP-TODO-NEXT.  Add an error pathway to run_context_t, that mirrors the error pathway in metta_t, so calls where a run_context_t is passed can propagate errors back to the caller
-//LP-TODO-Next.  Add an error-status result to the callbacks.  At a conceptual level, this error type fundamentally the same exec_error_t / ExecError
-
 impl module_descriptor_t {
-    fn new_err(err: String) -> Self {
-        Self{ descriptor: Box::into_raw(Box::new(RustModuleDescriptor::Err(err))) }
+    fn into_inner(self) -> ModuleDescriptor {
+        assert!(!self.descriptor.is_null());
+        unsafe{ *Box::from_raw(self.descriptor) }.0
     }
-    fn new_from_enum(rust_enum: RustModuleDescriptor) -> Self {
-        Self{ descriptor: Box::into_raw(Box::new(rust_enum)) }
+    fn borrow(&self) -> &ModuleDescriptor {
+        assert!(!self.descriptor.is_null());
+        &unsafe{ &*self.descriptor }.0
     }
-    fn into_rust_enum(self) -> RustModuleDescriptor {
-        unsafe{ *Box::from_raw(self.descriptor) }
-    }
-    fn borrow_rust_enum(&self) -> &RustModuleDescriptor {
-        unsafe{ &*self.descriptor }
-    }
-    //LP-TODO-NEXT: probably dead code.  Delete soon
-    // fn borrow(&self) -> &ModuleDescriptor {
-    //     match unsafe{ &*self.descriptor } {
-    //         RustModuleDescriptor::Descriptor(desc) => desc,
-    //         RustModuleDescriptor::Err(_err) => panic!("Fatal error.  Attempt to access Error module_descriptor_t")
-    //     }
-    // }
+}
+
+/// @brief Creates a new module_descriptor_t with the specified name
+/// @ingroup module_group
+/// @param[in]  name  A C-style string containing the name of the module
+/// @return The new `module_descriptor_t`
+/// @note The returned `module_descriptor_t` must be freed with `module_descriptor_free()`
+///
+#[no_mangle]
+pub extern "C" fn module_descriptor_new(name: *const c_char) -> module_descriptor_t {
+    ModuleDescriptor::new(cstr_as_str(name).to_string(), None, None).into()
+}
+
+#[no_mangle]
+pub extern "C" fn module_descriptor_new_with_path_and_fmt_id(name: *const c_char,
+        path: *const c_char, fmt_id: u64) -> module_descriptor_t {
+    ModuleDescriptor::new_with_path_and_fmt_id(cstr_as_str(name).to_string(), None, Path::new(cstr_as_str(path)), fmt_id).into()
+}
+
+/// @brief Creates a new module_descriptor_t that is a clone of the argument passed
+/// @ingroup module_group
+/// @param[in]  descriptor  The `module_descriptor_t` to clone
+/// @return The new `module_descriptor_t`
+/// @note The returned `module_descriptor_t` must be freed with `module_descriptor_free()`
+///
+#[no_mangle]
+pub extern "C" fn module_descriptor_clone(descriptor: *const module_descriptor_t) -> module_descriptor_t {
+    let rust_descriptor = unsafe{ &*descriptor }.borrow();
+    rust_descriptor.clone().into()
+}
+
+/// @brief Frees a module_descriptor_t
+/// @ingroup module_group
+/// @param[in]  descriptor  The `module_descriptor_t` to free
+///
+#[no_mangle]
+pub extern "C" fn module_descriptor_free(descriptor: module_descriptor_t) {
+    drop(descriptor.into_inner());
 }
 
 /// @brief Identifies a loaded module inside a specific `metta_t` MeTTa runner
@@ -228,63 +251,18 @@ pub extern "C" fn module_id_is_valid(mod_id: *const module_id_t) -> bool {
     ModId(mod_id.id) != ModId::INVALID
 }
 
-/// @brief Creates a new module_descriptor_t with the specified name
-/// @ingroup module_group
-/// @param[in]  name  A C-style string containing the name of the module
-/// @return The new `module_descriptor_t`
-/// @note The returned `module_descriptor_t` must be freed with `module_descriptor_free()`
-///
-#[no_mangle]
-pub extern "C" fn module_descriptor_new(name: *const c_char) -> module_descriptor_t {
-    //TODO-NEXT: We should probably take a version string, and parse it into a semver version
-    ModuleDescriptor::new(cstr_as_str(name).to_string(), None, None).into()
-}
 
-/// @brief Creates a new module_descriptor_t that represents the error attempting to interpret a module
-/// @ingroup module_group
-/// @param[in]  err_str  A C-style string containing the error message
-/// @return The new error `module_descriptor_t`
-///
-#[no_mangle]
-pub extern "C" fn module_descriptor_error(err_str: *const c_char) -> module_descriptor_t {
-    module_descriptor_t::new_err(cstr_as_str(err_str).to_string()).into()
-}
-
-/// @brief Creates a new module_descriptor_t that is a clone of the argument passed
-/// @ingroup module_group
-/// @param[in]  descriptor  The `module_descriptor_t` to clone
-/// @return The new `module_descriptor_t`
-/// @note The returned `module_descriptor_t` must be freed with `module_descriptor_free()`
-///
-#[no_mangle]
-pub extern "C" fn module_descriptor_clone(descriptor: *const module_descriptor_t) -> module_descriptor_t {
-    let rust_enum = unsafe{ &*descriptor }.borrow_rust_enum();
-    module_descriptor_t::new_from_enum(rust_enum.clone())
-}
-
-/// @brief Frees a module_descriptor_t
-/// @ingroup module_group
-/// @param[in]  descriptor  The `module_descriptor_t` to free
-///
-#[no_mangle]
-pub extern "C" fn module_descriptor_free(descriptor: module_descriptor_t) {
-    let descriptor = descriptor.into_rust_enum();
-    drop(descriptor);
-}
-
-
-/// @struct mod_file_fmt_api_t
+/// @struct fs_module_format_t
 /// @brief A table of functions to load MeTTa modules from an arbitrary format
 /// @ingroup module_group
 /// @warning All of the functions in this interface may be called from threads outside the main
 ///    thread, and may be called concurrently.  Therefore these functions must be fully reentrant.
 ///
 #[repr(C)]
-pub struct mod_file_fmt_api_t {
+pub struct fs_module_format_t {
 
     /// @brief Constructs a path for a module with a given name that resides in a parent directory
-    /// @param[in]  payload  The payload passed to `env_builder_push_fs_module_format` when the
-    ///    format was initialized.  This function must not modify the payload
+    /// @param[in]  payload  The reference to the this instance of the fs_module_format_t
     /// @param[in]  parent_dir  A NULL-terminated string, representing the path to the parent directory
     ///    in the file system
     /// @param[in]  mod_name  A NULL-terminated string, representing the name of the module
@@ -296,66 +274,50 @@ pub struct mod_file_fmt_api_t {
     /// @note The implementation does not need to check the validity of the returned path.  Results from
     ///    this method will be passed to `try_path` to perform validity checking
     ///
-    //QUESTION: The Rust interface allows for a single module loader to check multiple path variations.
-    //    That could be implemented here in the C interface but it would complicate the API functions
-    //    by requiring multiple buffers to be returned, and currently it's not needed.
     path_for_name: extern "C" fn(payload: *const c_void, parent_dir: *const c_char, mod_name: *const c_char, dst_buf: *mut c_char, buf_size: usize) -> usize,
 
     /// @brief Tests a path in the file system to determine if a valid module resides at the path
-    /// @param[in]  payload  The payload passed to `env_builder_push_fs_module_format` when the
-    ///    format was initialized.  This function must not modify the payload
+    /// @param[in]  payload  The reference to the this instance of the fs_module_format_t
     /// @param[in]  path  A NULL-terminated string, representing a path in the file system to test
     /// @param[in]  mod_name  A NULL-terminated string, representing the name of the module
-    /// @return any non-NULL value if the `path` contains a valid module in the format, otherwise NULL.
-    ///    If a non-NULL value is returned from this function, it may be passed to the `load` function
-    ///    as the `callback_context` argument.  If a non-NULL value is returned, it will eventually
-    ///    trigger a call to `free_callback_context` so the returned value can be an allocated pointer.
+    /// @param[out]  mod_loader  A module loader instance owned by caller
+    /// @param[out]  mod_descriptor  A module descriptor instance owned by caller
+    /// @return bool true if the `path` contains a valid module in the format, otherwise false.
     ///
     //TODO: This function will also be responsible for returning a module version, through an [out] arg,
     // when I add versions in the near future
-    try_path: extern "C" fn(payload: *const c_void, path: *const c_char, mod_name: *const c_char) -> *mut c_void,
-
-    /// @brief Loads the module into the runner, by making calls into the `run_context_t`
-    /// @param[in]  payload  The payload passed to `env_builder_push_fs_module_format` when the
-    ///    format was initialized.  This function must not modify the payload
-    /// @param[in]  run_context  The `run_context_t` to provide access to the MeTTa run interface
-    /// @param[in]  callback_context  The state pointer initially passed to the upstream function
-    ///
-    ///QUESTION: What should the error reporting pathway look like?
-    ///QUESTION: Is it worth trying to unify this function prototype with the `mod_loader_callback_t` type?
-    ///   The argument in favor is that they're fundamentally doing the same thing, but the function params
-    ///   are different on account of having a payload, and removing the `payload` argument complicates the
-    ///   API as it becomes necessary to repackage the payload inside the `callback_context`
-    load: extern "C" fn(payload: *const c_void, run_context: *mut run_context_t, callback_context: *mut c_void),
+    try_path: extern "C" fn(payload: *const c_void, path: *const c_char, mod_name: *const c_char, mod_loader: *mut *const module_loader_t, mod_descriptor: *mut module_descriptor_t) -> bool,
 
     /// @brief Frees a user-defined structure that may have been allocated in `try_path`.
     /// @param[in]  callback_context  The value returned from `try_path`, if it was non-NULL
     ///
-    free_callback_context: Option<extern "C" fn(callback_context: *mut c_void)>,
+    free: Option<extern "C" fn(payload: *mut c_void)>,
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct CFsModFmtLoader {
-    api: *const mod_file_fmt_api_t,
-    payload: *const c_void,
-    callback_context: *mut c_void,
-    fmt_id: u64,
+pub(crate) struct CFsModuleFormat {
+    payload: *const fs_module_format_t,
 }
 
-impl CFsModFmtLoader {
-    pub fn new(api: *const mod_file_fmt_api_t, payload: *const c_void, fmt_id: u64) -> Self {
-        Self {api, payload, callback_context: core::ptr::null_mut(), fmt_id }
+impl CFsModuleFormat {
+    pub fn new(payload: *const fs_module_format_t) -> Self {
+        Self { payload }
+    }
+
+    fn payload(&self) -> *const c_void {
+        self.payload.cast()
+    }
+
+    fn reference(&self) -> &fs_module_format_t {
+        unsafe{ &*self.payload }
     }
 }
 
-impl Drop for CFsModFmtLoader {
+impl Drop for CFsModuleFormat {
     fn drop(&mut self) {
-        let api = unsafe{ &*self.api };
-
-        if let Some(free_func) = api.free_callback_context {
-            if !self.callback_context.is_null() {
-                free_func(self.callback_context)
-            }
+        match self.reference().free {
+            Some(free) => free(self.payload().cast_mut()),
+            None => {},
         }
     }
 }
@@ -375,20 +337,18 @@ impl Drop for CFsModFmtLoader {
 //  & synchronization for Python within the hyperonpy layer.  My preference would be to undertake
 //  https://github.com/trueagi-io/hyperon-experimental/issues/283 before trying to implement the queueing &
 //  synchronization layer.  My reasoning is that the bug-surface-area will be a lot smaller in Rust than in C++
-unsafe impl Send for CFsModFmtLoader {}
-unsafe impl Sync for CFsModFmtLoader {}
+unsafe impl Send for CFsModuleFormat {}
+unsafe impl Sync for CFsModuleFormat {}
 
-impl FsModuleFormat for CFsModFmtLoader {
+impl FsModuleFormat for CFsModuleFormat {
     fn paths_for_name(&self, parent_dir: &Path, mod_name: &str) -> Vec<PathBuf> {
-        let api = unsafe{ &*self.api };
-
         let parent_dir_c_string = str_as_cstr(parent_dir.to_str().unwrap());
         let mod_name_c_string = str_as_cstr(mod_name);
         const BUF_SIZE: usize = 512;
         let mut buffer = [0 as c_char; BUF_SIZE];
 
-        let bytes_written = (api.path_for_name)(
-            self.payload,
+        let bytes_written = (self.reference().path_for_name)(
+            self.payload(),
             parent_dir_c_string.as_ptr(),
             mod_name_c_string.as_ptr(),
             buffer.as_mut_ptr(),
@@ -401,7 +361,6 @@ impl FsModuleFormat for CFsModFmtLoader {
         }
     }
     fn try_path(&self, path: &Path, mod_name: Option<&str>) -> Option<(Box<dyn ModuleLoader>, ModuleDescriptor)> {
-        let api = unsafe{ &*self.api };
         let path_c_string = str_as_cstr(path.to_str().unwrap());
         let mod_name = match mod_name {
             Some(mod_name) => mod_name,
@@ -409,36 +368,16 @@ impl FsModuleFormat for CFsModFmtLoader {
         };
         let mod_name_c_string = str_as_cstr(mod_name);
 
-        let result_context = (api.try_path)(self.payload, path_c_string.as_ptr(), mod_name_c_string.as_ptr());
-        if !result_context.is_null() {
-            //TODO-NEXT.  We want to provide a way for the loader to support loading a PkgInfo, and also pass
-            // the version from that PkgInfo when the new descriptor is created
-
-            let descriptor = ModuleDescriptor::new_with_path_and_fmt_id(mod_name.to_string(), None, path, self.fmt_id);
-
-            let mut new_loader = self.clone();
-            new_loader.callback_context = result_context;
-            Some((Box::new(new_loader), descriptor))
+        let mut mod_loader: *const module_loader_t = std::ptr::null(); 
+        let mut mod_descriptor: module_descriptor_t = Default::default();
+        let found = (self.reference().try_path)(self.payload(), path_c_string.as_ptr(), mod_name_c_string.as_ptr(), &mut mod_loader, &mut mod_descriptor);
+        if found {
+            let descriptor = mod_descriptor.into_inner();
+            let loader = CModuleLoader::new(mod_loader);
+            Some((Box::new(loader), descriptor))
         } else {
             None
         }
-    }
-}
-
-impl ModuleLoader for CFsModFmtLoader {
-    fn load(&self, context: &mut RunContext) -> Result<(), String> {
-        let api = unsafe{ &*self.api };
-        let mut c_context = run_context_t::from(context);
-
-        (api.load)(self.payload, &mut c_context, self.callback_context);
-        match c_context.take_err_string() {
-            None => Ok(()),
-            Some(err_string) => Err(err_string),
-        }
-    }
-    fn get_resource(&self, _res_key: ResourceKey) -> Result<Resource, String> {
-        //TODO, add C API for providing resources
-        Err("resource not found".to_string())
     }
 }
 

--- a/c/tests/check_runner.c
+++ b/c/tests/check_runner.c
@@ -173,7 +173,7 @@ START_TEST (test_custom_module_format)
 
     //Start by initializing a runner using an environment with our custom module format
     space_t space = space_new_grounding_space();
-    metta_t runner = metta_new_with_space_environment_and_stdlib(&space, env_builder, NULL);
+    metta_t runner = metta_new_with_stdlib_loader(NULL, &space, env_builder);
     space_free(space);
 
     //Load a module using our custom format, and verify it was loaded sucessfully
@@ -214,7 +214,7 @@ START_TEST (test_custom_stdlib)
     module_loader_t* stdlib_loader = calloc(sizeof(module_loader_t), 1);
     stdlib_loader->load = custom_stdlib_loader;
     stdlib_loader->free = free;
-    metta_t runner = metta_new_with_space_environment_and_stdlib(&space, env_builder_use_test_env(), stdlib_loader);
+    metta_t runner = metta_new_with_stdlib_loader(stdlib_loader, &space, env_builder_use_test_env());
     space_free(space);
 
     //Test that we can match an atom loaded from the custom stdlib function

--- a/c/tests/check_runner.c
+++ b/c/tests/check_runner.c
@@ -96,7 +96,7 @@ START_TEST (test_runner_errors)
 }
 END_TEST
 
-ssize_t load(void const* payload, run_context_t* run_context) {
+ssize_t load(void const* payload, run_context_t* run_context, write_t err) {
     space_t space = space_new_grounding_space();
     run_context_init_self_module(run_context, &space, NULL);
     space_free(space);
@@ -189,7 +189,7 @@ START_TEST (test_custom_module_format)
 }
 END_TEST
 
-ssize_t custom_stdlib_loader(void const* loader, run_context_t *run_context) {
+ssize_t custom_stdlib_loader(void const* loader, run_context_t *run_context, write_t err) {
 
     //Init our new module
     space_t space = space_new_grounding_space();

--- a/c/tests/check_runner.c
+++ b/c/tests/check_runner.c
@@ -173,7 +173,7 @@ START_TEST (test_custom_module_format)
 
     //Start by initializing a runner using an environment with our custom module format
     space_t space = space_new_grounding_space();
-    metta_t runner = metta_new_with_space_environment_and_stdlib_2(&space, env_builder, NULL);
+    metta_t runner = metta_new_with_space_environment_and_stdlib(&space, env_builder, NULL);
     space_free(space);
 
     //Load a module using our custom format, and verify it was loaded sucessfully
@@ -214,7 +214,7 @@ START_TEST (test_custom_stdlib)
     module_loader_t* stdlib_loader = calloc(sizeof(module_loader_t), 1);
     stdlib_loader->load = custom_stdlib_loader;
     stdlib_loader->free = free;
-    metta_t runner = metta_new_with_space_environment_and_stdlib_2(&space, env_builder_use_test_env(), stdlib_loader);
+    metta_t runner = metta_new_with_space_environment_and_stdlib(&space, env_builder_use_test_env(), stdlib_loader);
     space_free(space);
 
     //Test that we can match an atom loaded from the custom stdlib function

--- a/c/tests/check_runner.c
+++ b/c/tests/check_runner.c
@@ -166,7 +166,7 @@ START_TEST (test_custom_module_format)
 
     //Start by initializing a runner using an environment with our custom module format
     space_t space = space_new_grounding_space();
-    metta_t runner = metta_new_with_space_environment_and_stdlib(&space, env_builder, NULL, NULL);
+    metta_t runner = metta_new_with_space_environment_and_stdlib_2(&space, env_builder, NULL);
     space_free(space);
 
     //Load a module using our custom format, and verify it was loaded sucessfully
@@ -182,7 +182,7 @@ START_TEST (test_custom_module_format)
 }
 END_TEST
 
-void custom_stdlib_loader(run_context_t *run_context, void* callback_context) {
+ssize_t custom_stdlib_loader(void* loader, run_context_t *run_context) {
 
     //Init our new module
     space_t space = space_new_grounding_space();
@@ -196,13 +196,18 @@ void custom_stdlib_loader(run_context_t *run_context, void* callback_context) {
     //Load a custom atom using the MeTTa syntax
     sexpr_parser_t parser = sexpr_parser_new("test-atom");
     run_context_push_parser(run_context, parser);
+
+    return 0;
 }
 
 START_TEST (test_custom_stdlib)
 {
     //Start by initializing a runner using our custom stdlib loader
     space_t space = space_new_grounding_space();
-    metta_t runner = metta_new_with_space_environment_and_stdlib(&space, env_builder_use_test_env(), &custom_stdlib_loader, NULL);
+    module_loader_t* stdlib_loader = calloc(sizeof(module_loader_t), 1);
+    stdlib_loader->load = custom_stdlib_loader;
+    stdlib_loader->free = free;
+    metta_t runner = metta_new_with_space_environment_and_stdlib_2(&space, env_builder_use_test_env(), stdlib_loader);
     space_free(space);
 
     //Test that we can match an atom loaded from the custom stdlib function

--- a/c/tests/util.c
+++ b/c/tests/util.c
@@ -32,7 +32,7 @@ atom_t expr(atom_t atom, ...) {
 
 metta_t new_test_metta(void) {
     space_t space = space_new_grounding_space();
-    metta_t metta = metta_new_with_space_environment_and_stdlib_2(&space, env_builder_use_test_env(), NULL);
+    metta_t metta = metta_new_with_space_environment_and_stdlib(&space, env_builder_use_test_env(), NULL);
     space_free(space);
     return metta;
 }

--- a/c/tests/util.c
+++ b/c/tests/util.c
@@ -32,7 +32,7 @@ atom_t expr(atom_t atom, ...) {
 
 metta_t new_test_metta(void) {
     space_t space = space_new_grounding_space();
-    metta_t metta = metta_new_with_space_environment_and_stdlib(&space, env_builder_use_test_env(), NULL);
+    metta_t metta = metta_new_with_stdlib_loader(NULL, &space, env_builder_use_test_env());
     space_free(space);
     return metta;
 }

--- a/c/tests/util.c
+++ b/c/tests/util.c
@@ -32,7 +32,7 @@ atom_t expr(atom_t atom, ...) {
 
 metta_t new_test_metta(void) {
     space_t space = space_new_grounding_space();
-    metta_t metta = metta_new_with_space_environment_and_stdlib(&space, env_builder_use_test_env(), NULL, NULL);
+    metta_t metta = metta_new_with_space_environment_and_stdlib_2(&space, env_builder_use_test_env(), NULL);
     space_free(space);
     return metta;
 }

--- a/lib/src/metta/runner/builtin_mods/catalog_mods.rs
+++ b/lib/src/metta/runner/builtin_mods/catalog_mods.rs
@@ -57,10 +57,10 @@ impl ModuleLoader for CatalogModLoader {
     fn load(&self, context: &mut RunContext) -> Result<(), String> {
         let space = DynSpace::new(GroundingSpace::new());
         context.init_self_module(space, None);
-        self.load_tokens(context.module(), context.metta)
+        self.load_tokens(context.module(), context.metta.clone())
     }
 
-    fn load_tokens(&self, target: &MettaMod, metta: &Metta) -> Result<(), String> {
+    fn load_tokens(&self, target: &MettaMod, metta: Metta) -> Result<(), String> {
         let mut tref = target.tokenizer().borrow_mut();
 
         let catalog_list_op = Atom::gnd(CatalogListOp::new(metta.clone()));

--- a/lib/src/metta/runner/builtin_mods/skel.rs
+++ b/lib/src/metta/runner/builtin_mods/skel.rs
@@ -1,7 +1,7 @@
 use crate::metta::*;
 use crate::space::grounding::GroundingSpace;
 use crate::metta::text::SExprParser;
-use crate::metta::runner::{ModuleLoader, RunContext, DynSpace};
+use crate::metta::runner::{ModuleLoader, RunContext, DynSpace, Metta, MettaMod};
 use crate::atom::gnd::*;
 
 pub static SKEL_METTA: &'static str = include_str!("skel.metta");
@@ -16,10 +16,7 @@ impl ModuleLoader for SkelModLoader {
         context.init_self_module(space, None);
 
         // Load module's tokens
-        context.module().register_method(GroundedFunctionAtom::new(
-                r"skel-swap-pair-native".into(),
-                expr!("->" ("PairType" ta tb) ("PairType" tb ta)),
-                skel_swap_pair_native));
+        let _ = self.load_tokens(context.module(), context.metta)?;
 
         // Parse MeTTa code of the module
         let parser = SExprParser::new(SKEL_METTA);
@@ -28,6 +25,16 @@ impl ModuleLoader for SkelModLoader {
         Ok(())
     }
 
+    fn load_tokens(&self, target: &MettaMod, _metta: &Metta) -> Result<(), String> {
+        let mut tref = target.tokenizer().borrow_mut();
+
+        tref.register_function(GroundedFunctionAtom::new(
+                r"skel-swap-pair-native".into(),
+                expr!("->" ("PairType" ta tb) ("PairType" tb ta)),
+                skel_swap_pair_native));
+
+        Ok(())
+    }
 }
 
 fn skel_swap_pair_native(args: &[Atom]) -> Result<Vec<Atom>, ExecError> {

--- a/lib/src/metta/runner/builtin_mods/skel.rs
+++ b/lib/src/metta/runner/builtin_mods/skel.rs
@@ -16,7 +16,7 @@ impl ModuleLoader for SkelModLoader {
         context.init_self_module(space, None);
 
         // Load module's tokens
-        let _ = self.load_tokens(context.module(), context.metta)?;
+        let _ = self.load_tokens(context.module(), context.metta.clone())?;
 
         // Parse MeTTa code of the module
         let parser = SExprParser::new(SKEL_METTA);
@@ -25,7 +25,7 @@ impl ModuleLoader for SkelModLoader {
         Ok(())
     }
 
-    fn load_tokens(&self, target: &MettaMod, _metta: &Metta) -> Result<(), String> {
+    fn load_tokens(&self, target: &MettaMod, _metta: Metta) -> Result<(), String> {
         let mut tref = target.tokenizer().borrow_mut();
 
         tref.register_function(GroundedFunctionAtom::new(

--- a/lib/src/metta/runner/modules/mod.rs
+++ b/lib/src/metta/runner/modules/mod.rs
@@ -206,7 +206,7 @@ impl MettaMod {
 
         // Finally, Import the tokens from the dependency
         match &mod_ptr.loader {
-            Some(loader) => loader.load_tokens(self, metta),
+            Some(loader) => loader.load_tokens(self, metta.clone()),
             None => Ok(()), // no tokens are exported by mod_ptr
         }
     }
@@ -602,7 +602,7 @@ pub trait ModuleLoader: std::fmt::Debug + Send + Sync {
     /// Loads module's tokens into target module. This method is used for both
     /// initial token loading and exporting module's tokens into importing
     /// module.
-    fn load_tokens(&self, _target: &MettaMod, _metta: &Metta) -> Result<(), String> {
+    fn load_tokens(&self, _target: &MettaMod, _metta: Metta) -> Result<(), String> {
         Ok(())
     }
 }

--- a/lib/src/metta/runner/modules/mod.rs
+++ b/lib/src/metta/runner/modules/mod.rs
@@ -58,6 +58,7 @@ pub struct MettaMod {
     resource_dir: Option<PathBuf>,
     space: Rc<RefCell<ModuleSpace>>,
     tokenizer: Shared<Tokenizer>,
+    // FIXME: remove own_tokenizer from everywhere
     own_tokenizer: Shared<Tokenizer>,
     imported_deps: Mutex<HashMap<ModId, DynSpace>>,
     loader: Option<Box<dyn ModuleLoader>>,

--- a/lib/src/metta/runner/modules/mod.rs
+++ b/lib/src/metta/runner/modules/mod.rs
@@ -58,8 +58,6 @@ pub struct MettaMod {
     resource_dir: Option<PathBuf>,
     space: Rc<RefCell<ModuleSpace>>,
     tokenizer: Shared<Tokenizer>,
-    // FIXME: remove own_tokenizer from everywhere
-    own_tokenizer: Shared<Tokenizer>,
     imported_deps: Mutex<HashMap<ModId, DynSpace>>,
     loader: Option<Box<dyn ModuleLoader>>,
 }
@@ -78,13 +76,11 @@ impl MettaMod {
             }
         }
         let space = Rc::new(RefCell::new(ModuleSpace::new(space)));
-        let own_tokenizer  = Shared::new(Tokenizer::new());
 
         let new_mod = Self {
             mod_path,
             space,
             tokenizer,
-            own_tokenizer,
             imported_deps: Mutex::new(HashMap::new()),
             resource_dir,
             loader: None,
@@ -272,10 +268,6 @@ impl MettaMod {
 
     pub fn tokenizer(&self) -> &Shared<Tokenizer> {
         &self.tokenizer
-    }
-
-    pub fn own_tokenizer(&self) -> &Shared<Tokenizer> {
-        &self.own_tokenizer
     }
 
     pub fn resource_dir(&self) -> Option<&Path> {

--- a/lib/src/metta/runner/stdlib/mod.rs
+++ b/lib/src/metta/runner/stdlib/mod.rs
@@ -132,17 +132,17 @@ impl ModuleLoader for CoreLibLoader {
         let space = DynSpace::new(GroundingSpace::new());
         context.init_self_module(space, None);
 
-        self.load_tokens(context.module(), context.metta)?;
+        self.load_tokens(context.module(), context.metta.clone())?;
 
         let parser = SExprParser::new(METTA_CODE);
         context.push_parser(Box::new(parser));
         Ok(())
     }
 
-    fn load_tokens(&self, target: &MettaMod, metta: &Metta) -> Result<(), String> {
+    fn load_tokens(&self, target: &MettaMod, metta: Metta) -> Result<(), String> {
         let tokenizer = target.tokenizer();
         register_all_corelib_tokens(tokenizer.borrow_mut().deref_mut(),
-            tokenizer.clone(), &target.space(), metta);
+            tokenizer.clone(), &target.space(), &metta);
         Ok(())
     }
 }

--- a/lib/src/metta/runner/stdlib/mod.rs
+++ b/lib/src/metta/runner/stdlib/mod.rs
@@ -17,6 +17,7 @@ use crate::metta::*;
 use crate::metta::text::{Tokenizer, SExprParser};
 use crate::common::shared::Shared;
 use crate::metta::runner::{Metta, RunContext, ModuleLoader, PragmaSettings};
+use crate::metta::runner::modules::MettaMod;
 
 use regex::Regex;
 
@@ -131,12 +132,17 @@ impl ModuleLoader for CoreLibLoader {
         let space = DynSpace::new(GroundingSpace::new());
         context.init_self_module(space, None);
 
-        let module = context.module();
-        let tokenizer = module.tokenizer();
-        register_all_corelib_tokens(tokenizer.borrow_mut().deref_mut(), tokenizer.clone(), &module.space(), context.metta);
+        self.load_tokens(context.module(), context.metta)?;
 
         let parser = SExprParser::new(METTA_CODE);
         context.push_parser(Box::new(parser));
+        Ok(())
+    }
+
+    fn load_tokens(&self, target: &MettaMod, metta: &Metta) -> Result<(), String> {
+        let tokenizer = target.tokenizer();
+        register_all_corelib_tokens(tokenizer.borrow_mut().deref_mut(),
+            tokenizer.clone(), &target.space(), metta);
         Ok(())
     }
 }

--- a/lib/src/metta/text.rs
+++ b/lib/src/metta/text.rs
@@ -1,6 +1,7 @@
 //! MeTTa parser implementation.
 
 use crate::*;
+use crate::gnd::*;
 
 use core::ops::Range;
 use std::iter::Peekable;
@@ -46,6 +47,12 @@ impl Tokenizer {
 
     pub fn register_token_with_regex_str<C: 'static + Fn(&str) -> Atom>(&mut self, regex: &str, constr: C) {
         let regex = Regex::new(regex).unwrap();
+        self.register_token(regex, constr)
+    }
+
+    pub fn register_function<T: 'static + GroundedFunction>(&mut self, func: GroundedFunctionAtom<T>) {
+        let regex = Regex::new(func.name()).unwrap();
+        let constr = move |_token: &str| -> Atom { Atom::gnd(func.clone()) };
         self.register_token(regex, constr)
     }
 

--- a/python/hyperon/module.py
+++ b/python/hyperon/module.py
@@ -1,0 +1,13 @@
+from .base import Tokenizer
+
+class MettaModRef:
+    """Class represents a reference to the MeTTa module structure. It is a
+    wrapper of the reference to the corresponding Rust class."""
+
+    def __init__(self, cmodref):
+        """Initialize wrapper"""
+        self.cmodref = cmodref
+
+    def tokenizer(self):
+        """Returns module's tokenizer instance"""
+        return Tokenizer._from_ctokenizer(self.cmodref.tokenizer())

--- a/python/hyperon/runner.py
+++ b/python/hyperon/runner.py
@@ -311,7 +311,10 @@ class _PyFileMeTTaModFmt:
 def _priv_load_module(mod_name, path, c_run_context):
     """Loads the items from the python module into the runner as a MeTTa module"""
     run_context = RunContext(c_run_context)
-    resource_dir = os.path.dirname(path)
+    if path is not None:
+        resource_dir = os.path.dirname(path)
+    else:
+        resource_dir = None
     space = GroundingSpaceRef()
     run_context.init_self_module(space, resource_dir)
     return _priv_register_module_tokens_no_exception(mod_name,
@@ -327,37 +330,6 @@ def _priv_load_module_tokens(mod_name, cmettamod, cmetta):
     metta = MeTTa(cmetta=cmetta)
     return _priv_register_module_tokens_no_exception(mod_name, tokenizer, metta)
 
-def _priv_load_py_stdlib(c_run_context):
-    """
-    Private function called indirectly to load the Python stdlib during Python runner initialization
-    """
-    run_context = RunContext(c_run_context)
-    space = GroundingSpaceRef()
-    run_context.init_self_module(space, None)
-    return _priv_register_module_tokens_no_exception("hyperon.stdlib",
-                                                   run_context.tokenizer(),
-                                                   run_context.metta())
-
-    # #LP-TODO-Next Make a test for loading a metta module from a python module using load_module_direct_from_pymod
-
-    # #LP-TODO-Next Also make a test for a module that loads another module
-    # py_stdlib_id = run_context.metta().load_module_direct_from_pymod("stdlib-py", descriptor, "hyperon.stdlib")
-    # run_context.import_dependency(py_stdlib_id)
-
-    # #LP-TODO-Next Implement a Catalog that uses the Python module-space, so that any module loaded via `pip`
-    # can be found by MeTTa.  NOTE: We may want to explicitly give priority hyperon "exts" by first checking if Python
-    # has a module at `"hyperon.exts." + mod_name` before just checking `mod_name`, but it's unclear that will
-    # matter since we'll also search the `exts` directory with the include_path / fs_module_format logic
-    # #UPDATE: If we implement a Python module-space Catalog in the future, then the code to search site packages
-    #  directories directly, in the 'MeTTa.__init__' method, needs to be removed
-
-def _priv_load_tokens_py_stdlib(cmettamod, cmetta):
-    """
-    """
-    target = MettaModRef(cmettamod)
-    tokenizer = target.tokenizer()
-    metta = MeTTa(cmetta=cmetta)
-    return _priv_register_module_tokens_no_exception("hyperon.stdlib", tokenizer, metta)
 
 def _priv_register_module_tokens_no_exception(pymod_name, tokenizer, metta, resource_dir=None):
     """
@@ -371,6 +343,19 @@ def _priv_register_module_tokens_no_exception(pymod_name, tokenizer, metta, reso
     except Exception as e:
         print("Error loading Python module:", pymod_name, e)
         return 1
+
+# #LP-TODO-Next Make a test for loading a metta module from a python module using load_module_direct_from_pymod
+
+# #LP-TODO-Next Also make a test for a module that loads another module
+# py_stdlib_id = run_context.metta().load_module_direct_from_pymod("stdlib-py", descriptor, "hyperon.stdlib")
+# run_context.import_dependency(py_stdlib_id)
+
+# #LP-TODO-Next Implement a Catalog that uses the Python module-space, so that any module loaded via `pip`
+# can be found by MeTTa.  NOTE: We may want to explicitly give priority hyperon "exts" by first checking if Python
+# has a module at `"hyperon.exts." + mod_name` before just checking `mod_name`, but it's unclear that will
+# matter since we'll also search the `exts` directory with the include_path / fs_module_format logic
+# #UPDATE: If we implement a Python module-space Catalog in the future, then the code to search site packages
+#  directories directly, in the 'MeTTa.__init__' method, needs to be removed
 
 def _priv_register_module_tokens(pymod_name, tokenizer, metta, resource_dir=None):
     """

--- a/python/hyperon/runner.py
+++ b/python/hyperon/runner.py
@@ -128,7 +128,7 @@ class MeTTa:
             for path in py_site_packages_paths:
                 hp.env_builder_push_include_path(env_builder, path)
 
-            self.cmetta = hp.metta_new(space.cspace, env_builder)
+            self.cmetta = hp.metta_new_with_stdlib_loader(_priv_load_module_stdlib, space.cspace, env_builder)
 
     def __del__(self):
         hp.metta_free(self.cmetta)

--- a/python/hyperon/runner.py
+++ b/python/hyperon/runner.py
@@ -116,7 +116,7 @@ class MeTTa:
                 space = GroundingSpaceRef()
             if env_builder is None:
                 env_builder = hp.env_builder_start()
-            hp.env_builder_push_fs_module_format(env_builder, _PyFileMeTTaModFmt, 5000) #5000 is an arbitrary number unlikely to conflict with the arbitrary number chosen by other formats
+            hp.env_builder_push_fs_module_format(env_builder, _PyFileMeTTaModFmt)
             #LP-TODO-Next, add an fs_module_fmt arg to the standardized way to init environments, so that
             # the Python user can define additional formats without tweaking any hyperon files.  To make
             # this convenient it probably means making a virtual ModuleFormat base class
@@ -300,7 +300,8 @@ class _PyFileMeTTaModFmt:
 
             return {
                 'pymod_name': metta_mod_name,
-                'path': path
+                'path': path,
+                'fmt_id': 5000 #5000 is an arbitrary number unlikely to conflict with the arbitrary number chosen by other formats
             }
         except Exception as e:
             hp.log_error("Python error loading MeTTa module '" + metta_mod_name + "'. " + repr(e))

--- a/python/hyperon/runner.py
+++ b/python/hyperon/runner.py
@@ -317,10 +317,10 @@ def _priv_load_module(mod_name, path, c_run_context):
         resource_dir = None
     space = GroundingSpaceRef()
     run_context.init_self_module(space, resource_dir)
-    return _priv_register_module_tokens_no_exception(mod_name,
-                                    run_context.tokenizer(),
-                                    run_context.metta(),
-                                    resource_dir=resource_dir)
+    _priv_register_module_tokens(mod_name,
+                                 run_context.tokenizer(),
+                                 run_context.metta(),
+                                 resource_dir=resource_dir)
 
 def _priv_load_module_tokens(mod_name, cmettamod, cmetta):
     """
@@ -328,21 +328,7 @@ def _priv_load_module_tokens(mod_name, cmettamod, cmetta):
     target = MettaModRef(cmettamod)
     tokenizer = target.tokenizer()
     metta = MeTTa(cmetta=cmetta)
-    return _priv_register_module_tokens_no_exception(mod_name, tokenizer, metta)
-
-
-def _priv_register_module_tokens_no_exception(pymod_name, tokenizer, metta, resource_dir=None):
-    """
-    Private function to load tokens from Python module.
-    """
-
-    try:
-        _priv_register_module_tokens(pymod_name, tokenizer, metta,
-                                     resource_dir)
-        return 0
-    except Exception as e:
-        print("Error loading Python module:", pymod_name, e)
-        return 1
+    _priv_register_module_tokens(mod_name, tokenizer, metta)
 
 # #LP-TODO-Next Make a test for loading a metta module from a python module using load_module_direct_from_pymod
 
@@ -361,32 +347,28 @@ def _priv_register_module_tokens(pymod_name, tokenizer, metta, resource_dir=None
     """
     Private function to load tokens from Python module.
     """
-
-    try:
-        mod = import_module(pymod_name)
-        for n in dir(mod):
-            obj = getattr(mod, n)
-            if 'metta_type' in dir(obj):
-                typ = obj.metta_type
-                if obj.metta_pass_metta:
-                    items = obj(metta)
-                else:
-                    items = obj()
-                if typ == RegisterType.ATOM:
-                    def register(r, a):
-                        tokenizer.register_token(r, lambda _: a)
-                    for rex, atom in items.items():
-                        register(rex, atom)
-                elif typ == RegisterType.TOKEN:
-                    for rex, lam in items.items():
-                        tokenizer.register_token(rex, lam)
-
-    except Exception as e:
-        raise RuntimeError("Error loading Python module: ", pymod_name, e)
+    mod = import_module(pymod_name)
+    for n in dir(mod):
+        obj = getattr(mod, n)
+        if 'metta_type' in dir(obj):
+            typ = obj.metta_type
+            if obj.metta_pass_metta:
+                items = obj(metta)
+            else:
+                items = obj()
+            if typ == RegisterType.ATOM:
+                def register(r, a):
+                    tokenizer.register_token(r, lambda _: a)
+                for rex, atom in items.items():
+                    register(rex, atom)
+            elif typ == RegisterType.TOKEN:
+                for rex, lam in items.items():
+                    tokenizer.register_token(rex, lam)
 
 def _priv_make_module_loader_func_for_pymod(pymod_name, resource_dir=None):
     """
-    Private function to return a loader function to load a module into the runner directly from the specified Python module
+    Private function to return a loader function to load a module into the
+    runner directly from the specified Python module. Left for compatibility.
     """
 
     def loader_func(run_context):

--- a/python/hyperon/runner.py
+++ b/python/hyperon/runner.py
@@ -92,8 +92,6 @@ class RunContext:
     def register_token(self, regexp, constr):
         """Registers a token in the currently running module's Tokenizer"""
         self.tokenizer().register_token(regexp, constr)
-        own_tokenizer = Tokenizer._from_ctokenizer(hp.run_context_get_own_tokenizer(self.c_run_context))
-        own_tokenizer.register_token(regexp, constr)
 
     def register_atom(self, name, symbol):
         """Registers an Atom with a name in the currently running module's Tokenizer"""

--- a/python/hyperon/stdlib.py
+++ b/python/hyperon/stdlib.py
@@ -48,12 +48,12 @@ class RegexMatchableObject(MatchableObject):
                 return [{"matched_pattern": S(pattern)}]
         return []
 
-def parseImpl(atom, run_context):
+def parseImpl(atom, metta):
     try:
         s = atom.get_object().content
         if type(s) != str:
             raise IncorrectArgumentError()
-        return [SExprParser(repr(s)[1:-1]).parse(run_context.tokenizer())]
+        return [SExprParser(repr(s)[1:-1]).parse(metta.tokenizer())]
     except Exception as e:
         raise IncorrectArgumentError()
 

--- a/python/hyperon/stdlib.py
+++ b/python/hyperon/stdlib.py
@@ -59,7 +59,7 @@ def parseImpl(atom, run_context):
 
 
 @register_atoms(pass_metta=True)
-def text_ops(run_context):
+def text_ops(metta):
     """Add text operators
 
     repr: convert Atom to string.
@@ -73,7 +73,7 @@ def text_ops(run_context):
 
     reprAtom = OperationAtom('repr', lambda a: [ValueAtom(repr(a), 'String')],
                              ['Atom', 'String'], unwrap=False)
-    parseAtom = OperationAtom('parse', lambda s: parseImpl(s, run_context), ['String', 'Atom'], unwrap=False)
+    parseAtom = OperationAtom('parse', lambda s: parseImpl(s, metta), ['String', 'Atom'], unwrap=False)
     stringToCharsAtom = OperationAtom('stringToChars', lambda s: [E(*[ValueAtom(Char(c)) for c in str(s)[1:-1]])],
                                       ['String', 'Atom'], unwrap=False)
     charsToStringAtom = OperationAtom('charsToString', lambda a: [ValueAtom("".join([str(c)[1:-1] for c in a.get_children()]))],

--- a/python/hyperonpy.cpp
+++ b/python/hyperonpy.cpp
@@ -524,7 +524,7 @@ void syntax_node_copy_to_list_callback(const syntax_node_t* node, void *context)
     }
 };
 
-// A C function that wraps a Python function, so that the python code to load the stdlib can be run inside `metta_new_with_space_environment_and_stdlib()`
+// A C function that wraps a Python function, so that the python code to load the stdlib
 ssize_t stdlib_load(void* loader, run_context_t* run_context) {
     py::object runner_mod = py::module_::import("hyperon.runner");
     py::function load = runner_mod.attr("_priv_load_py_stdlib");

--- a/python/hyperonpy.cpp
+++ b/python/hyperonpy.cpp
@@ -559,7 +559,7 @@ struct python_module_loader_t {
 ssize_t module_load(void const* pyloader, run_context_t* run_context) {
     python_module_loader_t const* loader = static_cast<python_module_loader_t const*>(pyloader);
     py::object runner_mod = py::module_::import("hyperon.runner");
-    py::function load = runner_mod.attr("_priv_load_py_module");
+    py::function load = runner_mod.attr("_priv_load_module");
     CRunContext c_run_context = CRunContext(run_context);
     return load(loader->mod_name, loader->path, &c_run_context).cast<ssize_t>();
 }
@@ -567,7 +567,7 @@ ssize_t module_load(void const* pyloader, run_context_t* run_context) {
 ssize_t module_load_tokens(void const* pyloader, metta_mod_ref_t target, metta_t metta) {
     python_module_loader_t const* loader = static_cast<python_module_loader_t const*>(pyloader);
     py::object runner_mod = py::module_::import("hyperon.runner");
-    py::function load_tokens = runner_mod.attr("_priv_load_tokens_py_module");
+    py::function load_tokens = runner_mod.attr("_priv_load_module_tokens");
     CMettaModRef c_target = CMettaModRef(target);
     CMetta c_metta = CMetta(metta);
     // FIXME: convert error string

--- a/python/hyperonpy.cpp
+++ b/python/hyperonpy.cpp
@@ -539,7 +539,7 @@ ssize_t stdlib_load_tokens(void* loader, metta_mod_ref_t target, metta_t metta) 
     CMettaModRef c_target = CMettaModRef(target);
     CMetta c_metta = CMetta(metta);
     // FIXME: convert error string
-    return load_tokens(&c_target, &c_metta).cast<ssize_t>();
+    return load_tokens(&c_target, c_metta).cast<ssize_t>();
 }
 
 module_loader_t* new_stdlib_loader() {

--- a/python/hyperonpy.cpp
+++ b/python/hyperonpy.cpp
@@ -630,13 +630,14 @@ bool fs_module_format_try_path(const void* payload, const char* path,
     }
 }
 
-void fs_module_format_free(void* callback_context) {
-    py::object* py_context_obj = (py::object*)callback_context;
-    delete py_context_obj;
+void fs_module_format_free(void* payload) {
+    python_fs_module_format_t const* format = static_cast<python_fs_module_format_t const*>(payload);
+    delete format->py_format;
+    delete format;
 }
 
 fs_module_format_t* fs_module_format_new(py::object* py_format) {
-    python_fs_module_format_t* format = static_cast<python_fs_module_format_t*>(malloc(sizeof(python_fs_module_format_t)));
+    python_fs_module_format_t* format = new python_fs_module_format_t;
     format->api.path_for_name = fs_module_format_path_for_name;
     format->api.try_path = fs_module_format_try_path;
     format->api.free = fs_module_format_free;

--- a/python/hyperonpy.cpp
+++ b/python/hyperonpy.cpp
@@ -1072,10 +1072,8 @@ PYBIND11_MODULE(hyperonpy, m) {
         .def("tokenizer", [](CMettaModRef& cmodref) { return CTokenizer(metta_mod_ref_tokenizer(cmodref.ptr())); }, "Return tokenizer of the metta module");
 
     py::class_<CMetta>(m, "CMetta");
-    m.def("metta_new", [](CSpace space, EnvBuilder env_builder) {
-        py::object runner_mod = py::module_::import("hyperon.runner");
-        py::function loader_func = runner_mod.attr("_priv_load_module_stdlib");
-        return CMetta(metta_new_with_space_environment_and_stdlib(space.ptr(), env_builder.obj, module_loader_new("hyperon.stdlib", loader_func, nonstd::nullopt)));
+    m.def("metta_new_with_stdlib_loader", [](py::function stdlib_loader, CSpace space, EnvBuilder env_builder) {
+        return CMetta(metta_new_with_stdlib_loader(module_loader_new("stdlib", stdlib_loader, nonstd::nullopt), space.ptr(), env_builder.obj));
     }, "New MeTTa interpreter instance");
     m.def("metta_free", [](CMetta metta) { metta_free(metta.obj); }, "Free MeTTa interpreter");
     m.def("metta_err_str", [](CMetta& metta) {

--- a/python/hyperonpy.cpp
+++ b/python/hyperonpy.cpp
@@ -1063,9 +1063,6 @@ PYBIND11_MODULE(hyperonpy, m) {
     m.def("run_context_get_tokenizer", [](CRunContext& run_context) {
         return CTokenizer(run_context_get_tokenizer(run_context.ptr));
     }, "Returns the Tokenizer for the currently running module");
-    m.def("run_context_get_own_tokenizer", [](CRunContext& run_context) {
-        return CTokenizer(run_context_get_own_tokenizer(run_context.ptr));
-    }, "Returns the Own Tokenizer for the currently running module");
 
     m.def("run_context_import_dependency", [](CRunContext& run_context, ModuleId mod_id) {
         run_context_import_dependency(run_context.ptr, mod_id.obj);
@@ -1081,7 +1078,7 @@ PYBIND11_MODULE(hyperonpy, m) {
 
     py::class_<CMetta>(m, "CMetta");
     m.def("metta_new", [](CSpace space, EnvBuilder env_builder) {
-        return CMetta(metta_new_with_space_environment_and_stdlib_2(space.ptr(), env_builder.obj, module_loader_new("hyperon.stdlib", nonstd::nullopt)));
+        return CMetta(metta_new_with_space_environment_and_stdlib(space.ptr(), env_builder.obj, module_loader_new("hyperon.stdlib", nonstd::nullopt)));
     }, "New MeTTa interpreter instance");
     m.def("metta_free", [](CMetta metta) { metta_free(metta.obj); }, "Free MeTTa interpreter");
     m.def("metta_err_str", [](CMetta& metta) {

--- a/python/tests/test_modules.py
+++ b/python/tests/test_modules.py
@@ -47,3 +47,6 @@ class PyOpsTest(HyperonTestCase):
         runner.run("!(import! &self py_ops)")
         result = runner.run('!(* "a" 4)')
         self.assertEqual(result[0][0], ValueAtom('aaaa'))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR is a followup after #894. It adds `ModuleLoader::load_tokens` method and uses it to export tokens from module A into importing module B. Thus only exported tokens are copied into the importing module. This change is simple on a Rust side but required significant work on Python side as fully functional `ModuleLoader` implementation is required there.

On core library side `ModuleLoader::load_tokens` method is added and implemented for `corelib` and built-in modules. It is used to export tokens into importing module and old `own_tokenizer` is removed.

On `hyperonc` side new module `module.rs` is added. Most of the module handing code and structure are moved there. New `module_loader_t` is implemented which allows implementing `ModuleLoader` interface from a C program. `fs_module_format_t` structure is modified to reflect Rust `FsModuleFormat` API. Old `ModuleLoader` implementations are removed and replaced by the one.

On `hyperonpy` side the `module_loader_t` API is used to implement loading `stdlib` and direct loading other Python modules by name or via function call. `fs_module_format_t` API is used to implement loading Python modules by name using `import!` from MeTTa programs. `MettaModRef` is added to allow `load_tokens` implementation getting tokenizer from importing MeTTa module. 

The rework of the Python module importing code is done. Now functions which register MeTTa tokens are not wrapped but instead marked by `metta_type` attribute which also points how the returned atoms should be registered. Also `metta_pass_metta` attribute is added to know whether the function expects metta as a parameter or not. Then module loading function `_priv_register_module_tokens` goes through all marked functions and calls them passing results to the tokenizer.