### PR TITLE
Implement assert in metta

### DIFF
--- a/c/src/metta.rs
+++ b/c/src/metta.rs
@@ -1,13 +1,11 @@
 #![allow(non_camel_case_types)]
 
 use hyperon::common::shared::Shared;
-use hyperon::space::DynSpace;
 use hyperon::metta::text::*;
 use hyperon::metta::interpreter;
 use hyperon::metta::interpreter::InterpreterState;
 use hyperon::metta::runner::{Metta, RunContext, RunnerState, Environment, EnvBuilder};
 use hyperon::metta::runner::modules::{ModuleLoader, ModId};
-use hyperon::atom::*;
 
 use crate::util::*;
 use crate::atom::*;
@@ -564,7 +562,7 @@ pub extern "C" fn atom_error_message(atom: *const atom_ref_t, buf: *mut c_char, 
 /// @return  The `atom_t` representing the Symbol atom
 /// @note The returned `atom_t` must be freed with `atom_free()`
 ///
-#[no_mangle] pub extern "C" fn ATOM_TYPE_GROUNDED_SPACE() -> atom_t { rust_type_atom::<DynSpace>().into() }
+#[no_mangle] pub extern "C" fn ATOM_TYPE_GROUNDED_SPACE() -> atom_t { hyperon::metta::ATOM_TYPE_SPACE.into() }
 
 /// @brief Creates an atom used to indicate that an atom's type is a unit type.
 /// @ingroup metta_language_group

--- a/lib/src/common/collections.rs
+++ b/lib/src/common/collections.rs
@@ -289,6 +289,22 @@ impl<'a, T> Into<&'a [T]> for &'a CowArray<T> {
     }
 }
 
+pub struct IterDisplay<'a, T: 'a + Display, I: 'a + Clone + Iterator<Item=T>>(pub &'a I);
+
+impl<'a, T: 'a + Display, I: 'a + Clone + Iterator<Item=T>> Display for IterDisplay<'a, T, I> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[{}]", self.0.clone().format(", "))
+    }
+}
+
+pub struct SliceDisplay<'a, T: 'a + Display>(pub &'a [T]);
+
+impl<'a, T: 'a + Display> Display for SliceDisplay<'a, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[{}]", self.0.iter().format(", "))
+    }
+}
+
 pub struct VecDisplay<'a, T: 'a + Display>(pub &'a Vec<T>);
 
 impl<'a, T: 'a + Display> Display for VecDisplay<'a, T> {

--- a/lib/src/metta/mod.rs
+++ b/lib/src/metta/mod.rs
@@ -45,6 +45,8 @@ pub const CALL_NATIVE_SYMBOL : Atom = sym!("call-native");
 pub const UNIT_ATOM: Atom = constexpr!();
 pub const UNIT_TYPE: Atom = constexpr!(("->"));
 
+pub const ATOM_TYPE_SPACE: Atom = sym!("SpaceType");
+
 /// Initializes an error expression atom
 pub fn error_atom(err_atom: Option<Atom>, err_code: Option<Atom>, message: String) -> Atom {
     let err_atom = match err_atom {

--- a/lib/src/metta/mod.rs
+++ b/lib/src/metta/mod.rs
@@ -41,6 +41,7 @@ pub const SUPERPOSE_BIND_SYMBOL : Atom = sym!("superpose-bind");
 
 pub const METTA_SYMBOL : Atom = sym!("metta");
 pub const CALL_NATIVE_SYMBOL : Atom = sym!("call-native");
+pub const CONTEXT_SPACE_SYMBOL : Atom = sym!("context-space");
 
 pub const UNIT_ATOM: Atom = constexpr!();
 pub const UNIT_TYPE: Atom = constexpr!(("->"));

--- a/lib/src/metta/runner/stdlib/atom.rs
+++ b/lib/src/metta/runner/stdlib/atom.rs
@@ -421,7 +421,7 @@ grounded_op!(GetTypeSpaceOp, "get-type-space");
 
 impl Grounded for GetTypeSpaceOp {
     fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, rust_type_atom::<DynSpace>(), ATOM_TYPE_ATOM, ATOM_TYPE_ATOM])
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_SPACE, ATOM_TYPE_ATOM, ATOM_TYPE_ATOM])
     }
 
     fn as_execute(&self) -> Option<&dyn CustomExecute> {

--- a/lib/src/metta/runner/stdlib/core.rs
+++ b/lib/src/metta/runner/stdlib/core.rs
@@ -143,7 +143,7 @@ grounded_op!(MatchOp, "match");
 
 impl Grounded for MatchOp {
     fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, rust_type_atom::<DynSpace>(), ATOM_TYPE_ATOM, ATOM_TYPE_ATOM, ATOM_TYPE_UNDEFINED])
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_SPACE, ATOM_TYPE_ATOM, ATOM_TYPE_ATOM, ATOM_TYPE_UNDEFINED])
     }
 
     fn as_execute(&self) -> Option<&dyn CustomExecute> {

--- a/lib/src/metta/runner/stdlib/debug.rs
+++ b/lib/src/metta/runner/stdlib/debug.rs
@@ -2,23 +2,16 @@ use crate::*;
 use crate::metta::*;
 use crate::metta::text::Tokenizer;
 use crate::space::*;
-use crate::common::collections::{VecDisplay, Equality, DefaultEquality};
+use crate::common::collections::{VecDisplay, SliceDisplay, Equality, DefaultEquality};
 use crate::common::assert::compare_vec_no_order;
 use crate::atom::matcher::atoms_are_equivalent;
 use crate::metta::runner::stdlib::{grounded_op, regex, interpret_no_error, unit_result};
 use crate::metta::runner::bool::*;
-use crate::metta::runner::str::atom_to_string;
+use crate::metta::runner::str::*;
 use crate::metta::runner::{Metta, PragmaSettings};
+use crate::atom::gnd::GroundedFunctionAtom;
 
 use std::convert::TryInto;
-
-fn assert_results_equal(actual: &Vec<Atom>, expected: &Vec<Atom>) -> Result<Vec<Atom>, ExecError> {
-    let report = format!("\nExpected: {}\nGot: {}", VecDisplay(expected), VecDisplay(actual));
-    match compare_vec_no_order(actual.iter(), expected.iter(), DefaultEquality{}).as_display() {
-        None => unit_result(),
-        Some(diff) => Err(ExecError::Runtime(format!("{}\n{}", report, diff)))
-    }
-}
 
 /// Implement trace! built-in.
 ///
@@ -123,41 +116,20 @@ fn assert_alpha_equal(actual: &Vec<Atom>, expected: &Vec<Atom>) -> Result<Vec<At
     }
 }
 
-#[derive(Clone, Debug)]
-pub struct AssertEqualOp {
-    space: DynSpace,
-    settings: PragmaSettings,
-}
+fn assert_results_are_equal(args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
+    let arg_error = || ExecError::from("Pair of evaluation results with bindings is expected as an argument");
+    let actual = TryInto::<&ExpressionAtom>::try_into(args.get(0).ok_or_else(arg_error)?)?.children();
+    let expected = TryInto::<&ExpressionAtom>::try_into(args.get(1).ok_or_else(arg_error)?)?.children();
+    let assert = args.get(2).ok_or_else(arg_error)?;
 
-grounded_op!(AssertEqualOp, "assertEqual");
+    let report = format!("\nExpected: {}\nGot: {}", SliceDisplay(expected), SliceDisplay(actual));
 
-impl AssertEqualOp {
-    pub fn new(space: DynSpace, settings: PragmaSettings) -> Self {
-        Self{ space, settings }
-    }
-}
-
-impl Grounded for AssertEqualOp {
-    fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_ATOM, ATOM_TYPE_ATOM, UNIT_TYPE])
-    }
-
-    fn as_execute(&self) -> Option<&dyn CustomExecute> {
-        Some(self)
-    }
-}
-
-impl CustomExecute for AssertEqualOp {
-    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        log::debug!("AssertEqualOp::execute: {:?}", args);
-        let arg_error = || ExecError::from("assertEqual expects two atoms: actual and expected");
-        let actual_atom = args.get(0).ok_or_else(arg_error)?;
-        let expected_atom = args.get(1).ok_or_else(arg_error)?;
-
-        let actual = interpret_no_error(self.space.clone(), actual_atom, self.settings.clone())?;
-        let expected = interpret_no_error(self.space.clone(), expected_atom, self.settings.clone())?;
-
-        assert_results_equal(&actual, &expected)
+    match compare_vec_no_order(actual.iter(), expected.iter(), DefaultEquality{}).as_display() {
+        None => unit_result(),
+        Some(diff) => {
+            let msg = format!("{}\n{}", report, diff);
+            Ok(vec![Atom::expr([ERROR_SYMBOL, assert.clone(), Atom::sym(msg)])])
+        },
     }
 }
 
@@ -226,45 +198,6 @@ impl CustomExecute for AlphaEqOp {
 }
 
 #[derive(Clone, Debug)]
-pub struct AssertEqualToResultOp {
-    space: DynSpace,
-    settings: PragmaSettings,
-}
-
-grounded_op!(AssertEqualToResultOp, "assertEqualToResult");
-
-impl AssertEqualToResultOp {
-    pub fn new(space: DynSpace, settings: PragmaSettings) -> Self {
-        Self{ space, settings }
-    }
-}
-
-impl Grounded for AssertEqualToResultOp {
-    fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_ATOM, ATOM_TYPE_EXPRESSION, UNIT_TYPE])
-    }
-
-    fn as_execute(&self) -> Option<&dyn CustomExecute> {
-        Some(self)
-    }
-}
-
-impl CustomExecute for AssertEqualToResultOp {
-    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        log::debug!("AssertEqualToResultOp::execute: {:?}", args);
-        let arg_error = || ExecError::from("assertEqualToResult expects atom and expression as arguments: actual and expected");
-        let actual_atom = args.get(0).ok_or_else(arg_error)?;
-        let expected = TryInto::<&ExpressionAtom>::try_into(args.get(1).ok_or_else(arg_error)?)
-            .map_err(|_| arg_error())?
-            .children();
-
-        let actual = interpret_no_error(self.space.clone(), actual_atom, self.settings.clone())?;
-
-        assert_results_equal(&actual, &expected.into())
-    }
-}
-
-#[derive(Clone, Debug)]
 pub struct AssertAlphaEqualToResultOp {
     space: DynSpace,
     settings: PragmaSettings,
@@ -316,35 +249,24 @@ pub(super) fn register_context_independent_tokens(tref: &mut Tokenizer) {
 pub(super) fn register_context_dependent_tokens(tref: &mut Tokenizer, space: &DynSpace, metta: &Metta) {
     let assert_alpha_equal_to_result_op = Atom::gnd(AssertAlphaEqualToResultOp::new(space.clone(), metta.settings().clone()));
     tref.register_token(regex(r"assertAlphaEqualToResult"), move |_| { assert_alpha_equal_to_result_op.clone() });
-    let assert_equal_to_result_op = Atom::gnd(AssertEqualToResultOp::new(space.clone(), metta.settings().clone()));
-    tref.register_token(regex(r"assertEqualToResult"), move |_| { assert_equal_to_result_op.clone() });
     let assert_alpha_equal_op = Atom::gnd(AssertAlphaEqualOp::new(space.clone(), metta.settings().clone()));
     tref.register_token(regex(r"assertAlphaEqual"), move |_| { assert_alpha_equal_op.clone() });
-    let assert_equal_op = Atom::gnd(AssertEqualOp::new(space.clone(), metta.settings().clone()));
-    tref.register_token(regex(r"assertEqual"), move |_| { assert_equal_op.clone() });
+    tref.register_function(GroundedFunctionAtom::new(
+            r"_assert-results-are-equal".into(),
+            expr!("->" "Atom" "Atom" "Atom" ("->")),
+            assert_results_are_equal, 
+            ));
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::metta::runner::{Metta, EnvBuilder, SExprParser};
-    use crate::common::test_utils::metta_space;
     use crate::metta::runner::run_program;
-
-    use regex::Regex;
-
-    fn assert_runtime_error(actual: Result<Vec<Atom>, ExecError>, expected: Regex) {
-        match actual {
-            Err(ExecError::Runtime(msg)) => assert!(expected.is_match(msg.as_str()),
-                                                    "Incorrect error message:\nexpected: {:?}\n  actual: {:?}", expected.to_string(), msg),
-            _ => assert!(false, "Error is expected as result, {:?} returned", actual),
-        }
-    }
 
     #[test]
     fn metta_assert_equal_op() {
         let metta = Metta::new(Some(EnvBuilder::test_env()));
-        let assert = AssertEqualOp::new(metta.space().clone(), metta.settings().clone());
         let program = "
             (= (foo $x) $x)
             (= (bar $x) $x)
@@ -354,10 +276,10 @@ mod tests {
             vec![UNIT_ATOM],
         ]));
         assert_eq!(metta.run(SExprParser::new("!(assertEqual (foo A) (bar B))")), Ok(vec![
-            vec![expr!("Error" ({assert.clone()} ("foo" "A") ("bar" "B")) "\nExpected: [B]\nGot: [A]\nMissed results: B\nExcessive results: A")],
+            vec![expr!("Error" ("assertEqual" ("foo" "A") ("bar" "B")) "\nExpected: [B]\nGot: [A]\nMissed results: B\nExcessive results: A")],
         ]));
         assert_eq!(metta.run(SExprParser::new("!(assertEqual (foo A) Empty)")), Ok(vec![
-            vec![expr!("Error" ({assert.clone()} ("foo" "A") "Empty") "\nExpected: []\nGot: [A]\nExcessive results: A")]
+            vec![expr!("Error" ("assertEqual" ("foo" "A") "Empty") "\nExpected: []\nGot: [A]\nExcessive results: A")]
         ]));
     }
 
@@ -390,7 +312,6 @@ mod tests {
     #[test]
     fn metta_assert_equal_to_result_op() {
         let metta = Metta::new(Some(EnvBuilder::test_env()));
-        let assert = AssertEqualToResultOp::new(metta.space().clone(), metta.settings().clone());
         let program = "
             (= (foo) A)
             (= (foo) B)
@@ -404,10 +325,10 @@ mod tests {
             vec![UNIT_ATOM],
         ]));
         assert_eq!(metta.run(SExprParser::new("!(assertEqualToResult (bar) (A))")), Ok(vec![
-            vec![expr!("Error" ({assert.clone()} ("bar") ("A")) "\nExpected: [A]\nGot: [C]\nMissed results: A\nExcessive results: C")],
+            vec![expr!("Error" ("assertEqualToResult" ("bar") ("A")) "\nExpected: [A]\nGot: [C]\nMissed results: A\nExcessive results: C")],
         ]));
         assert_eq!(metta.run(SExprParser::new("!(assertEqualToResult (baz) (D))")), Ok(vec![
-            vec![expr!("Error" ({assert.clone()} ("baz") ("D")) "\nExpected: [D]\nGot: [D, D, D]\nExcessive results: D, D")]
+            vec![expr!("Error" ("assertEqualToResult" ("baz") ("D")) "\nExpected: [D]\nGot: [D, D, D]\nExcessive results: D, D")]
         ]));
     }
 
@@ -441,42 +362,6 @@ mod tests {
         assert_eq!(metta.run(SExprParser::new("!(assertAlphaEqualToResult (baz) (D))")), Ok(vec![
             vec![expr!("Error" ({assert.clone()} ("baz") ("D")) "\nExpected: [D]\nGot: [D, D, D]\nExcessive results: D, D")]
         ]));
-    }
-
-    #[test]
-    fn assert_equal_op() {
-        let space = metta_space("
-            (= (foo) (A B))
-            (= (foo) (B C))
-            (= (bar) (B C))
-            (= (bar) (A B))
-            (= (err) (A B))
-        ");
-
-        let assert_equal_op = AssertEqualOp::new(space, PragmaSettings::new());
-
-        assert_eq!(assert_equal_op.execute(&mut vec![expr!(("foo")), expr!(("bar"))]), unit_result());
-
-        let actual = assert_equal_op.execute(&mut vec![expr!(("foo")), expr!(("err"))]);
-        let expected = Regex::new("\nExpected: \\[(A B)\\]\nGot: \\[\\((B C)|, |(A B)\\){3}\\]\nExcessive result: (B C)").unwrap();
-        assert_runtime_error(actual, expected);
-
-        let actual = assert_equal_op.execute(&mut vec![expr!(("err")), expr!(("foo"))]);
-        let expected = Regex::new("\nExpected: \\[\\((B C)|, |(A B)\\){3}\\]\nGot: \\[(A B)\\]\nMissed result: (B C)").unwrap();
-        assert_runtime_error(actual, expected);
-    }
-
-    #[test]
-    fn assert_equal_to_result_op() {
-        let space = metta_space("
-            (= (foo) (A B))
-            (= (foo) (B C))
-        ");
-        let assert_equal_to_result_op = AssertEqualToResultOp::new(space, PragmaSettings::new());
-
-        assert_eq!(assert_equal_to_result_op.execute(&mut vec![
-            expr!(("foo")), expr!(("B" "C") ("A" "B"))]),
-                   unit_result());
     }
 
     #[test]

--- a/lib/src/metta/runner/stdlib/mod.rs
+++ b/lib/src/metta/runner/stdlib/mod.rs
@@ -78,7 +78,6 @@ fn register_context_dependent_tokens(tref: &mut Tokenizer, tokenizer: Shared<Tok
 
     atom::register_context_dependent_tokens(tref, space);
     core::register_context_dependent_tokens(tref, space, metta);
-    debug::register_context_dependent_tokens(tref, space, metta);
     module::register_context_dependent_tokens(tref, tokenizer.clone(), metta);
     #[cfg(feature = "pkg_mgmt")]
     package::register_context_dependent_tokens(tref, metta);

--- a/lib/src/metta/runner/stdlib/module.rs
+++ b/lib/src/metta/runner/stdlib/module.rs
@@ -170,7 +170,7 @@ impl ModSpaceOp {
 
 impl Grounded for ModSpaceOp {
     fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_ATOM, rust_type_atom::<DynSpace>()])
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_ATOM, ATOM_TYPE_SPACE])
     }
 
     fn as_execute(&self) -> Option<&dyn CustomExecute> {

--- a/lib/src/metta/runner/stdlib/space.rs
+++ b/lib/src/metta/runner/stdlib/space.rs
@@ -15,7 +15,7 @@ grounded_op!(NewSpaceOp, "new-space");
 
 impl Grounded for NewSpaceOp {
     fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, rust_type_atom::<DynSpace>()])
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_SPACE])
     }
 
     fn as_execute(&self) -> Option<&dyn CustomExecute> {
@@ -146,7 +146,7 @@ grounded_op!(GetAtomsOp, "get-atoms");
 
 impl Grounded for GetAtomsOp {
     fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, rust_type_atom::<DynSpace>(), ATOM_TYPE_ATOM])
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_SPACE, ATOM_TYPE_ATOM])
     }
 
     fn as_execute(&self) -> Option<&dyn CustomExecute> {
@@ -173,7 +173,7 @@ grounded_op!(AddAtomOp, "add-atom");
 
 impl Grounded for AddAtomOp {
     fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, rust_type_atom::<DynSpace>(),
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_SPACE,
             ATOM_TYPE_ATOM, UNIT_TYPE])
     }
 
@@ -200,7 +200,7 @@ grounded_op!(RemoveAtomOp, "remove-atom");
 
 impl Grounded for RemoveAtomOp {
     fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, rust_type_atom::<DynSpace>(),
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_SPACE,
             ATOM_TYPE_ATOM, UNIT_TYPE])
     }
 

--- a/lib/src/metta/runner/stdlib/stdlib.metta
+++ b/lib/src/metta/runner/stdlib/stdlib.metta
@@ -1013,6 +1013,12 @@
     (@param "First expression")
     (@param "Second expression")))
   (@return "Unit atom if both expressions after evaluation are equal, error - otherwise"))
+(: assertEqual (-> Atom Atom (->)))
+(= (assertEqual $actual $expected)
+   (chain (context-space) $space
+     (chain (metta (collapse $actual) %Undefined% $space) $actual-results
+       (chain (metta (collapse $expected) %Undefined% $space) $expected-results
+         (_assert-results-are-equal $actual-results $expected-results (assertEqual $actual $expected)) ))))
 
 (@doc assertAlphaEqual
   (@desc "Compares (sets of) results of evaluation of two expressions using alpha equality")
@@ -1025,8 +1031,13 @@
   (@desc "Same as assertEqual but it doesn't evaluate second argument. Second argument is considered as a set of values of the first argument's evaluation")
   (@params (
     (@param "First expression (it will be evaluated)")
-    (@param "Second expression (it won't be evaluated)")))
+    (@param "Second expression containing the expected evaluation results (it won't be evaluated)")))
   (@return "Unit atom if both expressions after evaluation of the first argument are equal, error - otherwise"))
+(: assertEqualToResult (-> Atom Atom (->)))
+(= (assertEqualToResult $actual $expected-results)
+   (chain (context-space) $space
+     (chain (metta (collapse $actual) %Undefined% $space) $actual-results
+       (_assert-results-are-equal $actual-results $expected-results (assertEqualToResult $actual $expected-results)) )))
 
 (@doc assertAlphaEqualToResult
   (@desc "Same as assertAlphaEqual but it doesn't evaluate second argument. Second argument is considered as a set of values of the first argument's evaluation")

--- a/lib/src/metta/runner/stdlib/stdlib.metta
+++ b/lib/src/metta/runner/stdlib/stdlib.metta
@@ -9,6 +9,9 @@
 (@doc ErrorType (@desc "Type of the atom which contains error"))
 (: ErrorType Type)
 
+(@doc SpaceType (@desc "Type of the atom which contains space"))
+(: SpaceType Type)
+
 (@doc Error
   (@desc "Error constructor")
   (@params (
@@ -224,7 +227,7 @@
     (@param "Type of input atom")
     (@param "Atomspace where intepretation should take place")))
   (@return "Result of interpretation"))
-(: metta (-> Atom Type Grounded Atom))
+(: metta (-> Atom Type SpaceType Atom))
 
 (@doc id
   (@desc "Returns its argument")

--- a/lib/src/metta/runner/stdlib/stdlib.metta
+++ b/lib/src/metta/runner/stdlib/stdlib.metta
@@ -460,9 +460,10 @@
   (function (eval (if-decons-expr $list $head $tail
     (chain (eval (atom-subst $init $a $op)) $op-init
       (chain (eval (atom-subst $head $b $op-init)) $op-head
-        (chain $op-head $head-folded
-          (chain (eval (foldl-atom $tail $head-folded $a $b $op)) $res (return $res)) )))
-    (return $init) ))))
+        (chain (context-space) $space
+          (chain (metta $op-head %Undefined% $space) $head-folded
+            (chain (eval (foldl-atom $tail $head-folded $a $b $op)) $res (return $res)) ))))
+      (return $init) ))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Standard library written in MeTTa ;
@@ -649,7 +650,7 @@
   (@return "Unit atom"))
 (: add-reducts (-> Grounded %Undefined% (->)))
 (= (add-reducts $space $tuple)
-    (foldl-atom $tuple () $a $b (eval (add-atom $space $b))))
+    (foldl-atom $tuple () $a $b (add-atom $space $b)))
 
 (@doc add-atoms
   (@desc "Function takes space and expression and adds atoms in Expression into given space without reducing them")
@@ -659,7 +660,7 @@
   (@return "Unit atom"))
 (: add-atoms (-> Grounded Expression (->)))
 (= (add-atoms $space $tuple)
-    (foldl-atom $tuple () $a $b (eval (add-atom $space $b))))
+    (foldl-atom $tuple () $a $b (add-atom $space $b)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Documentation formatting functions
@@ -1045,6 +1046,20 @@
   (@params (
     (@param "Atom which will be evaluated")))
   (@return "Tuple"))
+(: collapse (-> Atom Atom))
+(= (collapse $atom)
+  (function
+    (chain (context-space) $space
+      (chain (collapse-bind (metta $atom %Undefined% $space)) $eval
+        (chain (eval (foldl-atom $eval () $res $item (_collapse-add-next-atom-from-collapse-bind-result $res $item))) $result
+          (return $result) )))))
+
+(@doc _collapse-add-next-atom-from-collapse-bind-result
+  (@desc "Adds atom from collapse-bind result to the passed list")
+  (@params (
+    (@param "List to add an atom into")
+    (@param "collapse-bind result to extract atom from, should be a pair of atom and bindings")))
+  (@return "List with new atom as a head"))
 
 (@doc case
   (@desc "Subsequently tests multiple pattern-matching conditions (second argument) for the given value (first argument)")

--- a/lib/src/metta/runner/stdlib/stdlib.metta
+++ b/lib/src/metta/runner/stdlib/stdlib.metta
@@ -1026,6 +1026,12 @@
     (@param "First expression")
     (@param "Second expression")))
   (@return "Unit atom if both expressions after evaluation are alpha equal, error - otherwise"))
+(: assertAlphaEqual (-> Atom Atom (->)))
+(= (assertAlphaEqual $actual $expected)
+   (chain (context-space) $space
+     (chain (metta (collapse $actual) %Undefined% $space) $actual-results
+       (chain (metta (collapse $expected) %Undefined% $space) $expected-results
+         (_assert-results-are-alpha-equal $actual-results $expected-results (assertAlphaEqual $actual $expected)) ))))
 
 (@doc assertEqualToResult
   (@desc "Same as assertEqual but it doesn't evaluate second argument. Second argument is considered as a set of values of the first argument's evaluation")
@@ -1045,6 +1051,11 @@
     (@param "First expression (it will be evaluated)")
     (@param "Second expression (it won't be evaluated)")))
   (@return "Unit atom if both expressions after evaluation of the first argument are alpha equal, error - otherwise"))
+(: assertAlphaEqualToResult (-> Atom Atom (->)))
+(= (assertAlphaEqualToResult $actual $expected-results)
+   (chain (context-space) $space
+     (chain (metta (collapse $actual) %Undefined% $space) $actual-results
+       (_assert-results-are-alpha-equal $actual-results $expected-results (assertAlphaEqualToResult $actual $expected-results)) )))
 
 (@doc superpose
   (@desc "Turns a tuple (first argument) into a nondeterministic result")

--- a/lib/src/metta/runner/stdlib/stdlib.metta
+++ b/lib/src/metta/runner/stdlib/stdlib.metta
@@ -83,6 +83,12 @@
   (@return "Deconsed expression"))
 (: decons-atom (-> Expression Atom))
 
+(@doc context-space
+  (@desc "Returns the space which is used as a context space in atom evaluation")
+  (@params ())
+  (@return "Context space"))
+(: context-space (-> SpaceType))
+
 (@doc min-atom
   (@desc "Returns atom with min value in the expression (first argument). Only numbers allowed")
   (@params (

--- a/lib/src/space/mod.rs
+++ b/lib/src/space/mod.rs
@@ -323,7 +323,7 @@ impl PartialEq for DynSpace {
 
 impl crate::atom::Grounded for DynSpace {
     fn type_(&self) -> Atom {
-        rust_type_atom::<DynSpace>()
+        crate::metta::ATOM_TYPE_SPACE
     }
 
     fn as_match(&self) -> Option<&dyn CustomMatch> {


### PR DESCRIPTION
Add `context-space` operation to get current interpreter space and implement collapse on the top of it.
Use new collapse implementation in `assert...` implementations.
Fixes #924 Opens road to implement #900 
@Bitseat FYI