### PR TITLE
Introduce new quoting using noeval/id functions

### DIFF
--- a/lib/src/metta/runner/stdlib/stdlib.metta
+++ b/lib/src/metta/runner/stdlib/stdlib.metta
@@ -240,8 +240,16 @@
   (@params (
     (@param "Input argument")))
   (@return "Input argument"))
-(: id (-> Atom Atom))
+(: id (-> $t $t))
 (= (id $x) $x)
+
+(@doc noeval
+  (@desc "Returns its argument")
+  (@params (
+    (@param "Input argument")))
+  (@return "Input argument"))
+(: noeval (-> Atom Atom))
+(= (noeval $x) $x)
 
 (@doc atom-subst
   (@desc "Substitutes variable passed as a second argument in the third argument by the first argument")
@@ -252,7 +260,7 @@
   (@return "Template with substituted variable"))
 (: atom-subst (-> Atom Variable Atom Atom))
 (= (atom-subst $atom $var $templ)
-  (function (chain (eval (id $atom)) $var (return $templ))) )
+  (function (chain (eval (noeval $atom)) $var (return $templ))) )
 
 (@doc if-decons-expr
   (@desc "Checks if first argument is non empty expression. If so gets tail and head from the first argument and returns forth argument using head and tail values. Returns fifth argument otherwise.")

--- a/lib/tests/test_stdlib.metta
+++ b/lib/tests/test_stdlib.metta
@@ -32,3 +32,20 @@
 !(assertEqualToResult
    (assertIncludes (superpose (41 42 43)) (A))
    ((Error (assertIncludes (superpose (41 42 43)) (A)) (assertIncludes error: (A) not included in result: (41 42 43)))))
+
+!(assertEqualToResult
+   (= (f) (+ 1 2))
+   ((= (f) 3)))
+!(assertEqualToResult
+   (noeval (= (f) (+ 1 2)))
+   ((= (f) (+ 1 2))))
+!(assertEqualToResult
+   (quote (= (f) (+ 1 2)))
+   ((quote (= (f) (+ 1 2)))))
+
+!(assertEqualToResult
+   (noeval (+ 1 2))
+   ((+ 1 2)))
+!(assertEqualToResult
+   (id (noeval (+ 1 2)))
+   (3))


### PR DESCRIPTION
Fix proposal for #920 

After allowing using Atom meta-type to return an atom without evaluation, it is possible to implement a new quoting mechanism. (: noeval (-> Atom Atom)) function (former id) is used to return atom without evaluation. (: id (-> $t $t)) function is used to force evaluation of the atom.

This PR changes type of the id function from (-> Atom Atom) to (-> $t $t) as it is more logical. And introduces new noeval function with (-> Atom Atom) signature to implement new quoting mechanism.