### PR TITLE
Use DynSpace everywhere as the only way to pass some space through the code

### DIFF
--- a/c/src/metta.rs
+++ b/c/src/metta.rs
@@ -688,19 +688,19 @@ pub struct step_result_t {
     result: *mut RustStepResult,
 }
 
-struct RustStepResult(InterpreterState<DynSpace>);
+struct RustStepResult(InterpreterState);
 
-impl From<InterpreterState<DynSpace>> for step_result_t {
-    fn from(state: InterpreterState<DynSpace>) -> Self {
+impl From<InterpreterState> for step_result_t {
+    fn from(state: InterpreterState) -> Self {
         Self{ result: Box::into_raw(Box::new(RustStepResult(state))) }
     }
 }
 
 impl step_result_t {
-    fn into_inner(self) -> InterpreterState<DynSpace> {
+    fn into_inner(self) -> InterpreterState {
         unsafe{ Box::from_raw(self.result).0 }
     }
-    fn borrow(&self) -> &InterpreterState<DynSpace> {
+    fn borrow(&self) -> &InterpreterState {
         &unsafe{ &*(&*self).result }.0
     }
 }

--- a/c/src/metta.rs
+++ b/c/src/metta.rs
@@ -630,7 +630,7 @@ pub extern "C" fn check_type(space: *const space_t, atom: *const atom_ref_t, typ
     let dyn_space = unsafe{ &*space }.borrow();
     let atom = unsafe{ &*atom }.borrow();
     let typ = unsafe{ &*typ }.borrow();
-    hyperon::metta::types::check_type(dyn_space.borrow().as_space(), atom, typ)
+    hyperon::metta::types::check_type(dyn_space, atom, typ)
 }
 
 /// @brief Checks whether `atom` is correctly typed
@@ -644,7 +644,7 @@ pub extern "C" fn check_type(space: *const space_t, atom: *const atom_ref_t, typ
 pub extern "C" fn validate_atom(space: *const space_t, atom: *const atom_ref_t) -> bool {
     let dyn_space = unsafe{ &*space }.borrow();
     let atom = unsafe{ &*atom }.borrow();
-    hyperon::metta::types::validate_atom(dyn_space.borrow().as_space(), atom)
+    hyperon::metta::types::validate_atom(dyn_space, atom)
 }
 
 /// @brief Provides all types for `atom` in the context of `space`
@@ -661,7 +661,7 @@ pub extern "C" fn get_atom_types(space: *const space_t, atom: *const atom_ref_t,
         callback: c_atom_vec_callback_t, context: *mut c_void) {
     let dyn_space = unsafe{ &*space }.borrow();
     let atom = unsafe{ (&*atom).borrow() };
-    let types = hyperon::metta::types::get_atom_types(dyn_space.borrow().as_space(), atom);
+    let types = hyperon::metta::types::get_atom_types(dyn_space, atom);
     return_atoms(&types, callback, context);
 }
 

--- a/c/src/space.rs
+++ b/c/src/space.rs
@@ -239,7 +239,7 @@ pub extern "C" fn space_atom_count(space: *const space_t) -> isize {
 pub extern "C" fn space_iterate(space: *const space_t,
         callback: c_atom_callback_t, context: *mut c_void) -> bool {
     let dyn_space = unsafe{ &*space }.borrow();
-    match dyn_space.visit(&mut |atom: Cow<Atom>| callback(atom.as_ref().into(), context)) {
+    match dyn_space.borrow().visit(&mut |atom: Cow<Atom>| callback(atom.as_ref().into(), context)) {
         Ok(()) => true,
         Err(()) => false,
     }
@@ -799,9 +799,6 @@ impl SpaceMut for CSpace {
         let api = unsafe{ &*self.api };
         let from: atom_ref_t = from.into();
         (api.replace)(&self.params, &from, to.into())
-    }
-    fn as_space<'a>(&self) -> &(dyn Space + 'a) {
-        self
     }
 }
 

--- a/c/src/space.rs
+++ b/c/src/space.rs
@@ -751,9 +751,6 @@ impl Space for CSpace {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
-    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
-        self
-    }
 }
 
 impl std::fmt::Display for CSpace {
@@ -775,7 +772,6 @@ impl Space for DefaultSpace<'_> {
     fn query(&self, query: &Atom) -> BindingsSet { self.0.query(query) }
     fn visit(&self, v: &mut dyn SpaceVisitor) -> Result<(), ()> { self.0.visit(v) }
     fn as_any(&self) -> &dyn std::any::Any { self.0 }
-    fn as_any_mut(&mut self) -> &mut dyn std::any::Any { unreachable!() }
 }
 
 impl std::fmt::Display for DefaultSpace<'_> {
@@ -798,6 +794,9 @@ impl SpaceMut for CSpace {
         let api = unsafe{ &*self.api };
         let from: atom_ref_t = from.into();
         (api.replace)(&self.params, &from, to.into())
+    }
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
     }
 }
 

--- a/c/src/space.rs
+++ b/c/src/space.rs
@@ -123,10 +123,8 @@ pub extern "C" fn space_eq(a: *const space_t, b: *const space_t) -> bool {
 #[no_mangle]
 pub extern "C" fn space_get_payload(space: *mut space_t) -> *mut c_void {
     let dyn_space = unsafe{ &*space }.borrow();
-    if let Some(any_ref) = dyn_space.borrow_mut().as_any() {
-        if let Some(c_space) = any_ref.downcast_ref::<CSpace>() {
-            return c_space.params.payload;
-        }
+    if let Some(c_space) = dyn_space.borrow_mut().as_any().downcast_ref::<CSpace>() {
+        return c_space.params.payload;
     }
     panic!("Only CSpace has a payload")
 }
@@ -750,11 +748,11 @@ impl Space for CSpace {
             _ => Err(()),
         }
     }
-    fn as_any(&self) -> Option<&dyn std::any::Any> {
-        Some(self)
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
     }
-    fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
-        Some(self)
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
     }
 }
 
@@ -776,9 +774,10 @@ impl Space for DefaultSpace<'_> {
     fn common(&self) -> FlexRef<SpaceCommon> { self.0.common() }
     fn query(&self, query: &Atom) -> BindingsSet { self.0.query(query) }
     fn visit(&self, v: &mut dyn SpaceVisitor) -> Result<(), ()> { self.0.visit(v) }
-    fn as_any(&self) -> Option<&dyn std::any::Any> { Some(self.0) }
-    fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> { None }
+    fn as_any(&self) -> &dyn std::any::Any { self.0 }
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any { unreachable!() }
 }
+
 impl std::fmt::Display for DefaultSpace<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "DefaultSpace")

--- a/lib/benches/interpreter_minimal.rs
+++ b/lib/benches/interpreter_minimal.rs
@@ -6,6 +6,7 @@ extern crate test;
 use test::Bencher;
 
 use hyperon::*;
+use hyperon::space::DynSpace;
 use hyperon::space::grounding::*;
 use hyperon::metta::*;
 use hyperon::metta::interpreter::*;
@@ -18,36 +19,40 @@ fn chain_atom(size: isize) -> Atom {
     atom
 }
 
+fn new_space() -> DynSpace {
+    DynSpace::new(GroundingSpace::new())
+}
+
 
 #[bench]
 fn chain_x10(bencher: &mut Bencher) {
-    let space = GroundingSpace::new();
+    let space = new_space();
     let atom = chain_atom(10);
     let expected = Ok(vec![expr!("A")]);
     bencher.iter(move || {
-        let res = interpret(&space, &atom);
+        let res = interpret(space.clone(), &atom);
         assert_eq!(res, expected);
     })
 }
 
 #[bench]
 fn chain_x100(bencher: &mut Bencher) {
-    let space = GroundingSpace::new();
+    let space = new_space();
     let atom = chain_atom(100);
     let expected = Ok(vec![expr!("A")]);
     bencher.iter(move || {
-        let res = interpret(&space, &atom);
+        let res = interpret(space.clone(), &atom);
         assert_eq!(res, expected);
     })
 }
 
 #[bench]
 fn chain_x1000(bencher: &mut Bencher) {
-    let space = GroundingSpace::new();
+    let space = new_space();
     let atom = chain_atom(1000);
     let expected = Ok(vec![expr!("A")]);
     bencher.iter(move || {
-        let res = interpret(&space, &atom);
+        let res = interpret(space.clone(), &atom);
         assert_eq!(res, expected);
     })
 }

--- a/lib/benches/interpreter_minimal.rs
+++ b/lib/benches/interpreter_minimal.rs
@@ -20,7 +20,7 @@ fn chain_atom(size: isize) -> Atom {
 }
 
 fn new_space() -> DynSpace {
-    DynSpace::new(GroundingSpace::new())
+    GroundingSpace::new().into()
 }
 
 

--- a/lib/benches/type.rs
+++ b/lib/benches/type.rs
@@ -16,7 +16,7 @@ fn metta_space(text: &str) -> DynSpace {
     while let Some(atom) = parser.parse(&tokenizer).unwrap() {
         space.add(atom);
     }
-    DynSpace::new(space)
+    space.into()
 }
 
 fn atom_with_depth(depth: usize) -> Atom {

--- a/lib/benches/type.rs
+++ b/lib/benches/type.rs
@@ -5,17 +5,18 @@ extern crate test;
 use test::Bencher;
 use hyperon::*;
 use hyperon::metta::types::*;
+use hyperon::space::DynSpace;
 use hyperon::space::grounding::*;
 use hyperon::metta::text::*;
 
-fn metta_space(text: &str) -> GroundingSpace {
+fn metta_space(text: &str) -> DynSpace {
     let tokenizer = Tokenizer::new();
     let mut space = GroundingSpace::new();
     let mut parser = SExprParser::new(text);
     while let Some(atom) = parser.parse(&tokenizer).unwrap() {
         space.add(atom);
     }
-    space
+    DynSpace::new(space)
 }
 
 fn atom_with_depth(depth: usize) -> Atom {

--- a/lib/src/common/test_utils.rs
+++ b/lib/src/common/test_utils.rs
@@ -10,7 +10,7 @@ pub(crate) fn metta_space(text: &str) -> DynSpace {
     while let Some(atom) = parser.parse(&Tokenizer::new()).unwrap() {
         space.add(atom);
     }
-    DynSpace::new(space)
+    space.into()
 }
 
 pub(crate) fn metta_atom(atom_str: &str) -> Atom {

--- a/lib/src/common/test_utils.rs
+++ b/lib/src/common/test_utils.rs
@@ -1,15 +1,16 @@
 
 use crate::*;
 use crate::metta::text::{Tokenizer, SExprParser};
+use crate::space::DynSpace;
 use crate::space::grounding::GroundingSpace;
 
-pub(crate) fn metta_space(text: &str) -> GroundingSpace {
+pub(crate) fn metta_space(text: &str) -> DynSpace {
     let mut space = GroundingSpace::new();
     let mut parser = SExprParser::new(text);
     while let Some(atom) = parser.parse(&Tokenizer::new()).unwrap() {
         space.add(atom);
     }
-    space
+    DynSpace::new(space)
 }
 
 pub(crate) fn metta_atom(atom_str: &str) -> Atom {

--- a/lib/src/metta/interpreter.rs
+++ b/lib/src/metta/interpreter.rs
@@ -594,7 +594,7 @@ fn query(space: &DynSpace, prev: Option<Rc<RefCell<Stack>>>, to_eval: Atom, bind
     }
     let var_x = &VariableAtom::new("X").make_unique();
     let query = Atom::expr([EQUAL_SYMBOL, to_eval.clone(), Atom::Variable(var_x.clone())]);
-    let results = space.query(&query);
+    let results = space.borrow().query(&query);
     log::debug!("interpreter::query: query: {}", query);
     log::debug!("interpreter::query: results.len(): {}, bindings.len(): {}, results: {} bindings: {}",
         results.len(), bindings.len(), results, bindings);

--- a/lib/src/metta/interpreter.rs
+++ b/lib/src/metta/interpreter.rs
@@ -150,12 +150,12 @@ impl Display for InterpretedAtom {
 }
 
 #[derive(Debug)]
-struct InterpreterContext<T: Space> {
-    space: T,
+struct InterpreterContext {
+    space: DynSpace,
 }
 
-impl<T: Space> InterpreterContext<T> {
-    fn new(space: T) -> Self {
+impl InterpreterContext {
+    fn new(space: DynSpace) -> Self {
         Self{ space }
     }
 }
@@ -165,13 +165,13 @@ impl<T: Space> InterpreterContext<T> {
 
 /// State of the interpreter which passed between `interpret_step` calls.
 #[derive(Debug)]
-pub struct InterpreterState<T: Space> {
+pub struct InterpreterState {
     /// List of the alternatives to evaluate further.
     plan: Vec<InterpretedAtom>,
     /// List of the completely evaluated results to be returned.
     finished: Vec<Atom>,
     /// Evaluation context.
-    context: InterpreterContext<T>,
+    context: InterpreterContext,
     /// Maximum stack depth
     max_stack_depth: usize,
 }
@@ -188,10 +188,10 @@ fn atom_into_array<const N: usize>(atom: Atom) -> Option<[Atom; N]> {
     <[Atom; N]>::try_from(atom).ok()
 }
 
-impl<T: Space> InterpreterState<T> {
+impl InterpreterState {
 
     /// INTERNAL USE ONLY. Create an InterpreterState that is ready to yield results
-    pub(crate) fn new_finished(space: T, results: Vec<Atom>) -> Self {
+    pub(crate) fn new_finished(space: DynSpace, results: Vec<Atom>) -> Self {
         Self {
             plan: vec![],
             finished: results,
@@ -236,7 +236,7 @@ impl<T: Space> InterpreterState<T> {
     }
 }
 
-impl<T: Space> std::fmt::Display for InterpreterState<T> {
+impl std::fmt::Display for InterpreterState {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{:?}\n", self.plan)
     }
@@ -248,7 +248,7 @@ impl<T: Space> std::fmt::Display for InterpreterState<T> {
 /// # Arguments
 /// * `space` - atomspace to query for interpretation
 /// * `expr` - atom to interpret
-pub fn interpret_init<T: Space>(space: T, expr: &Atom) -> InterpreterState<T> {
+pub fn interpret_init(space: DynSpace, expr: &Atom) -> InterpreterState {
     let context = InterpreterContext::new(space);
     InterpreterState {
         plan: vec![InterpretedAtom(atom_to_stack(expr.clone(), None), Bindings::new())],
@@ -263,7 +263,7 @@ pub fn interpret_init<T: Space>(space: T, expr: &Atom) -> InterpreterState<T> {
 ///
 /// # Arguments
 /// * `state` - interpreter state from the previous step.
-pub fn interpret_step<T: Space>(mut state: InterpreterState<T>) -> InterpreterState<T> {
+pub fn interpret_step(mut state: InterpreterState) -> InterpreterState {
     let interpreted_atom = state.pop().unwrap();
     log::debug!("interpret_step:\n{}", interpreted_atom);
     let InterpretedAtom(stack, bindings) = interpreted_atom;
@@ -279,7 +279,7 @@ pub fn interpret_step<T: Space>(mut state: InterpreterState<T>) -> InterpreterSt
 /// # Arguments
 /// * `space` - atomspace to query for interpretation
 /// * `expr` - atom to interpret
-pub fn interpret<T: Space>(space: T, expr: &Atom) -> Result<Vec<Atom>, String> {
+pub fn interpret(space: DynSpace, expr: &Atom) -> Result<Vec<Atom>, String> {
     let mut state = interpret_init(space, expr);
     while state.has_next() {
         state = interpret_step(state);
@@ -365,7 +365,7 @@ impl Display for Variables {
     }
 }
 
-fn interpret_stack<'a, T: Space>(context: &InterpreterContext<T>, stack: Stack, mut bindings: Bindings, max_stack_depth: usize) -> Vec<InterpretedAtom> {
+fn interpret_stack(context: &InterpreterContext, stack: Stack, mut bindings: Bindings, max_stack_depth: usize) -> Vec<InterpretedAtom> {
     if stack.finished {
         // first executed minimal operation returned error
         if stack.prev.is_none() {
@@ -466,7 +466,7 @@ fn finished_result(atom: Atom, bindings: Bindings, prev: Option<Rc<RefCell<Stack
     vec![InterpretedAtom(Stack::finished(prev, atom), bindings)]
 }
 
-fn evalc<'a, T: Space>(_context: &InterpreterContext<T>, stack: Stack, bindings: Bindings) -> Vec<InterpretedAtom> {
+fn evalc(_context: &InterpreterContext, stack: Stack, bindings: Bindings) -> Vec<InterpretedAtom> {
     let Stack{ prev, atom: eval, vars, .. } = stack;
     let (to_eval, space) = match_atom!{
         eval ~ [_op, to_eval, space]
@@ -477,10 +477,10 @@ fn evalc<'a, T: Space>(_context: &InterpreterContext<T>, stack: Stack, bindings:
         }
     };
     let space = space.as_gnd::<DynSpace>().unwrap();
-    eval_impl(to_eval, space, bindings, prev, vars)
+    eval_impl(to_eval, &space, bindings, prev, vars)
 }
 
-fn eval<'a, T: Space>(context: &InterpreterContext<T>, stack: Stack, bindings: Bindings) -> Vec<InterpretedAtom> {
+fn eval(context: &InterpreterContext, stack: Stack, bindings: Bindings) -> Vec<InterpretedAtom> {
     let Stack{ prev, atom: eval, vars, .. } = stack;
     let to_eval = match_atom!{
         eval ~ [_op, to_eval] => to_eval,
@@ -492,7 +492,7 @@ fn eval<'a, T: Space>(context: &InterpreterContext<T>, stack: Stack, bindings: B
     eval_impl(to_eval, &context.space, bindings, prev, vars)
 }
 
-fn eval_impl<'a, T: Space>(to_eval: Atom, space: T, bindings: Bindings, prev: Option<Rc<RefCell<Stack>>>, vars: Variables) -> Vec<InterpretedAtom> {
+fn eval_impl(to_eval: Atom, space: &DynSpace, bindings: Bindings, prev: Option<Rc<RefCell<Stack>>>, vars: Variables) -> Vec<InterpretedAtom> {
     let to_eval = apply_bindings_to_atom_move(to_eval, &bindings);
     log::debug!("eval: to_eval: {}", to_eval);
     match atom_as_slice(&to_eval) {
@@ -1434,33 +1434,33 @@ mod tests {
 
     #[test]
     fn interpret_atom_evaluate_incorrect_args() {
-        assert_eq!(call_interpret(&space(""), &metta_atom("(eval)")),
+        assert_eq!(call_interpret(space(""), &metta_atom("(eval)")),
             vec![expr!("Error" ("eval") "expected: (eval <atom>), found: (eval)")]);
-        assert_eq!(call_interpret(&space(""), &metta_atom("(eval a b)")),
+        assert_eq!(call_interpret(space(""), &metta_atom("(eval a b)")),
             vec![expr!("Error" ("eval" "a" "b") "expected: (eval <atom>), found: (eval a b)")]);
     }
 
     #[test]
     fn interpret_atom_evaluate_atom() {
-        let result = call_interpret(&space("(= a b)"), &metta_atom("(eval a)"));
+        let result = call_interpret(space("(= a b)"), &metta_atom("(eval a)"));
         assert_eq!(result, vec![metta_atom("b")]);
     }
 
     #[test]
     fn interpret_atom_evaluate_atom_no_definition() {
-        let result = call_interpret(&space(""), &metta_atom("(eval a)"));
+        let result = call_interpret(space(""), &metta_atom("(eval a)"));
         assert_eq!(result, vec![metta_atom("NotReducible")]);
     }
 
     #[test]
     fn interpret_atom_evaluate_empty_expression() {
-        let result = call_interpret(&space(""), &metta_atom("(eval ())"));
+        let result = call_interpret(space(""), &metta_atom("(eval ())"));
         assert_eq!(result, vec![metta_atom("NotReducible")]);
     }
 
     #[test]
     fn interpret_atom_evaluate_grounded_value() {
-        let result = call_interpret(&space(""), &expr!("eval" {6}));
+        let result = call_interpret(space(""), &expr!("eval" {6}));
         assert_eq!(result, vec![metta_atom("NotReducible")]);
     }
 
@@ -1468,7 +1468,7 @@ mod tests {
     #[test]
     fn interpret_atom_evaluate_pure_expression() {
         let space = space("(= (foo $a B) $a)");
-        let result = call_interpret(&space, &metta_atom("(eval (foo A $b))"));
+        let result = call_interpret(space, &metta_atom("(eval (foo A $b))"));
         assert_eq!(result, vec![metta_atom("A")]);
     }
 
@@ -1479,7 +1479,7 @@ mod tests {
             (= color green)
             (= color blue)
         ");
-        let result = call_interpret(&space, &metta_atom("(eval color)"));
+        let result = call_interpret(space, &metta_atom("(eval color)"));
         assert_eq_no_order!(result, vec![
             metta_atom("red"),
             metta_atom("green"),
@@ -1489,58 +1489,58 @@ mod tests {
 
     #[test]
     fn interpret_atom_evaluate_pure_expression_no_definition() {
-        let result = call_interpret(&space(""), &metta_atom("(eval (foo A))"));
+        let result = call_interpret(space(""), &metta_atom("(eval (foo A))"));
         assert_eq!(result, vec![metta_atom("NotReducible")]);
     }
 
     #[test]
     fn interpret_atom_evaluate_pure_expression_variable_in_space() {
         let space = space("$t (= (foo $a B) $a)");
-        let result = call_interpret(&space, &metta_atom("(eval (foo A $b))"));
+        let result = call_interpret(space, &metta_atom("(eval (foo A $b))"));
         assert_eq!(result, vec![metta_atom("A")]);
     }
 
     #[test]
     fn interpret_atom_evaluate_pure_expression_variable_name_conflict() {
         let space = space("(= (foo ($W)) True)");
-        let result = call_interpret(&space, &metta_atom("(eval (foo $W))"));
+        let result = call_interpret(space, &metta_atom("(eval (foo $W))"));
         assert_eq!(result[0], sym!("True"));
     }
 
     #[test]
     fn interpret_atom_evaluate_grounded_expression() {
-        let result = call_interpret(&space(""), &expr!("eval" ({MulXUndefinedType(7)} {6})));
+        let result = call_interpret(space(""), &expr!("eval" ({MulXUndefinedType(7)} {6})));
         assert_eq!(result, vec![expr!({42})]);
     }
 
     #[test]
     fn interpret_atom_evaluate_grounded_expression_empty() {
-        let result = call_interpret(&space(""), &expr!("eval" ({ReturnNothing()} {6})));
+        let result = call_interpret(space(""), &expr!("eval" ({ReturnNothing()} {6})));
         assert_eq!(result, vec![]);
     }
 
     #[test]
     fn interpret_atom_evaluate_grounded_expression_noreduce() {
-        let result = call_interpret(&space(""), &expr!("eval" ({NonReducible()} {6})));
+        let result = call_interpret(space(""), &expr!("eval" ({NonReducible()} {6})));
         assert_eq!(result, vec![NOT_REDUCIBLE_SYMBOL]);
     }
 
     #[test]
     fn interpret_atom_evaluate_grounded_expression_incorrect_argument() {
-        let result = call_interpret(&space(""), &expr!("eval" ({IncorrectArgument()} {6.5})));
+        let result = call_interpret(space(""), &expr!("eval" ({IncorrectArgument()} {6.5})));
         assert_eq!(result, vec![NOT_REDUCIBLE_SYMBOL]);
     }
 
     #[test]
     fn interpret_atom_evaluate_grounded_expression_error() {
-        let result = call_interpret(&space(""), &expr!("eval" ({ThrowError()} {"Test error"})));
+        let result = call_interpret(space(""), &expr!("eval" ({ThrowError()} {"Test error"})));
         assert_eq!(result, vec![expr!("Error" ({ThrowError()} {"Test error"}) "Test error")]);
     }
 
     #[test]
     fn interpret_atom_evaluate_variable_operation() {
         let space = space("(= (foo $a B) $a)");
-        let result = call_interpret(&space, &metta_atom("(eval ($a A $b))"));
+        let result = call_interpret(space, &metta_atom("(eval ($a A $b))"));
         #[cfg(feature = "variable_operation")]
         assert_eq!(result, vec![metta_atom("A")]);
         #[cfg(not(feature = "variable_operation"))]
@@ -1556,7 +1556,7 @@ mod tests {
               (unify $b value
                 (return ())
                 (return (Error () \"Unexpected error\")) ))))");
-        let result = call_interpret(&space,
+        let result = call_interpret(space,
             &metta_atom("(chain (eval (foo $a)) $_ $a)"));
         assert_eq!(result[0], sym!("value"));
     }
@@ -1570,7 +1570,7 @@ mod tests {
               (unify $b value
                 (return ())
                 (return (Error () \"Unexpected error\")) ))))");
-        let result = call_interpret(&formal_arg_struct,
+        let result = call_interpret(formal_arg_struct,
             &metta_atom("(chain (eval (foo $a)) $_ $a)"));
         assert_eq!(result[0], expr!(("value")));
 
@@ -1581,7 +1581,7 @@ mod tests {
               (unify $b (value)
                 (return ())
                 (return (Error () \"Unexpected error\")) ))))");
-        let result = call_interpret(&actual_arg_struct,
+        let result = call_interpret(actual_arg_struct,
             &metta_atom("(chain (eval (foo ($a))) $_ $a)"));
         assert_eq!(result[0], sym!("value"));
     }
@@ -1589,7 +1589,7 @@ mod tests {
     #[test]
     fn interpret_atom_evaluate_variable_operation_nested() {
         let space = space("(= ((baz $a) $b) ($a $b))");
-        let result = call_interpret(&space, &metta_atom("(eval (($a A) B))"));
+        let result = call_interpret(space, &metta_atom("(eval (($a A) B))"));
         #[cfg(feature = "variable_operation")]
         assert_eq!(result, vec![metta_atom("(A B)")]);
         #[cfg(not(feature = "variable_operation"))]
@@ -1607,17 +1607,17 @@ mod tests {
 
     #[test]
     fn interpret_atom_chain_incorrect_args() {
-        assert_eq!(call_interpret(&space(""), &metta_atom("(chain n $v t o)")),
+        assert_eq!(call_interpret(space(""), &metta_atom("(chain n $v t o)")),
             vec![expr!("Error" ("chain" "n" v "t" "o") "expected: (chain <nested> (: <var> Variable) <templ>), found: (chain n $v t o)")]);
-        assert_eq!(call_interpret(&space(""), &metta_atom("(chain n v t)")),
+        assert_eq!(call_interpret(space(""), &metta_atom("(chain n v t)")),
             vec![expr!("Error" ("chain" "n" "v" "t") "expected: (chain <nested> (: <var> Variable) <templ>), found: (chain n v t)")]);
-        assert_eq!(call_interpret(&space(""), &metta_atom("(chain n $v)")),
+        assert_eq!(call_interpret(space(""), &metta_atom("(chain n $v)")),
             vec![expr!("Error" ("chain" "n" v) "expected: (chain <nested> (: <var> Variable) <templ>), found: (chain n $v)")]);
     }
 
     #[test]
     fn interpret_atom_chain_atom() {
-        let result = call_interpret(&space(""), &expr!("chain" ("A" () {6} y) x ("bar" x)));
+        let result = call_interpret(space(""), &expr!("chain" ("A" () {6} y) x ("bar" x)));
         assert_eq!(result, vec![expr!("bar" ("A" () {6} y))]);
     }
 
@@ -1625,20 +1625,20 @@ mod tests {
     #[test]
     fn interpret_atom_chain_evaluation() {
         let space = space("(= (foo $a B) $a)");
-        let result = call_interpret(&space, &metta_atom("(chain (eval (foo A $b)) $x (bar $x))"));
+        let result = call_interpret(space, &metta_atom("(chain (eval (foo A $b)) $x (bar $x))"));
         assert_eq!(result, vec![metta_atom("(bar A)")]);
     }
 
     #[test]
     fn interpret_atom_chain_nested_evaluation() {
         let space = space("(= (foo $a B) $a)");
-        let result = call_interpret(&space, &metta_atom("(chain (chain (eval (foo A $b)) $x (bar $x)) $y (baz $y))"));
+        let result = call_interpret(space, &metta_atom("(chain (chain (eval (foo A $b)) $x (bar $x)) $y (baz $y))"));
         assert_eq!(result, vec![metta_atom("(baz (bar A))")]);
     }
 
     #[test]
     fn interpret_atom_chain_nested_value() {
-        let result = call_interpret(&space(""), &metta_atom("(chain (chain A $x (bar $x)) $y (baz $y))"));
+        let result = call_interpret(space(""), &metta_atom("(chain (chain A $x (bar $x)) $y (baz $y))"));
         assert_eq!(result, vec![metta_atom("(baz (bar A))")]);
     }
 
@@ -1649,7 +1649,7 @@ mod tests {
             (= (color) green)
             (= (color) blue)
         ");
-        let result = call_interpret(&space, &metta_atom("(chain (eval (color)) $x (bar $x))"));
+        let result = call_interpret(space, &metta_atom("(chain (eval (color)) $x (bar $x))"));
         assert_eq_no_order!(result, vec![
             metta_atom("(bar red)"),
             metta_atom("(bar green)"),
@@ -1659,92 +1659,92 @@ mod tests {
 
     #[test]
     fn interpret_atom_chain_return() {
-        let result = call_interpret(&space(""), &metta_atom("(chain Empty $x (bar $x))"));
+        let result = call_interpret(space(""), &metta_atom("(chain Empty $x (bar $x))"));
         assert_eq!(result, vec![metta_atom("(bar Empty)")]);
     }
 
     #[test]
     fn interpret_atom_chain_keep_var_from_evaluated_part() {
-        let result = call_interpret(&space("(= (even 4) True)"), &metta_atom("(chain (eval (even $x)) $res (= (is-even $x) $res))"));
+        let result = call_interpret(space("(= (even 4) True)"), &metta_atom("(chain (eval (even $x)) $res (= (is-even $x) $res))"));
         assert_eq!(result, vec![metta_atom("(= (is-even 4) True)")]);
     }
 
 
     #[test]
     fn interpret_atom_unify_incorrect_args() {
-        assert_eq!(call_interpret(&space(""), &metta_atom("(unify a p t e o)")),
+        assert_eq!(call_interpret(space(""), &metta_atom("(unify a p t e o)")),
             vec![expr!("Error" ("unify" "a" "p" "t" "e" "o") "expected: (unify <atom> <pattern> <then> <else>), found: (unify a p t e o)")]);
-        assert_eq!(call_interpret(&space(""), &metta_atom("(unify a p t)")),
+        assert_eq!(call_interpret(space(""), &metta_atom("(unify a p t)")),
             vec![expr!("Error" ("unify" "a" "p" "t") "expected: (unify <atom> <pattern> <then> <else>), found: (unify a p t)")]);
     }
 
     #[test]
     fn interpret_atom_unify_then() {
-        let result = call_interpret(&space(""), &metta_atom("(unify (A $b) ($a B) ($a $b) Empty)"));
+        let result = call_interpret(space(""), &metta_atom("(unify (A $b) ($a B) ($a $b) Empty)"));
         assert_eq!(result, vec![metta_atom("(A B)")]);
     }
 
     #[test]
     fn interpret_atom_unify_else() {
-        let result = call_interpret(&space(""), &metta_atom("(unify (A $b C) ($a B D) ($a $b) Empty)"));
+        let result = call_interpret(space(""), &metta_atom("(unify (A $b C) ($a B D) ($a $b) Empty)"));
         assert_eq!(result, vec![]);
     }
 
 
     #[test]
     fn interpret_atom_decons_atom_incorrect_args() {
-        assert_eq!(call_interpret(&space(""), &metta_atom("(decons-atom a)")),
+        assert_eq!(call_interpret(space(""), &metta_atom("(decons-atom a)")),
             vec![expr!("Error" ("decons-atom" "a") "expected: (decons-atom (: <expr> Expression)), found: (decons-atom a)")]);
-        assert_eq!(call_interpret(&space(""), &metta_atom("(decons-atom (a) (b))")),
+        assert_eq!(call_interpret(space(""), &metta_atom("(decons-atom (a) (b))")),
             vec![expr!("Error" ("decons-atom" ("a") ("b")) "expected: (decons-atom (: <expr> Expression)), found: (decons-atom (a) (b))")]);
-        assert_eq!(call_interpret(&space(""), &metta_atom("(decons-atom)")),
+        assert_eq!(call_interpret(space(""), &metta_atom("(decons-atom)")),
             vec![expr!("Error" ("decons-atom") "expected: (decons-atom (: <expr> Expression)), found: (decons-atom)")]);
     }
 
     #[test]
     fn interpret_atom_decons_atom_empty() {
-        let result = call_interpret(&space(""), &metta_atom("(decons-atom ())"));
+        let result = call_interpret(space(""), &metta_atom("(decons-atom ())"));
         assert_eq!(result, vec![expr!("Error" ("decons-atom" ()) "expected: (decons-atom (: <expr> Expression)), found: (decons-atom ())")]);
     }
 
     #[test]
     fn interpret_atom_decons_atom_single() {
-        let result = call_interpret(&space(""), &metta_atom("(decons-atom (a))"));
+        let result = call_interpret(space(""), &metta_atom("(decons-atom (a))"));
         assert_eq!(result, vec![metta_atom("(a ())")]);
     }
 
     #[test]
     fn interpret_atom_decons_atom_list() {
-        let result = call_interpret(&space(""), &metta_atom("(decons-atom (a b c))"));
+        let result = call_interpret(space(""), &metta_atom("(decons-atom (a b c))"));
         assert_eq!(result, vec![metta_atom("(a (b c))")]);
     }
 
 
     #[test]
     fn interpret_atom_cons_atom_incorrect_args() {
-        assert_eq!(call_interpret(&space(""), &metta_atom("(cons-atom a (e) o)")),
+        assert_eq!(call_interpret(space(""), &metta_atom("(cons-atom a (e) o)")),
             vec![expr!("Error" ("cons-atom" "a" ("e") "o") "expected: (cons-atom <head> (: <tail> Expression)), found: (cons-atom a (e) o)")]);
-        assert_eq!(call_interpret(&space(""), &metta_atom("(cons-atom a e)")),
+        assert_eq!(call_interpret(space(""), &metta_atom("(cons-atom a e)")),
             vec![expr!("Error" ("cons-atom" "a" "e") "expected: (cons-atom <head> (: <tail> Expression)), found: (cons-atom a e)")]);
-        assert_eq!(call_interpret(&space(""), &metta_atom("(cons-atom a)")),
+        assert_eq!(call_interpret(space(""), &metta_atom("(cons-atom a)")),
             vec![expr!("Error" ("cons-atom" "a") "expected: (cons-atom <head> (: <tail> Expression)), found: (cons-atom a)")]);
     }
 
     #[test]
     fn interpret_atom_cons_atom_empty() {
-        let result = call_interpret(&space(""), &metta_atom("(cons-atom a ())"));
+        let result = call_interpret(space(""), &metta_atom("(cons-atom a ())"));
         assert_eq!(result, vec![metta_atom("(a)")]);
     }
 
     #[test]
     fn interpret_atom_cons_atom_single() {
-        let result = call_interpret(&space(""), &metta_atom("(cons-atom a (b))"));
+        let result = call_interpret(space(""), &metta_atom("(cons-atom a (b))"));
         assert_eq!(result, vec![metta_atom("(a b)")]);
     }
 
     #[test]
     fn interpret_atom_cons_atom_list() {
-        let result = call_interpret(&space(""), &metta_atom("(cons-atom a (b c))"));
+        let result = call_interpret(space(""), &metta_atom("(cons-atom a (b c))"));
         assert_eq!(result, vec![metta_atom("(a b c)")]);
     }
 
@@ -1819,23 +1819,23 @@ mod tests {
             (= (color) green)
             (= (color) blue)
         ");
-        let result = interpret(&space, &metta_atom("(chain (chain A $x $x) $y $y)"));
+        let result = interpret(space.clone(), &metta_atom("(chain (chain A $x $x) $y $y)"));
         assert_eq!(result, Ok(vec![metta_atom("A")]));
-        let result = interpret(&space, &metta_atom("(chain (chain (eval (foo A $b)) $x (bar $x)) $y (baz $y))"));
+        let result = interpret(space.clone(), &metta_atom("(chain (chain (eval (foo A $b)) $x (bar $x)) $y (baz $y))"));
         assert_eq!(result, Ok(vec![metta_atom("(baz (bar A))")]));
-        let result = interpret(&space, &metta_atom("(chain (chain (eval (fu A)) $x (bar $x)) $y (baz $y))"));
+        let result = interpret(space.clone(), &metta_atom("(chain (chain (eval (fu A)) $x (bar $x)) $y (baz $y))"));
         assert_eq!(result, Ok(vec![metta_atom("(baz (bar A))")]));
-        let result = interpret(&space, &metta_atom("(unify (A $b) ($a B) ($a $b) Empty)"));
+        let result = interpret(space.clone(), &metta_atom("(unify (A $b) ($a B) ($a $b) Empty)"));
         assert_eq!(result, Ok(vec![metta_atom("(A B)")]));
-        let result = interpret(&space, &metta_atom("(decons-atom (a b c))"));
+        let result = interpret(space.clone(), &metta_atom("(decons-atom (a b c))"));
         assert_eq!(result, Ok(vec![metta_atom("(a (b c))")]));
-        let result = interpret(&space, &metta_atom("(cons-atom a (b c))"));
+        let result = interpret(space.clone(), &metta_atom("(cons-atom a (b c))"));
         assert_eq!(result, Ok(vec![metta_atom("(a b c)")]));
-        let result = interpret(&space, &metta_atom("(chain (collapse-bind (eval (color))) $collapsed (superpose-bind $collapsed))")).unwrap();
+        let result = interpret(space.clone(), &metta_atom("(chain (collapse-bind (eval (color))) $collapsed (superpose-bind $collapsed))")).unwrap();
         assert_eq_no_order!(result, vec![metta_atom("red"), metta_atom("green"), metta_atom("blue")]);
-        let result = interpret(&space, &metta_atom("((P $a B) $a)"));
+        let result = interpret(space.clone(), &metta_atom("((P $a B) $a)"));
         assert_eq!(result, Ok(vec![metta_atom("((P $a B) $a)")]));
-        let result = interpret(&space, &metta_atom("(collapse-bind (eval (color)))")).unwrap();
+        let result = interpret(space.clone(), &metta_atom("(collapse-bind (eval (color)))")).unwrap();
         assert_eq!(result.len(), 1);
         assert_eq_no_order!(atom_as_slice(&result[0]).unwrap(), [
             atom_bindings_into_atom(expr!("red"), bind!{}),
@@ -1844,11 +1844,11 @@ mod tests {
         ]);
     }
 
-    fn space(text: &str) -> GroundingSpace {
+    fn space(text: &str) -> DynSpace {
         metta_space(text)
     }
 
-    fn call_interpret<'a, T: Space>(space: T, atom: &Atom) -> Vec<Atom> {
+    fn call_interpret(space: DynSpace, atom: &Atom) -> Vec<Atom> {
         let _ = env_logger::builder().is_test(true).try_init();
         let result = interpret(space, atom);
         assert!(result.is_ok());
@@ -1977,40 +1977,40 @@ mod tests {
 
     #[test]
     fn interpret_duplicated_types() {
-        let space = DynSpace::new(space("
+        let space = space("
             (: foo (-> A A))
             (: foo (-> A A))
             (: foo (-> Atom A))
             (: a A)
             (= (foo $x) a)
-        "));
-        let result = interpret(&space, &Atom::expr([METTA_SYMBOL, expr!("foo" "a"), ATOM_TYPE_UNDEFINED, Atom::gnd(space.clone())]));
+        ");
+        let result = interpret(space.clone(), &Atom::expr([METTA_SYMBOL, expr!("foo" "a"), ATOM_TYPE_UNDEFINED, Atom::gnd(space)]));
         assert_eq!(result, Ok(vec![metta_atom("a")]));
     }
 
     #[test]
     fn run_metta_using_context() {
-        let outer = DynSpace::new(space(""));
-        let nested = DynSpace::new(space("
+        let outer = space("");
+        let nested = space("
             (= (foo $x) $x)
-        "));
-        let result = interpret(&outer, &Atom::expr([METTA_SYMBOL, expr!("foo" "a"), ATOM_TYPE_UNDEFINED, Atom::gnd(nested)]));
+        ");
+        let result = interpret(outer, &Atom::expr([METTA_SYMBOL, expr!("foo" "a"), ATOM_TYPE_UNDEFINED, Atom::gnd(nested)]));
         assert_eq!(result, Ok(vec![metta_atom("a")]));
     }
 
     #[test]
     fn interpret_stop_evaluation() {
-        let space = DynSpace::new(space("
+        let space = space("
             (= (bar) X)
             (= (foo) (bar))
 
             (: q (-> Atom Atom))
             (= (q $a) $a)
             (= (e $a) $a)
-        "));
-        let result = interpret(&space, &Atom::expr([METTA_SYMBOL, expr!("q" ("foo")), ATOM_TYPE_UNDEFINED, Atom::gnd(space.clone())]));
+        ");
+        let result = interpret(space.clone(), &Atom::expr([METTA_SYMBOL, expr!("q" ("foo")), ATOM_TYPE_UNDEFINED, Atom::gnd(space.clone())]));
         assert_eq!(result, Ok(vec![Atom::expr([Atom::sym("foo")])]));
-        let result = interpret(&space, &Atom::expr([METTA_SYMBOL, expr!("e" ("q" ("foo"))), ATOM_TYPE_UNDEFINED, Atom::gnd(space.clone())]));
+        let result = interpret(space.clone(), &Atom::expr([METTA_SYMBOL, expr!("e" ("q" ("foo"))), ATOM_TYPE_UNDEFINED, Atom::gnd(space)]));
         assert_eq!(result, Ok(vec![Atom::sym("X")]));
     }
 }

--- a/lib/src/metta/interpreter.rs
+++ b/lib/src/metta/interpreter.rs
@@ -584,7 +584,7 @@ fn is_variable_op_expr(expr: &ExpressionAtom) -> bool {
     }
 }
 
-fn query<'a, T: Space>(space: T, prev: Option<Rc<RefCell<Stack>>>, to_eval: Atom, bindings: Bindings, vars: Variables) -> Vec<InterpretedAtom> {
+fn query(space: &DynSpace, prev: Option<Rc<RefCell<Stack>>>, to_eval: Atom, bindings: Bindings, vars: Variables) -> Vec<InterpretedAtom> {
     #[cfg(not(feature = "variable_operation"))]
     if is_variable_op(&to_eval) {
         // TODO: This is a hotfix. Better way of doing this is adding

--- a/lib/src/metta/runner/builtin_mods/catalog_mods.rs
+++ b/lib/src/metta/runner/builtin_mods/catalog_mods.rs
@@ -1,7 +1,7 @@
 use crate::atom::{Atom, Grounded, ExecError, CustomExecute};
 use crate::space::grounding::GroundingSpace;
 use crate::metta::{ARROW_SYMBOL, ATOM_TYPE_SYMBOL, UNIT_TYPE};
-use crate::metta::runner::{Metta, ModuleLoader, RunContext, DynSpace};
+use crate::metta::runner::{Metta, ModuleLoader, RunContext};
 use crate::metta::runner::pkg_mgmt::{UpdateMode, ManagedCatalog};
 use crate::metta::runner::stdlib::{regex, unit_result};
 use crate::metta::runner::modules::MettaMod;
@@ -55,8 +55,8 @@ pub(crate) struct CatalogModLoader;
 
 impl ModuleLoader for CatalogModLoader {
     fn load(&self, context: &mut RunContext) -> Result<(), String> {
-        let space = DynSpace::new(GroundingSpace::new());
-        context.init_self_module(space, None);
+        let space = GroundingSpace::new();
+        context.init_self_module(space.into(), None);
         self.load_tokens(context.module(), context.metta.clone())
     }
 

--- a/lib/src/metta/runner/builtin_mods/skel.rs
+++ b/lib/src/metta/runner/builtin_mods/skel.rs
@@ -1,7 +1,7 @@
 use crate::metta::*;
 use crate::space::grounding::GroundingSpace;
 use crate::metta::text::SExprParser;
-use crate::metta::runner::{ModuleLoader, RunContext, DynSpace, Metta, MettaMod};
+use crate::metta::runner::{ModuleLoader, RunContext, Metta, MettaMod};
 use crate::atom::gnd::*;
 
 pub static SKEL_METTA: &'static str = include_str!("skel.metta");
@@ -12,8 +12,8 @@ pub(crate) struct SkelModLoader;
 impl ModuleLoader for SkelModLoader {
     fn load(&self, context: &mut RunContext) -> Result<(), String> {
         // Initialize module's space
-        let space = DynSpace::new(GroundingSpace::new());
-        context.init_self_module(space, None);
+        let space = GroundingSpace::new();
+        context.init_self_module(space.into(), None);
 
         // Load module's tokens
         let _ = self.load_tokens(context.module(), context.metta.clone())?;

--- a/lib/src/metta/runner/environment.rs
+++ b/lib/src/metta/runner/environment.rs
@@ -5,6 +5,7 @@ use std::fs;
 use std::sync::Arc;
 
 use crate::{sym, ExpressionAtom, metta::GroundingSpace};
+use crate::space::DynSpace;
 
 #[cfg(feature = "pkg_mgmt")]
 use crate::metta::runner::pkg_mgmt::{ModuleCatalog, DirCatalog, LocalCatalog, FsModuleFormat, SingleFileModuleFmt, DirModuleFmt, git_catalog::*};
@@ -398,11 +399,11 @@ fn interpret_environment_metta<P: AsRef<Path>>(env_metta_path: P, env: &mut Envi
     let file = fs::File::open(env_metta_path).map_err(|e| e.to_string())?;
     let buf_reader = BufReader::new(file);
 
-    let space = GroundingSpace::new();
+    let space = DynSpace::new(GroundingSpace::new());
     let tokenizer = crate::metta::runner::Tokenizer::new();
     let mut parser = crate::metta::runner::SExprParser::new(buf_reader);
     while let Some(atom) = parser.parse(&tokenizer)? {
-        let atoms = crate::metta::runner::interpret(&space, &atom)?;
+        let atoms = crate::metta::runner::interpret(space.clone(), &atom)?;
         let atom = if atoms.len() != 1 {
             return Err(format!("Error in environment.metta. Atom must evaluate into a single deterministic result.  Found {atoms:?}"));
         } else {

--- a/lib/src/metta/runner/mod.rs
+++ b/lib/src/metta/runner/mod.rs
@@ -477,7 +477,7 @@ impl Metta {
         if self.type_check_is_enabled() && !validate_atom(&self.module_space(ModId::TOP), &atom) {
             Ok(vec![Atom::expr([ERROR_SYMBOL, atom, BAD_TYPE_SYMBOL])])
         } else {
-            interpret(self.space(), &atom)
+            interpret(self.space().clone(), &atom)
         }
     }
 
@@ -1132,7 +1132,7 @@ fn is_bare_minimal_interpreter(metta: &Metta) -> bool {
 struct InterpreterWrapper<'i> {
     mode: MettaRunnerMode,
     input_src: InputStream<'i>,
-    interpreter_state: Option<InterpreterState<DynSpace>>,
+    interpreter_state: Option<InterpreterState>,
     results: Vec<Vec<Atom>>,
 }
 

--- a/lib/src/metta/runner/mod.rs
+++ b/lib/src/metta/runner/mod.rs
@@ -1085,7 +1085,7 @@ impl<'input> RunContext<'_, 'input> {
                         },
                         MettaRunnerMode::INTERPRET => {
 
-                            if self.metta.type_check_is_enabled() && !validate_atom(self.module().space().borrow().as_space(), &atom) {
+                            if self.metta.type_check_is_enabled() && !validate_atom(&self.module().space(), &atom) {
                                 let type_err_exp = Atom::expr([ERROR_SYMBOL, atom, BAD_TYPE_SYMBOL]);
                                 self.i_wrapper.interpreter_state = Some(InterpreterState::new_finished(self.module().space().clone(), vec![type_err_exp]));
                             } else {

--- a/lib/src/metta/runner/mod.rs
+++ b/lib/src/metta/runner/mod.rs
@@ -244,7 +244,7 @@ impl Metta {
     pub fn new_core(space: Option<DynSpace>, env_builder: Option<EnvBuilder>) -> Self {
         let space = match space {
             Some(space) => space,
-            None => DynSpace::new(GroundingSpace::new())
+            None => GroundingSpace::new().into(),
         };
         let settings = PragmaSettings::new();
         let environment = match env_builder {

--- a/lib/src/metta/runner/modules/mod.rs
+++ b/lib/src/metta/runner/modules/mod.rs
@@ -68,11 +68,9 @@ impl MettaMod {
     pub(crate) fn new_with_tokenizer(metta: &Metta, mod_path: String, space: DynSpace, tokenizer: Shared<Tokenizer>, resource_dir: Option<PathBuf>, no_stdlib: bool) -> Self {
 
         //Give the space a name based on the module, if it doesn't already have one
-        if let Some(any_space) = space.borrow_mut().as_any_mut() {
-            if let Some(g_space) = any_space.downcast_mut::<GroundingSpace>() {
-                if g_space.name().is_none() {
-                    g_space.set_name(mod_path.clone());
-                }
+        if let Some(g_space) = space.borrow_mut().as_any_mut().downcast_mut::<GroundingSpace>() {
+            if g_space.name().is_none() {
+                g_space.set_name(mod_path.clone());
             }
         }
         let space = DynSpace::new(ModuleSpace::new(space));
@@ -218,7 +216,7 @@ impl MettaMod {
     fn insert_dep(&self, mod_id: ModId, dep_space: DynSpace) -> Result<(), String> {
         let mut deps_table = self.imported_deps.lock().unwrap();
         if !deps_table.contains_key(&mod_id) {
-            match self.space.borrow_mut().as_any_mut().unwrap().downcast_mut::<ModuleSpace>() {
+            match self.space.borrow_mut().as_any_mut().downcast_mut::<ModuleSpace>() {
                 Some(s) => s.add_dep(dep_space.clone()),
                 None => unreachable!(),
             }

--- a/lib/src/metta/runner/modules/mod.rs
+++ b/lib/src/metta/runner/modules/mod.rs
@@ -665,8 +665,8 @@ mod test {
 
     impl ModuleLoader for OuterLoader {
         fn load(&self, context: &mut RunContext) -> Result<(), String> {
-            let space = DynSpace::new(GroundingSpace::new());
-            context.init_self_module(space, None);
+            let space = GroundingSpace::new();
+            context.init_self_module(space.into(), None);
 
             let parser = SExprParser::new("outer-module-test-atom");
             context.push_parser(Box::new(parser));
@@ -680,8 +680,8 @@ mod test {
 
     impl ModuleLoader for InnerLoader {
         fn load(&self, context: &mut RunContext) -> Result<(), String> {
-            let space = DynSpace::new(GroundingSpace::new());
-            context.init_self_module(space, None);
+            let space = GroundingSpace::new();
+            context.init_self_module(space.into(), None);
 
             let parser = SExprParser::new("inner-module-test-atom");
             context.push_parser(Box::new(parser));
@@ -726,8 +726,8 @@ mod test {
 
     impl ModuleLoader for RelativeOuterLoader {
         fn load(&self, context: &mut RunContext) -> Result<(), String> {
-            let space = DynSpace::new(GroundingSpace::new());
-            context.init_self_module(space, None);
+            let space = GroundingSpace::new();
+            context.init_self_module(space.into(), None);
 
             let _inner_mod_id = context.load_module_direct(Box::new(InnerLoader), "self:inner").unwrap();
 

--- a/lib/src/metta/runner/pkg_mgmt/catalog.rs
+++ b/lib/src/metta/runner/pkg_mgmt/catalog.rs
@@ -425,9 +425,9 @@ impl SingleFileModule {
 impl ModuleLoader for SingleFileModule {
     fn load(&self, context: &mut RunContext) -> Result<(), String> {
 
-        let space = DynSpace::new(GroundingSpace::new());
+        let space = GroundingSpace::new();
         let resource_dir = self.path.parent().unwrap();
-        context.init_self_module(space, Some(resource_dir.into()));
+        context.init_self_module(space.into(), Some(resource_dir.into()));
 
         let parser = SExprParser::new(std::io::BufReader::new(self.open_file()?));
         context.push_parser(Box::new(parser));
@@ -469,9 +469,9 @@ impl DirModule {
 impl ModuleLoader for DirModule {
     fn load(&self, context: &mut RunContext) -> Result<(), String> {
 
-        let space = DynSpace::new(GroundingSpace::new());
+        let space = GroundingSpace::new();
         let resource_dir = &self.path;
-        context.init_self_module(space, Some(resource_dir.into()));
+        context.init_self_module(space.into(), Some(resource_dir.into()));
 
         // A module.metta file is optional.  Without one a dir module behaves as just
         // a container for other resources and sub-modules.
@@ -806,8 +806,8 @@ mod tests {
 
     impl ModuleLoader for TestCatalog {
         fn load(&self, context: &mut RunContext) -> Result<(), String> {
-            let space = DynSpace::new(GroundingSpace::new());
-            context.init_self_module(space, None);
+            let space = GroundingSpace::new();
+            context.init_self_module(space.into(), None);
             Ok(())
         }
     }
@@ -870,8 +870,8 @@ mod tests {
 
     impl ModuleLoader for TestLoader {
         fn load(&self, context: &mut RunContext) -> Result<(), String> {
-            let space = DynSpace::new(GroundingSpace::new());
-            context.init_self_module(space, None);
+            let space = GroundingSpace::new();
+            context.init_self_module(space.into(), None);
 
             Ok(())
         }

--- a/lib/src/metta/runner/stdlib/atom.rs
+++ b/lib/src/metta/runner/stdlib/atom.rs
@@ -718,12 +718,12 @@ mod tests {
 
     #[test]
     fn get_type_op() {
-        let space = DynSpace::new(metta_space("
+        let space = metta_space("
             (: B Type)
             (: C Type)
             (: A B)
             (: A C)
-        "));
+        ");
 
         let get_type_op = GetTypeOp::new(space.clone());
         assert_eq_no_order!(get_type_op.execute(&mut vec![sym!("A"), expr!({space.clone()})]).unwrap(),
@@ -732,11 +732,11 @@ mod tests {
 
     #[test]
     fn get_type_op_non_valid_atom() {
-        let space = DynSpace::new(metta_space("
+        let space = metta_space("
             (: f (-> Number String))
             (: 42 Number)
             (: \"test\" String)
-        "));
+        ");
 
         let get_type_op = GetTypeOp::new(space.clone());
         assert_eq_no_order!(get_type_op.execute(&mut vec![expr!("f" "42"), expr!({space.clone()})]).unwrap(),

--- a/lib/src/metta/runner/stdlib/core.rs
+++ b/lib/src/metta/runner/stdlib/core.rs
@@ -546,7 +546,7 @@ mod tests {
 
     #[test]
     fn match_op() {
-        let space = DynSpace::new(metta_space("(A B)"));
+        let space = metta_space("(A B)");
         let match_op = MatchOp{};
         assert_eq!(match_op.execute(&mut vec![expr!({space}), expr!("A" "B"), expr!("B" "A")]),
                    Ok(vec![expr!("B" "A")]));
@@ -554,7 +554,7 @@ mod tests {
 
     #[test]
     fn match_op_issue_530() {
-        let space = DynSpace::new(metta_space("(A $a $a)"));
+        let space = metta_space("(A $a $a)");
         let match_op = MatchOp{};
         let result = match_op.execute(&mut vec![expr!({space}), expr!("A" x y), expr!("A" x y)]).unwrap();
         assert_eq!(result.len(), 1);

--- a/lib/src/metta/runner/stdlib/debug.rs
+++ b/lib/src/metta/runner/stdlib/debug.rs
@@ -445,13 +445,13 @@ mod tests {
 
     #[test]
     fn assert_equal_op() {
-        let space = DynSpace::new(metta_space("
+        let space = metta_space("
             (= (foo) (A B))
             (= (foo) (B C))
             (= (bar) (B C))
             (= (bar) (A B))
             (= (err) (A B))
-        "));
+        ");
 
         let assert_equal_op = AssertEqualOp::new(space, PragmaSettings::new());
 
@@ -468,10 +468,10 @@ mod tests {
 
     #[test]
     fn assert_equal_to_result_op() {
-        let space = DynSpace::new(metta_space("
+        let space = metta_space("
             (= (foo) (A B))
             (= (foo) (B C))
-        "));
+        ");
         let assert_equal_to_result_op = AssertEqualToResultOp::new(space, PragmaSettings::new());
 
         assert_eq!(assert_equal_to_result_op.execute(&mut vec![

--- a/lib/src/metta/runner/stdlib/mod.rs
+++ b/lib/src/metta/runner/stdlib/mod.rs
@@ -129,8 +129,8 @@ impl Default for CoreLibLoader {
 
 impl ModuleLoader for CoreLibLoader {
     fn load(&self, context: &mut RunContext) -> Result<(), String> {
-        let space = DynSpace::new(GroundingSpace::new());
-        context.init_self_module(space, None);
+        let space = GroundingSpace::new();
+        context.init_self_module(space.into(), None);
 
         self.load_tokens(context.module(), context.metta.clone())?;
 

--- a/lib/src/metta/runner/stdlib/space.rs
+++ b/lib/src/metta/runner/stdlib/space.rs
@@ -267,10 +267,10 @@ mod tests {
 
     #[test]
     fn remove_atom_op() {
-        let space = DynSpace::new(metta_space("
+        let space = metta_space("
             (foo bar)
             (bar foo)
-        "));
+        ");
         let satom = Atom::gnd(space.clone());
         let res = RemoveAtomOp{}.execute(&mut vec![satom, expr!(("foo" "bar"))]).expect("No result returned");
         // REM: can return Bool in future
@@ -281,10 +281,10 @@ mod tests {
 
     #[test]
     fn get_atoms_op() {
-        let space = DynSpace::new(metta_space("
+        let space = metta_space("
             (foo bar)
             (bar foo)
-        "));
+        ");
         let satom = Atom::gnd(space.clone());
         let res = GetAtomsOp{}.execute(&mut vec![satom]).expect("No result returned");
         let space_atoms = collect_atoms(space.borrow().as_space());

--- a/lib/src/metta/types.rs
+++ b/lib/src/metta/types.rs
@@ -607,7 +607,7 @@ mod tests {
         while let Some(atom) = parser.parse(&*metta.tokenizer().borrow()).unwrap() {
             space.add(atom);
         }
-        DynSpace::new(space)
+        space.into()
     }
 
     fn atom(atom_str: &str) -> Atom {
@@ -633,14 +633,15 @@ mod tests {
         space.add(expr!(":" "like" "Verb"));
         space.add(expr!(":" "a" "Det"));
         space.add(expr!(":" "pizza" "Noun"));
-        DynSpace::new(space)
+        space.into()
     }
 
     #[test]
     fn test_check_type() {
-        let space = DynSpace::new(GroundingSpace::new());
-        space.borrow_mut().add(expr!(":" "do" "Verb"));
-        space.borrow_mut().add(expr!(":" "do" "Aux"));
+        let mut space = GroundingSpace::new();
+        space.add(expr!(":" "do" "Verb"));
+        space.add(expr!(":" "do" "Aux"));
+        let space = space.into();
 
         let aux = sym!("Aux");
         let verb = sym!("Verb");
@@ -659,12 +660,13 @@ mod tests {
 
     #[test]
     fn test_check_expr_type() {
-        let space = DynSpace::new(GroundingSpace::new());
-        space.borrow_mut().add(expr!(":" "i" "Pron"));
-        space.borrow_mut().add(expr!(":" "like" "Verb"));
-        space.borrow_mut().add(expr!(":" "music" "Noun"));
-        space.borrow_mut().add(expr!(":" ("do" "you" "like" "music") "Quest"));
-        space.borrow_mut().add(expr!(":<" ("Pron" "Verb" "Noun") "Statement"));
+        let mut space = GroundingSpace::new();
+        space.add(expr!(":" "i" "Pron"));
+        space.add(expr!(":" "like" "Verb"));
+        space.add(expr!(":" "music" "Noun"));
+        space.add(expr!(":" ("do" "you" "like" "music") "Quest"));
+        space.add(expr!(":<" ("Pron" "Verb" "Noun") "Statement"));
+        let space = space.into();
 
         let i_like_music = expr!("i" "like" "music");
         assert!(check_type(&space, &i_like_music, &ATOM_TYPE_UNDEFINED));
@@ -916,7 +918,7 @@ mod tests {
     fn get_atom_types_variables_are_substituted_for_grounded_atom_type() {
         let actual_type = Atom::var("t");
         let gnd = GroundedAtomWithParameterizedType(actual_type.clone());
-        let resolved_type = get_atom_types(&DynSpace::new(GroundingSpace::new()), &Atom::gnd(gnd));
+        let resolved_type = get_atom_types(&GroundingSpace::new().into(), &Atom::gnd(gnd));
         assert_eq!(resolved_type.len(), 1);
         assert_ne!(resolved_type[0], actual_type);
         assert!(atoms_are_equivalent(&resolved_type[0], &actual_type));
@@ -927,8 +929,8 @@ mod tests {
         let actual_type = Atom::expr([ARROW_SYMBOL, Atom::var("t"), Atom::var("t")]);
         let gnd_1 = GroundedAtomWithParameterizedType(actual_type.clone());
         let gnd_2 = GroundedAtomWithParameterizedType(actual_type.clone());
-        let resolved_type_1 = get_atom_types(&DynSpace::new(GroundingSpace::new()), &Atom::gnd(gnd_1));
-        let resolved_type_2 = get_atom_types(&DynSpace::new(GroundingSpace::new()), &Atom::gnd(gnd_2));
+        let resolved_type_1 = get_atom_types(&GroundingSpace::new().into(), &Atom::gnd(gnd_1));
+        let resolved_type_2 = get_atom_types(&GroundingSpace::new().into(), &Atom::gnd(gnd_2));
 
         //Types of gnd_1 and gnd_2 are different in the space
         assert_ne!(resolved_type_1, resolved_type_2);

--- a/lib/src/metta/types.rs
+++ b/lib/src/metta/types.rs
@@ -20,7 +20,7 @@
 
 use super::*;
 use crate::atom::matcher::{Bindings, BindingsSet, apply_bindings_to_atom_move};
-use crate::space::Space;
+use crate::space::DynSpace;
 
 use std::fmt::{Display, Debug};
 use itertools::Itertools;
@@ -33,19 +33,19 @@ fn isa_query(sub_type: &Atom, super_type: &Atom) -> Atom {
     Atom::expr(vec![SUB_TYPE_SYMBOL, sub_type.clone(), super_type.clone()])
 }
 
-fn query_has_type(space: &dyn Space, sub_type: &Atom, super_type: &Atom) -> BindingsSet {
-    space.query(&typeof_query(sub_type, super_type))
+fn query_has_type(space: &DynSpace, sub_type: &Atom, super_type: &Atom) -> BindingsSet {
+    space.borrow().query(&typeof_query(sub_type, super_type))
 }
 
-fn query_super_types(space: &dyn Space, sub_type: &Atom) -> Vec<Atom> {
+fn query_super_types(space: &DynSpace, sub_type: &Atom) -> Vec<Atom> {
     // TODO: query should check that sub type is a type and not another typed symbol
     let var_x = VariableAtom::new("X").make_unique();
-    let super_types = space.query(&isa_query(&sub_type, &Atom::Variable(var_x.clone())));
+    let super_types = space.borrow().query(&isa_query(&sub_type, &Atom::Variable(var_x.clone())));
     let atom_x = Atom::Variable(var_x);
     super_types.into_iter().map(|bindings| { apply_bindings_to_atom_move(atom_x.clone(), &bindings) }).collect()
 }
 
-fn add_super_types(space: &dyn Space, sub_types: &mut Vec<Atom>, from: usize) {
+fn add_super_types(space: &DynSpace, sub_types: &mut Vec<Atom>, from: usize) {
     let mut types = Vec::new();
     sub_types.iter().skip(from).for_each(|typ| {
         for typ in query_super_types(space, typ) {
@@ -119,7 +119,7 @@ pub fn is_func(typ: &Atom) -> bool {
     }
 }
 
-fn query_types(space: &dyn Space, atom: &Atom) -> Vec<Atom> {
+fn query_types(space: &DynSpace, atom: &Atom) -> Vec<Atom> {
     let var_x = VariableAtom::new("X").make_unique();
     let types = query_has_type(space, atom, &Atom::Variable(var_x.clone()));
     let atom_x = Atom::Variable(var_x);
@@ -248,7 +248,7 @@ impl Display for AtomType {
 /// assert_eq_no_order!(get_atom_types(&space, &expr!("f" "a")), vec![expr!("B")]);
 /// assert_eq_no_order!(get_atom_types(&space, &expr!("f" "b")), Vec::<Atom>::new());
 /// ```
-pub fn get_atom_types(space: &dyn Space, atom: &Atom) -> Vec<Atom> {
+pub fn get_atom_types(space: &DynSpace, atom: &Atom) -> Vec<Atom> {
     let atom_types = get_atom_types_v2(space, atom);
     if atom_types.is_empty() {
         vec![ATOM_TYPE_UNDEFINED]
@@ -267,7 +267,7 @@ struct ExprTypeInfo {
 }
 
 impl ExprTypeInfo {
-    fn new(space: &dyn Space, expr: &ExpressionAtom) -> Self {
+    fn new(space: &DynSpace, expr: &ExpressionAtom) -> Self {
         let (op, args) = expr.children().split_first().unwrap();
         let op_types = get_atom_types_v2(space, op);
         let mut op_func_types = Vec::with_capacity(op_types.len());
@@ -300,7 +300,7 @@ impl ExprTypeInfo {
     }
 }
 
-pub fn get_atom_types_v2(space: &dyn Space, atom: &Atom) -> Vec<AtomType> {
+pub fn get_atom_types_v2(space: &DynSpace, atom: &Atom) -> Vec<AtomType> {
     log::trace!("get_atom_types_v2: atom: {}", atom);
     let types = match atom {
         // TODO: type of the variable could be actually a type variable,
@@ -393,7 +393,7 @@ impl<'a> Iterator for TupleIndex<'a> {
     }
 }
 
-fn get_tuple_types(space: &dyn Space, atom: &Atom, type_info: &ExprTypeInfo) -> Vec<AtomType> {
+fn get_tuple_types(space: &DynSpace, atom: &Atom, type_info: &ExprTypeInfo) -> Vec<AtomType> {
     let mut types = if let Some(index) = TupleIndex::new(type_info) {
         let mut types = Vec::with_capacity(index.size());
         index.for_each(|v| types.push(Atom::expr(v)));
@@ -498,7 +498,7 @@ fn replace_undefined_types(atom: &Atom) -> Atom {
     atom
 }
 
-fn get_matched_types(space: &dyn Space, atom: &Atom, typ: &Atom) -> Vec<(Atom, Bindings)> {
+fn get_matched_types(space: &DynSpace, atom: &Atom, typ: &Atom) -> Vec<(Atom, Bindings)> {
     let types = get_atom_types(space, atom);
     types.into_iter().flat_map(|t| {
         // TODO: write a unit test
@@ -524,7 +524,7 @@ fn get_matched_types(space: &dyn Space, atom: &Atom, typ: &Atom) -> Vec<(Atom, B
 ///
 /// assert!(check_type(&metta.space(), &expr!("a"), &expr!("B")));
 /// ```
-pub fn check_type(space: &dyn Space, atom: &Atom, typ: &Atom) -> bool {
+pub fn check_type(space: &DynSpace, atom: &Atom, typ: &Atom) -> bool {
     check_meta_type(atom, typ) || !get_matched_types(space, atom, typ).is_empty()
 }
 
@@ -546,7 +546,7 @@ pub fn check_type(space: &dyn Space, atom: &Atom, typ: &Atom) -> bool {
 ///
 /// assert_eq!(types, vec![(expr!("List" "A"), bind!{ t: expr!("A") })]);
 /// ```
-pub fn get_type_bindings(space: &dyn Space, atom: &Atom, typ: &Atom) -> Vec<(Atom, Bindings)> {
+pub fn get_type_bindings(space: &DynSpace, atom: &Atom, typ: &Atom) -> Vec<(Atom, Bindings)> {
     let mut result = Vec::new();
     if check_meta_type(atom, typ) {
         result.push((typ.clone(), Bindings::new()));
@@ -589,7 +589,7 @@ fn check_meta_type(atom: &Atom, typ: &Atom) -> bool {
 /// assert!(validate_atom(&space, &expr!("foo" "a")));
 /// assert!(!validate_atom(&space, &expr!("foo" "b")));
 /// ```
-pub fn validate_atom(space: &dyn Space, atom: &Atom) -> bool {
+pub fn validate_atom(space: &DynSpace, atom: &Atom) -> bool {
     !get_atom_types(space, atom).is_empty()
 }
 
@@ -600,14 +600,14 @@ mod tests {
     use crate::metta::runner::*;
     use crate::metta::text::SExprParser;
 
-    fn metta_space(text: &str) -> GroundingSpace {
+    fn metta_space(text: &str) -> DynSpace {
         let metta = Metta::new(Some(EnvBuilder::test_env()));
         let mut space = GroundingSpace::new();
         let mut parser = SExprParser::new(text);
         while let Some(atom) = parser.parse(&*metta.tokenizer().borrow()).unwrap() {
             space.add(atom);
         }
-        space
+        DynSpace::new(space)
     }
 
     fn atom(atom_str: &str) -> Atom {
@@ -617,7 +617,7 @@ mod tests {
         atom
     }
 
-    fn grammar_space() -> GroundingSpace {
+    fn grammar_space() -> DynSpace {
         let mut space = GroundingSpace::new();
         space.add(expr!(":" "answer" ("->" "Sent" "Sent")));
         space.add(expr!(":<" "Quest" "Sent"));
@@ -633,14 +633,14 @@ mod tests {
         space.add(expr!(":" "like" "Verb"));
         space.add(expr!(":" "a" "Det"));
         space.add(expr!(":" "pizza" "Noun"));
-        space
+        DynSpace::new(space)
     }
 
     #[test]
     fn test_check_type() {
-        let mut space = GroundingSpace::new();
-        space.add(expr!(":" "do" "Verb"));
-        space.add(expr!(":" "do" "Aux"));
+        let space = DynSpace::new(GroundingSpace::new());
+        space.borrow_mut().add(expr!(":" "do" "Verb"));
+        space.borrow_mut().add(expr!(":" "do" "Aux"));
 
         let aux = sym!("Aux");
         let verb = sym!("Verb");
@@ -659,12 +659,12 @@ mod tests {
 
     #[test]
     fn test_check_expr_type() {
-        let mut space = GroundingSpace::new();
-        space.add(expr!(":" "i" "Pron"));
-        space.add(expr!(":" "like" "Verb"));
-        space.add(expr!(":" "music" "Noun"));
-        space.add(expr!(":" ("do" "you" "like" "music") "Quest"));
-        space.add(expr!(":<" ("Pron" "Verb" "Noun") "Statement"));
+        let space = DynSpace::new(GroundingSpace::new());
+        space.borrow_mut().add(expr!(":" "i" "Pron"));
+        space.borrow_mut().add(expr!(":" "like" "Verb"));
+        space.borrow_mut().add(expr!(":" "music" "Noun"));
+        space.borrow_mut().add(expr!(":" ("do" "you" "like" "music") "Quest"));
+        space.borrow_mut().add(expr!(":<" ("Pron" "Verb" "Noun") "Statement"));
 
         let i_like_music = expr!("i" "like" "music");
         assert!(check_type(&space, &i_like_music, &ATOM_TYPE_UNDEFINED));
@@ -708,7 +708,7 @@ mod tests {
 
     #[test]
     fn validate_symbol() {
-        let space = GroundingSpace::new();
+        let space = DynSpace::new(GroundingSpace::new());
         assert!(validate_atom(&space, &sym!("a")));
     }
 
@@ -748,7 +748,7 @@ mod tests {
 
     #[test]
     fn validate_basic_expr() {
-        let space = GroundingSpace::new();
+        let space = DynSpace::new(GroundingSpace::new());
         assert!(validate_atom(&space, &expr!({5})));
         assert!(validate_atom(&space, &expr!("+" {3} {5})));
         assert!(validate_atom(&space, &expr!("=" ("f" x) x)));
@@ -887,13 +887,13 @@ mod tests {
 
     #[test]
     fn get_atom_types_variable() {
-        let space = GroundingSpace::new();
+        let space = DynSpace::new(GroundingSpace::new());
         assert_eq!(get_atom_types(&space, &atom("$x")), vec![ATOM_TYPE_UNDEFINED]);
     }
 
     #[test]
     fn get_atom_types_grounded_atom() {
-        let space = GroundingSpace::new();
+        let space = DynSpace::new(GroundingSpace::new());
         assert_eq!(get_atom_types(&space, &Atom::value(3)), vec![atom("i32")]);
     }
 
@@ -916,7 +916,7 @@ mod tests {
     fn get_atom_types_variables_are_substituted_for_grounded_atom_type() {
         let actual_type = Atom::var("t");
         let gnd = GroundedAtomWithParameterizedType(actual_type.clone());
-        let resolved_type = get_atom_types(&GroundingSpace::new(), &Atom::gnd(gnd));
+        let resolved_type = get_atom_types(&DynSpace::new(GroundingSpace::new()), &Atom::gnd(gnd));
         assert_eq!(resolved_type.len(), 1);
         assert_ne!(resolved_type[0], actual_type);
         assert!(atoms_are_equivalent(&resolved_type[0], &actual_type));
@@ -927,8 +927,8 @@ mod tests {
         let actual_type = Atom::expr([ARROW_SYMBOL, Atom::var("t"), Atom::var("t")]);
         let gnd_1 = GroundedAtomWithParameterizedType(actual_type.clone());
         let gnd_2 = GroundedAtomWithParameterizedType(actual_type.clone());
-        let resolved_type_1 = get_atom_types(&GroundingSpace::new(), &Atom::gnd(gnd_1));
-        let resolved_type_2 = get_atom_types(&GroundingSpace::new(), &Atom::gnd(gnd_2));
+        let resolved_type_1 = get_atom_types(&DynSpace::new(GroundingSpace::new()), &Atom::gnd(gnd_1));
+        let resolved_type_2 = get_atom_types(&DynSpace::new(GroundingSpace::new()), &Atom::gnd(gnd_2));
 
         //Types of gnd_1 and gnd_2 are different in the space
         assert_ne!(resolved_type_1, resolved_type_2);
@@ -968,7 +968,7 @@ mod tests {
 
     #[test]
     fn get_atom_types_empty_expression() {
-        let space = GroundingSpace::new();
+        let space = DynSpace::new(GroundingSpace::new());
         assert_eq!(get_atom_types(&space, &Atom::expr([])), vec![ATOM_TYPE_UNDEFINED]);
     }
 

--- a/lib/src/space/grounding/mod.rs
+++ b/lib/src/space/grounding/mod.rs
@@ -193,11 +193,11 @@ impl Space for GroundingSpace {
     fn visit(&self, v: &mut dyn SpaceVisitor) -> Result<(), ()> {
        Ok(self.index.iter().for_each(|atom| v.accept(atom)))
     }
-    fn as_any(&self) -> Option<&dyn std::any::Any> {
-        Some(self)
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
     }
-    fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
-        Some(self)
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
     }
 }
 

--- a/lib/src/space/grounding/mod.rs
+++ b/lib/src/space/grounding/mod.rs
@@ -211,9 +211,6 @@ impl SpaceMut for GroundingSpace {
     fn replace(&mut self, from: &Atom, to: Atom) -> bool {
         GroundingSpace::replace(self, from, to)
     }
-    fn as_space<'a>(&self) -> &(dyn Space + 'a) {
-        self
-    }
 }
 
 impl PartialEq for GroundingSpace {

--- a/lib/src/space/grounding/mod.rs
+++ b/lib/src/space/grounding/mod.rs
@@ -196,9 +196,6 @@ impl Space for GroundingSpace {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
-    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
-        self
-    }
 }
 
 impl SpaceMut for GroundingSpace {
@@ -210,6 +207,9 @@ impl SpaceMut for GroundingSpace {
     }
     fn replace(&mut self, from: &Atom, to: Atom) -> bool {
         GroundingSpace::replace(self, from, to)
+    }
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
     }
 }
 

--- a/lib/src/space/mod.rs
+++ b/lib/src/space/mod.rs
@@ -212,10 +212,10 @@ pub trait Space: std::fmt::Debug + std::fmt::Display {
     fn visit(&self, v: &mut dyn SpaceVisitor) -> Result<(), ()>;
 
     /// Returns an `&dyn `[Any](std::any::Any) for spaces where this is possible
-    fn as_any(&self) -> Option<&dyn std::any::Any>;
+    fn as_any(&self) -> &dyn std::any::Any;
 
     /// Returns an `&mut dyn `[Any](std::any::Any) for spaces where this is possible
-    fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any>;
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any;
 }
 
 /// Mutable space trait.
@@ -334,30 +334,6 @@ impl crate::atom::Grounded for DynSpace {
 impl CustomMatch for DynSpace {
     fn match_(&self, other: &Atom) -> matcher::MatchResultIter {
         Box::new(self.borrow().query(other).into_iter())
-    }
-}
-
-impl<T: Space> Space for &T {
-    fn common(&self) -> FlexRef<SpaceCommon> {
-        T::common(*self)
-    }
-    fn query(&self, query: &Atom) -> BindingsSet {
-        T::query(*self, query)
-    }
-    fn subst(&self, pattern: &Atom, template: &Atom) -> Vec<Atom> {
-        T::subst(*self, pattern, template)
-    }
-    fn atom_count(&self) -> Option<usize> {
-        T::atom_count(*self)
-    }
-    fn visit(&self, v: &mut dyn SpaceVisitor) -> Result<(), ()> {
-        T::visit(*self, v)
-    }
-    fn as_any(&self) -> Option<&dyn std::any::Any> {
-        None
-    }
-    fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
-        None
     }
 }
 

--- a/lib/src/space/mod.rs
+++ b/lib/src/space/mod.rs
@@ -213,9 +213,6 @@ pub trait Space: std::fmt::Debug + std::fmt::Display {
 
     /// Returns an `&dyn `[Any](std::any::Any) for spaces where this is possible
     fn as_any(&self) -> &dyn std::any::Any;
-
-    /// Returns an `&mut dyn `[Any](std::any::Any) for spaces where this is possible
-    fn as_any_mut(&mut self) -> &mut dyn std::any::Any;
 }
 
 /// Mutable space trait.
@@ -276,6 +273,9 @@ pub trait SpaceMut: Space {
     /// assert_eq!(space.query(&sym!("B")), BindingsSet::single());
     /// ```
     fn replace(&mut self, from: &Atom, to: Atom) -> bool;
+
+    /// Returns an `&mut dyn `[Any](std::any::Any) for spaces where this is possible
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any;
 }
 
 #[derive(Clone)]

--- a/lib/src/space/mod.rs
+++ b/lib/src/space/mod.rs
@@ -276,19 +276,12 @@ pub trait SpaceMut: Space {
     /// assert_eq!(space.query(&sym!("B")), BindingsSet::single());
     /// ```
     fn replace(&mut self, from: &Atom, to: Atom) -> bool;
-
-    /// Turn a &dyn SpaceMut into an &dyn Space.  Obsolete when Trait Upcasting is stabilized.
-    /// [Rust issue #65991](https://github.com/rust-lang/rust/issues/65991)  Any month now.
-    fn as_space<'a>(&self) -> &(dyn Space + 'a);
 }
 
 #[derive(Clone)]
 pub struct DynSpace(Rc<RefCell<dyn SpaceMut>>);
 
 impl DynSpace {
-    pub fn with_rc(space: Rc<RefCell<dyn SpaceMut>>) -> Self {
-        Self(space)
-    }
     pub fn new<T: SpaceMut + 'static>(space: T) -> Self {
         let shared = Rc::new(RefCell::new(space));
         DynSpace(shared)
@@ -299,9 +292,14 @@ impl DynSpace {
     pub fn borrow_mut(&self) -> RefMut<dyn SpaceMut> {
         self.0.borrow_mut()
     }
-    /// A convenience.  See [SpaceCommon::register_observer]
-    pub fn register_observer<T: SpaceObserver + 'static>(&self, observer: T) -> SpaceObserverRef<T> {
-        self.common().register_observer(observer)
+    pub fn common(&self) -> FlexRef<SpaceCommon> {
+        FlexRef::from_ref_cell(Ref::map(self.0.borrow(), |space| space.common().into_simple()))
+    }
+}
+
+impl<T: SpaceMut + 'static> From<T> for DynSpace {
+    fn from(value: T) -> Self {
+        DynSpace::new(value)
     }
 }
 
@@ -314,45 +312,6 @@ impl core::fmt::Debug for DynSpace {
 impl Display for DynSpace {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", &*self.0.borrow())
-    }
-}
-
-impl SpaceMut for DynSpace {
-    fn add(&mut self, atom: Atom) {
-        self.0.borrow_mut().add(atom)
-    }
-    fn remove(&mut self, atom: &Atom) -> bool {
-        self.0.borrow_mut().remove(atom)
-    }
-    fn replace(&mut self, from: &Atom, to: Atom) -> bool {
-        self.0.borrow_mut().replace(from, to)
-    }
-    fn as_space<'a>(&self) -> &(dyn Space + 'a) {
-        self
-    }
-}
-
-impl Space for DynSpace {
-    fn common(&self) -> FlexRef<SpaceCommon> {
-        FlexRef::from_ref_cell(Ref::map(self.0.borrow(), |space| space.common().into_simple()))
-    }
-    fn query(&self, query: &Atom) -> BindingsSet {
-        self.0.borrow().query(query)
-    }
-    fn subst(&self, pattern: &Atom, template: &Atom) -> Vec<Atom> {
-        self.0.borrow().subst(pattern, template)
-    }
-    fn atom_count(&self) -> Option<usize> {
-        self.0.borrow().atom_count()
-    }
-    fn visit(&self, v: &mut dyn SpaceVisitor) -> Result<(), ()> {
-        self.0.borrow().visit(v)
-    }
-    fn as_any(&self) -> Option<&dyn std::any::Any> {
-        None
-    }
-    fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
-        None
     }
 }
 
@@ -374,7 +333,7 @@ impl crate::atom::Grounded for DynSpace {
 
 impl CustomMatch for DynSpace {
     fn match_(&self, other: &Atom) -> matcher::MatchResultIter {
-        Box::new(self.query(other).into_iter())
+        Box::new(self.borrow().query(other).into_iter())
     }
 }
 

--- a/lib/src/space/module.rs
+++ b/lib/src/space/module.rs
@@ -71,9 +71,6 @@ impl Space for ModuleSpace {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
-    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
-        self
-    }
 }
 
 impl SpaceMut for ModuleSpace {
@@ -85,6 +82,9 @@ impl SpaceMut for ModuleSpace {
     }
     fn replace(&mut self, from: &Atom, to: Atom) -> bool {
         self.main.borrow_mut().replace(from, to)
+    }
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
     }
 }
 

--- a/lib/src/space/module.rs
+++ b/lib/src/space/module.rs
@@ -3,7 +3,7 @@ use super::*;
 use std::fmt::Debug;
 
 pub struct ModuleSpace {
-    main: Box<dyn SpaceMut>,
+    main: DynSpace,
     deps: Vec<DynSpace>,
 }
 
@@ -20,8 +20,8 @@ impl Debug for ModuleSpace {
 }
 
 impl ModuleSpace {
-    pub fn new<T: SpaceMut + 'static>(space: T) -> Self {
-        Self { main: Box::new(space), deps: Vec::new() }
+    pub fn new(space: DynSpace) -> Self {
+        Self { main: space, deps: Vec::new() }
     }
 
     pub fn query(&self, query: &Atom) -> BindingsSet {
@@ -103,12 +103,12 @@ mod test {
 
     #[test]
     fn complex_query_two_subspaces() {
-        let mut a = GroundingSpace::new();
+        let mut a = DynSpace::new(GroundingSpace::new());
         a.add(expr!("a" "b"));
-        let mut b = GroundingSpace::new();
+        let mut b = DynSpace::new(GroundingSpace::new());
         b.add(expr!("b" "c"));
 
-        let mut main = ModuleSpace::new(GroundingSpace::new());
+        let mut main = ModuleSpace::new(DynSpace::new(GroundingSpace::new()));
         main.add_dep(DynSpace::new(ModuleSpace::new(a)));
         main.add_dep(DynSpace::new(ModuleSpace::new(b)));
 

--- a/lib/src/space/module.rs
+++ b/lib/src/space/module.rs
@@ -32,14 +32,10 @@ impl ModuleSpace {
         log::debug!("ModuleSpace::query: {} {}", self, query);
         let mut results = self.main.borrow().query(query);
         for dep in &self.deps {
-            if let Some(space) = dep.borrow().as_any() {
-                if let Some(space) = space.downcast_ref::<Self>()  {
-                    results.extend(space.query_no_deps(query));
-                } else {
-                    panic!("Only ModuleSpace is expected inside dependencies collection");
-                }
+            if let Some(space) = dep.borrow().as_any().downcast_ref::<Self>()  {
+                results.extend(space.query_no_deps(query));
             } else {
-                panic!("Cannot get space as Any inside ModuleSpace dependencies: {}", dep);
+                panic!("Only ModuleSpace is expected inside dependencies collection");
             }
         }
         results
@@ -72,11 +68,11 @@ impl Space for ModuleSpace {
     fn visit(&self, v: &mut dyn SpaceVisitor) -> Result<(), ()> {
         self.main.borrow().visit(v)
     }
-    fn as_any(&self) -> Option<&dyn std::any::Any> {
-        Some(self)
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
     }
-    fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
-        Some(self)
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
     }
 }
 


### PR DESCRIPTION
Before I tried to pass the instance of `Space` or `SpaceMut` into interpreter and other functions but it doesn't work for all use-cases. For example I cannot get the space and wrap it into the atom inside interpreter. Thus I decided to use `Space` and `SpaceMut` only as an API for the new kind of space implementers. After space is instantiated it should be wrapped into `DynSpace` and then passed via code.

This change simplifies `Space` and `SpaceMut` API, removes some unnecessary `Space` implementations and significantly simplifies `DynSpace` as it should not implement nor `Space` or `SpaceMut` anymore.