### PR TITLE
Add ability to push new children into ExpressionAtom's

### DIFF
--- a/hyperon-atom/src/lib.rs
+++ b/hyperon-atom/src/lib.rs
@@ -185,8 +185,8 @@ impl ExpressionAtom {
     }
 
     /// Returns a mutable reference to a vector of sub-atoms.
-    pub fn children_mut(&mut self) -> &mut [Atom] {
-        self.children.as_slice_mut()
+    pub fn children_mut(&mut self) -> &mut Vec<Atom> {
+        self.children.as_vec_mut()
     }
 
     /// Converts into a vector of sub-atoms.
@@ -1115,7 +1115,7 @@ mod test {
 
     #[inline]
     fn expression<const N: usize>(children: [Atom; N]) -> Atom {
-        Atom::Expression(ExpressionAtom::new(CowArray::Allocated(Box::new(children))))
+        Atom::Expression(ExpressionAtom::new(CowArray::Allocated(children.into())))
     }
 
     #[inline]

--- a/hyperon-common/src/collections.rs
+++ b/hyperon-common/src/collections.rs
@@ -201,7 +201,7 @@ impl From<String> for ImmutableString {
 
 #[derive(Debug, Clone)]
 pub enum CowArray<T: 'static> {
-    Allocated(Box<[T]>),
+    Allocated(Vec<T>),
     Literal(&'static [T]),
 }
 
@@ -218,12 +218,12 @@ impl<T: 'static> CowArray<T> {
         }
     }
 
-    pub fn as_slice_mut(&mut self) -> &mut [T] where T: Clone {
+    pub fn as_vec_mut(&mut self) -> &mut Vec<T> where T: Clone {
         match self {
-            Self::Allocated(array) => &mut *array,
+            Self::Allocated(array) => array,
             Self::Literal(array) => {
                 *self = Self::Allocated((*array).into());
-                self.as_slice_mut()
+                self.as_vec_mut()
             }
         }
     }
@@ -264,13 +264,13 @@ impl<T: 'static> From<&'static [T]> for CowArray<T> {
 
 impl<T, const N: usize> From<[T; N]> for CowArray<T> {
     fn from(a: [T; N]) -> Self {
-        CowArray::Allocated(Box::new(a))
+        CowArray::Allocated(a.into())
     }
 }
 
 impl<T> From<Vec<T>> for CowArray<T> {
     fn from(v: Vec<T>) -> Self {
-        CowArray::Allocated(v.into_boxed_slice())
+        CowArray::Allocated(v)
     }
 }
 

--- a/lib/src/metta/runner/stdlib/core.rs
+++ b/lib/src/metta/runner/stdlib/core.rs
@@ -341,9 +341,9 @@ fn collapse_add_next_atom_from_collapse_bind_result(args: &[Atom]) -> Result<Vec
     let bindings = atom_bindings.children().get(1).and_then(|a| a.as_gnd::<Bindings>()).ok_or_else(arg1_error)?;
 
     let atom = apply_bindings_to_atom_move(atom.clone(), bindings);
-    let mut list = list.clone().into_children();
-    list.push(atom);
-    Ok(vec![Atom::expr(list)])
+    let mut list = list.clone();
+    list.children_mut().push(atom);
+    Ok(vec![Atom::Expression(list)])
 }
 
 pub(super) fn register_context_independent_tokens(tref: &mut Tokenizer) {


### PR DESCRIPTION
This allows save some time on operations like collapse where results are collected into an atom.