### PR TITLE
Fix infinite loop because of no return inside function

### DIFF
--- a/lib/src/metta/mod.rs
+++ b/lib/src/metta/mod.rs
@@ -25,6 +25,7 @@ pub const BAD_TYPE_SYMBOL : Atom = sym!("BadType");
 pub const INCORRECT_NUMBER_OF_ARGUMENTS_SYMBOL : Atom = sym!("IncorrectNumberOfArguments");
 pub const NOT_REDUCIBLE_SYMBOL : Atom = sym!("NotReducible");
 pub const STACK_OVERFLOW_SYMBOL : Atom = sym!("StackOverflow");
+pub const NO_RETURN_SYMBOL : Atom = sym!("NoReturn");
 
 pub const EMPTY_SYMBOL : Atom = sym!("Empty");
 


### PR DESCRIPTION
Return Error from function instead of falling into the infinite loop when the result of evaluation is not a minimal MeTTa operation and not a return.