### PR TITLE
Make integer and float have different hash

### DIFF
--- a/lib/src/metta/runner/number.rs
+++ b/lib/src/metta/runner/number.rs
@@ -14,6 +14,11 @@ pub enum Number {
 
 impl PartialEq<Self> for Number {
     fn eq(&self, other: &Self) -> bool {
+        // TODO: this promoting is helpful for the atoms which contain Number
+        // objects, but it breaks logic for Rust data structures which use
+        // Number. For example Map can mix up Float and Number because of
+        // promoting. Possible solution is to have separate equality
+        // implementation for the Grounded trait.
         let (a, b) = Number::promote(self.clone(), other.clone());
         match (a, b) {
             (Number::Integer(a), Number::Integer(b)) => a == b,


### PR DESCRIPTION
Fixes #949 

In Rust `1.0 as u64` converts float into an integer by rounding. As a result `1` and `1.0` has the same hash when they are hashed by serializer implementation for `DefaultHasher`. This commit uses `transmute` to convert binary representation of the `f64` to `i64` and thus makes hashes different.