### PR TITLE
Fix minimal MeTTa interpreter behavior

### DIFF
--- a/lib/src/metta/interpreter.rs
+++ b/lib/src/metta/interpreter.rs
@@ -222,10 +222,8 @@ impl InterpreterState {
     fn push(&mut self, atom: InterpretedAtom) {
         if atom.0.prev.is_none() && atom.0.finished {
             let InterpretedAtom(stack, bindings) = atom;
-            if stack.atom != EMPTY_SYMBOL {
-                let atom = apply_bindings_to_atom_move(stack.atom, &bindings);
-                self.finished.push(atom);
-            }
+            let atom = apply_bindings_to_atom_move(stack.atom, &bindings);
+            self.finished.push(atom);
         } else {
             self.plan.push(atom);
         }
@@ -1531,7 +1529,7 @@ mod tests {
     #[test]
     fn interpret_atom_evaluate_grounded_expression_empty() {
         let result = call_interpret(space(""), &expr!("eval" ({ReturnNothing()} {6})));
-        assert_eq!(result, vec![]);
+        assert_eq!(result, vec![EMPTY_SYMBOL]);
     }
 
     #[test]
@@ -1702,7 +1700,7 @@ mod tests {
     #[test]
     fn interpret_atom_unify_else() {
         let result = call_interpret(space(""), &metta_atom("(unify (A $b C) ($a B D) ($a $b) Empty)"));
-        assert_eq!(result, vec![]);
+        assert_eq!(result, vec![EMPTY_SYMBOL]);
     }
 
 

--- a/lib/src/metta/runner/stdlib/atom.rs
+++ b/lib/src/metta/runner/stdlib/atom.rs
@@ -483,13 +483,13 @@ mod tests {
 
     #[test]
     fn metta_car_atom() {
-        let result = run_program("!(eval (car-atom (A $b)))");
+        let result = run_program("!(car-atom (A $b))");
         assert_eq!(result, Ok(vec![vec![expr!("A")]]));
-        let result = run_program("!(eval (car-atom ($a B)))");
+        let result = run_program("!(car-atom ($a B))");
         assert_eq!(result, Ok(vec![vec![expr!(a)]]));
-        let result = run_program("!(eval (car-atom ()))");
+        let result = run_program("!(car-atom ())");
         assert_eq!(result, Ok(vec![vec![expr!("Error" ("car-atom" ()) {Str::from_str("car-atom expects a non-empty expression as an argument")})]]));
-        let result = run_program("!(eval (car-atom A))");
+        let result = run_program("!(car-atom A)");
         assert_eq!(result, Ok(vec![vec![expr!("Error" ("car-atom" "A") {Str::from_str("car-atom expects a non-empty expression as an argument")})]]));
     }
 

--- a/lib/src/metta/runner/stdlib/stdlib.metta
+++ b/lib/src/metta/runner/stdlib/stdlib.metta
@@ -32,14 +32,14 @@
   (@params (
     (@param "Atom to be evaluated")))
   (@return "Result of atom's evaluation"))
-(: function (-> Atom %Undefined%))
+(: function (-> Atom Atom))
 
 (@doc eval
   (@desc "Evaluates input atom, makes one step of the evaluation")
   (@params (
     (@param "Atom to be evaluated, can be reduced via equality expression (= ...) or by calling a grounded function")))
   (@return "Result of evaluation"))
-(: eval (-> Atom %Undefined%))
+(: eval (-> Atom Atom))
 
 (@doc evalc
   (@desc "Evaluates input atom, makes one step of the evaluation")
@@ -47,7 +47,7 @@
     (@param "Atom to be evaluated, can be reduced via equality expression (= ...) or by calling a grounded function")
     (@param "Space to evaluate atom in its context")))
   (@return "Result of evaluation"))
-(: evalc (-> Atom Grounded %Undefined%))
+(: evalc (-> Atom Grounded Atom))
 
 (@doc chain
   (@desc "Evaluates first argument, binds it to the variable (second argument) and then evaluates third argument which contains (or not) mentioned variable")
@@ -542,9 +542,11 @@
   (@return "Second argument or Empty"))
 (: let* (-> Expression Atom %Undefined%))
 (= (let* $pairs $template)
-  (eval (if-decons-expr $pairs ($pattern $atom) $tail
-    (let $pattern $atom (let* $tail $template))
-    $template )))
+  (if-decons-expr $pairs $head $tail
+    (unify ($pattern $atom) $head
+      (let $pattern $atom (let* $tail $template))
+      (Error (let* $pairs $template) "List of (<pattern> <atom>) pairs is expected as a second argument"))
+    $template ))
 
 (@doc add-reduct
   (@desc "Reduces atom (second argument) and adds it into the atomspace (first argument)")
@@ -562,9 +564,9 @@
   (@return "First atom of an expression"))
 (: car-atom (-> Expression %Undefined%))
 (= (car-atom $atom)
-  (eval (if-decons-expr $atom $head $_
+  (if-decons-expr $atom $head $_
     $head
-    (Error (car-atom $atom) "car-atom expects a non-empty expression as an argument") )))
+    (Error (car-atom $atom) "car-atom expects a non-empty expression as an argument") ))
 
 (@doc cdr-atom
   (@desc "Extracts the tail of an expression (all except first atom)")
@@ -573,9 +575,9 @@
   (@return "Tail of an expression"))
 (: cdr-atom (-> Expression Expression))
 (= (cdr-atom $atom)
-  (eval (if-decons-expr $atom $_ $tail
+  (if-decons-expr $atom $_ $tail
     $tail
-    (Error (cdr-atom $atom) "cdr-atom expects a non-empty expression as an argument") )))
+    (Error (cdr-atom $atom) "cdr-atom expects a non-empty expression as an argument") ))
 
 (@doc quote
   (@desc "Prevents atom from being reduced")


### PR DESCRIPTION
1. Fix eval/evalc/function return type. Changing unify/chain breaks too many programs.
2. Return Empty from minimal MeTTa interpreter on a final step

