### PR TITLE
Eval cleaning

### DIFF
--- a/lib/src/metta/runner/builtin_mods/random.rs
+++ b/lib/src/metta/runner/builtin_mods/random.rs
@@ -196,7 +196,7 @@ mod tests {
     fn metta_random() {
         assert_eq!(run_program(&format!(
             "!(import! &self random)
-             !(chain (eval (random-int &rng 0 5)) $rint
+             !(let $rint (random-int &rng 0 5)
                 (and (>= $rint 0) (< $rint 5)))")),
             Ok(vec![vec![UNIT_ATOM], vec![expr!({Bool(true)})]]));
         assert_eq!(run_program(&format!(
@@ -207,7 +207,7 @@ mod tests {
             Ok(vec![vec![UNIT_ATOM], vec![UNIT_ATOM]]));
         assert_eq!(run_program(&format!(
             "!(import! &self random)
-             !(chain (eval (random-float &rng 0.0 5.0)) $rfloat
+             !(let $rfloat (random-float &rng 0.0 5.0)
                 (and (>= $rfloat 0.0) (< $rfloat 5.0)))")),
             Ok(vec![vec![UNIT_ATOM], vec![expr!({Bool(true)})]]));
         assert_eq!(run_program(&format!(

--- a/lib/src/metta/runner/stdlib/atom.rs
+++ b/lib/src/metta/runner/stdlib/atom.rs
@@ -532,21 +532,21 @@ mod tests {
 
     #[test]
     fn metta_filter_atom() {
-        assert_eq!(run_program("!(eval (filter-atom () $x (eval (if-error $x False True))))"), Ok(vec![vec![expr!()]]));
-        assert_eq!(run_program("!(eval (filter-atom (a (b) $c) $x (eval (if-error $x False True))))"), Ok(vec![vec![expr!("a" ("b") c)]]));
-        assert_eq!(run_program("!(eval (filter-atom (a (Error (b) \"Test error\") $c) $x (eval (if-error $x False True))))"), Ok(vec![vec![expr!("a" c)]]));
+        assert_eq!(run_program("!(filter-atom () $x (eval (if-error $x False True)))"), Ok(vec![vec![expr!()]]));
+        assert_eq!(run_program("!(filter-atom (a (b) $c) $x (eval (if-error $x False True)))"), Ok(vec![vec![expr!("a" ("b") c)]]));
+        assert_eq!(run_program("!(filter-atom (a (Error (b) \"Test error\") $c) $x (eval (if-error $x False True)))"), Ok(vec![vec![expr!("a" c)]]));
     }
 
     #[test]
     fn metta_map_atom() {
-        assert_eq!(run_program("!(eval (map-atom () $x ($x mapped)))"), Ok(vec![vec![expr!()]]));
-        assert_eq!(run_program("!(eval (map-atom (a (b) $c) $x (mapped $x)))"), Ok(vec![vec![expr!(("mapped" "a") ("mapped" ("b")) ("mapped" c))]]));
+        assert_eq!(run_program("!(map-atom () $x ($x mapped))"), Ok(vec![vec![expr!()]]));
+        assert_eq!(run_program("!(map-atom (a (b) $c) $x (mapped $x))"), Ok(vec![vec![expr!(("mapped" "a") ("mapped" ("b")) ("mapped" c))]]));
     }
 
     #[test]
     fn metta_foldl_atom() {
-        assert_eq!(run_program("!(eval (foldl-atom () 1 $a $b (eval (+ $a $b))))"), Ok(vec![vec![expr!({Number::Integer(1)})]]));
-        assert_eq!(run_program("!(eval (foldl-atom (1 2 3) 0 $a $b (eval (+ $a $b))))"), Ok(vec![vec![expr!({Number::Integer(6)})]]));
+        assert_eq!(run_program("!(foldl-atom () 1 $a $b (eval (+ $a $b)))"), Ok(vec![vec![expr!({Number::Integer(1)})]]));
+        assert_eq!(run_program("!(foldl-atom (1 2 3) 0 $a $b (eval (+ $a $b)))"), Ok(vec![vec![expr!({Number::Integer(6)})]]));
     }
 
     #[test]

--- a/lib/src/metta/runner/stdlib/debug.rs
+++ b/lib/src/metta/runner/stdlib/debug.rs
@@ -213,8 +213,8 @@ mod tests {
 
     #[test]
     fn metta_alpha_eq_op() {
-        assert_eq!(run_program(&format!("(= (foo) (R $x $y)) !(let $foo (eval (foo)) (=alpha $foo (R $x $y)))")), Ok(vec![vec![expr!({Bool(true)})]]));
-        assert_eq!(run_program(&format!("(= (foo) (R $x $y)) !(let $foo (eval (foo)) (=alpha $foo (R $x $x)))")), Ok(vec![vec![expr!({Bool(false)})]]));
+        assert_eq!(run_program(&format!("(= (foo) (R $x $y)) !(let $foo (foo) (=alpha $foo (R $x $y)))")), Ok(vec![vec![expr!({Bool(true)})]]));
+        assert_eq!(run_program(&format!("(= (foo) (R $x $y)) !(let $foo (foo) (=alpha $foo (R $x $x)))")), Ok(vec![vec![expr!({Bool(false)})]]));
     }
 
     #[test]

--- a/lib/src/metta/runner/stdlib/math.rs
+++ b/lib/src/metta/runner/stdlib/math.rs
@@ -460,7 +460,7 @@ mod tests {
     #[test]
     fn metta_sqrt_math() {
         assert_eq!(run_program(&format!("!(sqrt-math 4)")), Ok(vec![vec![expr!({Number::Integer(2)})]]));
-        assert_eq!(run_program(&format!("!(chain (eval (sqrt-math -4)) $sqrt (isnan-math $sqrt))")), Ok(vec![vec![expr!({Bool(true)})]]));
+        assert_eq!(run_program(&format!("!(let $sqrt (sqrt-math -4) (isnan-math $sqrt))")), Ok(vec![vec![expr!({Bool(true)})]]));
         assert_eq!(run_program(&format!("!(sqrt-math A)")), Ok(vec![vec![expr!("Error" ({ SqrtMathOp{} } "A") "sqrt-math expects one argument: number")]]));
     }
 
@@ -474,8 +474,8 @@ mod tests {
     #[test]
     fn metta_log_math() {
         assert_eq!(run_program(&format!("!(log-math 2 4)")), Ok(vec![vec![expr!({Number::Integer(2)})]]));
-        assert_eq!(run_program(&format!("!(chain (eval (log-math 0 0)) $log (isnan-math $log))")), Ok(vec![vec![expr!({Bool(true)})]]));
-        assert_eq!(run_program(&format!("!(chain (eval (log-math 5 0)) $log (isinf-math $log))")), Ok(vec![vec![expr!({Bool(true)})]]));
+        assert_eq!(run_program(&format!("!(let $log (log-math 0 0) (isnan-math $log))")), Ok(vec![vec![expr!({Bool(true)})]]));
+        assert_eq!(run_program(&format!("!(let $log (log-math 5 0) (isinf-math $log))")), Ok(vec![vec![expr!({Bool(true)})]]));
     }
 
     #[test]
@@ -508,56 +508,56 @@ mod tests {
     #[test]
     fn metta_sin_math() {
         assert_eq!(run_program(&format!("!(sin-math 0)")), Ok(vec![vec![expr!({Number::Integer(0)})]]));
-        assert_eq!(run_program(&format!("!(chain (eval (sin-math 1.570796327)) $sin (< (- $sin 1.0) 1e-10))")), Ok(vec![vec![expr!({Bool(true)})]]));
+        assert_eq!(run_program(&format!("!(let $sin (sin-math 1.570796327) (< (- $sin 1.0) 1e-10))")), Ok(vec![vec![expr!({Bool(true)})]]));
         assert_eq!(run_program(&format!("!(sin-math A)")), Ok(vec![vec![expr!("Error" ({ SinMathOp{} } "A") "sin-math expects one argument: input number")]]));
     }
 
     #[test]
     fn metta_asin_math() {
         assert_eq!(run_program(&format!("!(asin-math 0)")), Ok(vec![vec![expr!({Number::Integer(0)})]]));
-        assert_eq!(run_program(&format!("!(chain (eval (sin-math 1)) $sin (< (- (asin-math $sin) 1.0) 1e-10))")), Ok(vec![vec![expr!({Bool(true)})]]));
+        assert_eq!(run_program(&format!("!(let $sin (sin-math 1) (< (- (asin-math $sin) 1.0) 1e-10))")), Ok(vec![vec![expr!({Bool(true)})]]));
         assert_eq!(run_program(&format!("!(asin-math A)")), Ok(vec![vec![expr!("Error" ({ AsinMathOp{} } "A") "asin-math expects one argument: input number")]]));
     }
 
     #[test]
     fn metta_cos_math() {
         assert_eq!(run_program(&format!("!(cos-math 0)")), Ok(vec![vec![expr!({Number::Integer(1)})]]));
-        assert_eq!(run_program(&format!("!(chain (eval (cos-math 1.570796327)) $cos (< (- $cos 0.0) 1e-10))")), Ok(vec![vec![expr!({Bool(true)})]]));
+        assert_eq!(run_program(&format!("!(let $cos (cos-math 1.570796327) (< (- $cos 0.0) 1e-10))")), Ok(vec![vec![expr!({Bool(true)})]]));
         assert_eq!(run_program(&format!("!(cos-math A)")), Ok(vec![vec![expr!("Error" ({ CosMathOp{} } "A") "cos-math expects one argument: input number")]]));
     }
 
     #[test]
     fn metta_acos_math() {
         assert_eq!(run_program(&format!("!(acos-math 1)")), Ok(vec![vec![expr!({Number::Integer(0)})]]));
-        assert_eq!(run_program(&format!("!(chain (eval (cos-math 1)) $cos (< (- (acos-math $cos) 1.0) 1e-10))")), Ok(vec![vec![expr!({Bool(true)})]]));
+        assert_eq!(run_program(&format!("!(let $cos (cos-math 1) (< (- (acos-math $cos) 1.0) 1e-10))")), Ok(vec![vec![expr!({Bool(true)})]]));
         assert_eq!(run_program(&format!("!(acos-math A)")), Ok(vec![vec![expr!("Error" ({ AcosMathOp{} } "A") "acos-math expects one argument: input number")]]));
     }
 
     #[test]
     fn metta_tan_math() {
         assert_eq!(run_program(&format!("!(tan-math 0)")), Ok(vec![vec![expr!({Number::Integer(0)})]]));
-        assert_eq!(run_program(&format!("!(chain (eval (tan-math 0.78539816339)) $tan (< (- $tan 1.0) 1e-10))")), Ok(vec![vec![expr!({Bool(true)})]]));
+        assert_eq!(run_program(&format!("!(let $tan (tan-math 0.78539816339) (< (- $tan 1.0) 1e-10))")), Ok(vec![vec![expr!({Bool(true)})]]));
         assert_eq!(run_program(&format!("!(tan-math A)")), Ok(vec![vec![expr!("Error" ({ TanMathOp{} } "A") "tan-math expects one argument: input number")]]));
     }
 
     #[test]
     fn metta_atan_math() {
         assert_eq!(run_program(&format!("!(atan-math 0)")), Ok(vec![vec![expr!({Number::Integer(0)})]]));
-        assert_eq!(run_program(&format!("!(chain (eval (atan-math 1)) $atan (< (- $atan 0.78539816339) 1e-10))")), Ok(vec![vec![expr!({Bool(true)})]]));
+        assert_eq!(run_program(&format!("!(let $atan (atan-math 1) (< (- $atan 0.78539816339) 1e-10))")), Ok(vec![vec![expr!({Bool(true)})]]));
         assert_eq!(run_program(&format!("!(atan-math A)")), Ok(vec![vec![expr!("Error" ({ AtanMathOp{} } "A") "atan-math expects one argument: input number")]]));
     }
 
     #[test]
     fn metta_isnan_math() {
         assert_eq!(run_program(&format!("!(isnan-math 0)")), Ok(vec![vec![expr!({Bool(false)})]]));
-        assert_eq!(run_program(&format!("!(chain (eval (log-math 0 0)) $log (isnan-math $log))")), Ok(vec![vec![expr!({Bool(true)})]]));
+        assert_eq!(run_program(&format!("!(let $log (log-math 0 0) (isnan-math $log))")), Ok(vec![vec![expr!({Bool(true)})]]));
         assert_eq!(run_program(&format!("!(isnan-math A)")), Ok(vec![vec![expr!("Error" ({ IsNanMathOp{} } "A") "isnan-math expects one argument: input number")]]));
     }
 
     #[test]
     fn metta_isinf_math() {
         assert_eq!(run_program(&format!("!(isinf-math 0)")), Ok(vec![vec![expr!({Bool(false)})]]));
-        assert_eq!(run_program(&format!("!(chain (eval (log-math 5 0)) $log (isinf-math $log))")), Ok(vec![vec![expr!({Bool(true)})]]));
+        assert_eq!(run_program(&format!("!(let $log (log-math 5 0) (isinf-math $log))")), Ok(vec![vec![expr!({Bool(true)})]]));
         assert_eq!(run_program(&format!("!(isinf-math A)")), Ok(vec![vec![expr!("Error" ({ IsInfMathOp{} } "A") "isinf-math expects one argument: input number")]]));
     }
 

--- a/lib/src/metta/runner/stdlib/mod.rs
+++ b/lib/src/metta/runner/stdlib/mod.rs
@@ -161,40 +161,40 @@ mod tests {
 
     #[test]
     fn metta_switch() {
-        let result = run_program("!(eval (switch (A $b) ( (($a B) ($b $a)) ((B C) (C B)) )))");
+        let result = run_program("!(switch (A $b) ( (($a B) ($b $a)) ((B C) (C B)) ))");
         assert_eq!(result, Ok(vec![vec![expr!("B" "A")]]));
-        let result = run_program("!(eval (switch (A $b) ( ((B C) (C B)) (($a B) ($b $a)) )))");
+        let result = run_program("!(switch (A $b) ( ((B C) (C B)) (($a B) ($b $a)) ))");
         assert_eq!(result, Ok(vec![vec![expr!("B" "A")]]));
-        let result = run_program("!(eval (switch (A $b) ( ((B C) (C B)) ((D E) (E B)) )))");
+        let result = run_program("!(switch (A $b) ( ((B C) (C B)) ((D E) (E B)) ))");
         assert_eq!(result, Ok(vec![vec![]]));
     }
 
     #[test]
     fn metta_is_function() {
-        let result = run_program("!(eval (is-function (-> $t)))");
+        let result = run_program("!(is-function (-> $t))");
         assert_eq!(result, Ok(vec![vec![expr!({Bool(true)})]]));
-        let result = run_program("!(eval (is-function (A $t)))");
+        let result = run_program("!(is-function (A $t))");
         assert_eq!(result, Ok(vec![vec![expr!({Bool(false)})]]));
-        let result = run_program("!(eval (is-function %Undefined%))");
+        let result = run_program("!(is-function %Undefined%)");
         assert_eq!(result, Ok(vec![vec![expr!({Bool(false)})]]));
     }
 
     #[test]
     fn metta_type_cast() {
-        assert_eq!(run_program("(: a A) !(eval (type-cast a A &self))"), Ok(vec![vec![expr!("a")]]));
-        assert_eq!(run_program("(: a A) !(eval (type-cast a B &self))"), Ok(vec![vec![expr!("Error" "a" "BadType")]]));
-        assert_eq!(run_program("(: a A) !(eval (type-cast a %Undefined% &self))"), Ok(vec![vec![expr!("a")]]));
-        assert_eq!(run_program("!(eval (type-cast a B &self))"), Ok(vec![vec![expr!("a")]]));
-        assert_eq!(run_program("!(eval (type-cast 42 Number &self))"), Ok(vec![vec![expr!({Number::Integer(42)})]]));
-        assert_eq!(run_program("!(eval (type-cast 42 %Undefined% &self))"), Ok(vec![vec![expr!({Number::Integer(42)})]]));
-        assert_eq!(run_program("(: a A) !(eval (type-cast a Atom &self))"), Ok(vec![vec![expr!("a")]]));
-        assert_eq!(run_program("(: a A) !(eval (type-cast a Symbol &self))"), Ok(vec![vec![expr!("a")]]));
-        assert_eq!(run_program("!(eval (type-cast 42 Grounded &self))"), Ok(vec![vec![expr!({Number::Integer(42)})]]));
-        assert_eq!(run_program("!(eval (type-cast () Expression &self))"), Ok(vec![vec![expr!()]]));
-        assert_eq!(run_program("!(eval (type-cast (a b) Expression &self))"), Ok(vec![vec![expr!("a" "b")]]));
-        assert_eq!(run_program("!(eval (type-cast $v Variable &self))"), Ok(vec![vec![expr!(v)]]));
-        assert_eq!(run_program("(: a A) (: b B) !(eval (type-cast (a b) (A B) &self))"), Ok(vec![vec![expr!("a" "b")]]));
-        assert_eq!(run_program("(: a A) (: a B) !(eval (type-cast a A &self))"), Ok(vec![vec![expr!("a")]]));
+        assert_eq!(run_program("(: a A) !(type-cast a A &self)"), Ok(vec![vec![expr!("a")]]));
+        assert_eq!(run_program("(: a A) !(type-cast a B &self)"), Ok(vec![vec![expr!("Error" "a" "BadType")]]));
+        assert_eq!(run_program("(: a A) !(type-cast a %Undefined% &self)"), Ok(vec![vec![expr!("a")]]));
+        assert_eq!(run_program("!(type-cast a B &self)"), Ok(vec![vec![expr!("a")]]));
+        assert_eq!(run_program("!(type-cast 42 Number &self)"), Ok(vec![vec![expr!({Number::Integer(42)})]]));
+        assert_eq!(run_program("!(type-cast 42 %Undefined% &self)"), Ok(vec![vec![expr!({Number::Integer(42)})]]));
+        assert_eq!(run_program("(: a A) !(type-cast a Atom &self)"), Ok(vec![vec![expr!("a")]]));
+        assert_eq!(run_program("(: a A) !(type-cast a Symbol &self)"), Ok(vec![vec![expr!("a")]]));
+        assert_eq!(run_program("!(type-cast 42 Grounded &self)"), Ok(vec![vec![expr!({Number::Integer(42)})]]));
+        assert_eq!(run_program("!(type-cast () Expression &self)"), Ok(vec![vec![expr!()]]));
+        assert_eq!(run_program("!(type-cast (a b) Expression &self)"), Ok(vec![vec![expr!("a" "b")]]));
+        assert_eq!(run_program("!(type-cast $v Variable &self)"), Ok(vec![vec![expr!(v)]]));
+        assert_eq!(run_program("(: a A) (: b B) !(type-cast (a b) (A B) &self)"), Ok(vec![vec![expr!("a" "b")]]));
+        assert_eq!(run_program("(: a A) (: a B) !(type-cast a A &self)"), Ok(vec![vec![expr!("a")]]));
     }
 
     #[test]


### PR DESCRIPTION
Re-make of [PR](https://github.com/trueagi-io/hyperon-experimental/pull/966) after Vitaly's review. Eval's either removed from tests or changed from chain+eval to let.