### PR TITLE
assert and asserts with messages added

### DIFF
--- a/lib/src/metta/runner/stdlib/debug.rs
+++ b/lib/src/metta/runner/stdlib/debug.rs
@@ -111,13 +111,18 @@ fn assert_results_are_equal<'a, E: Equality<&'a Atom>>(args: &'a [Atom], cmp: E)
     let expected = TryInto::<&ExpressionAtom>::try_into(args.get(1).ok_or_else(arg_error)?)?.children();
     let assert = args.get(2).ok_or_else(arg_error)?;
 
+
     let report = format!("\nExpected: {}\nGot: {}", SliceDisplay(expected), SliceDisplay(actual));
 
     match compare_vec_no_order(actual.iter(), expected.iter(), cmp).as_display() {
         None => unit_result(),
         Some(diff) => {
-            let msg = format!("{}\n{}", report, diff);
-            Ok(vec![Atom::expr([ERROR_SYMBOL, assert.clone(), Atom::gnd(Str::from_string(msg))])])
+            match args.get(3) {
+                None => {
+                    let msg = format!("{}\n{}", report, diff);
+                    Ok(vec![Atom::expr([ERROR_SYMBOL, assert.clone(), Atom::gnd(Str::from_string(msg))])])},
+                Some(m) => Ok(vec![Atom::expr([m.clone()])])
+            }
         },
     }
 }
@@ -165,6 +170,16 @@ pub(super) fn register_context_independent_tokens(tref: &mut Tokenizer) {
             expr!("->" "Atom" "Atom" "Atom" ("->")),
             |args: &[Atom]| -> Result<Vec<Atom>, ExecError> { assert_results_are_equal(args, AlphaEquality{}) }, 
             ));
+    tref.register_function(GroundedFunctionAtom::new(
+        r"_assert-results-are-equal-msg".into(),
+        expr!("->" "Atom" "Atom" "Atom" "String" ("->")),
+        |args: &[Atom]| -> Result<Vec<Atom>, ExecError> { assert_results_are_equal(args, DefaultEquality{}) },
+    ));
+    tref.register_function(GroundedFunctionAtom::new(
+        r"_assert-results-are-alpha-equal-msg".into(),
+        expr!("->" "Atom" "Atom" "Atom" "String" ("->")),
+        |args: &[Atom]| -> Result<Vec<Atom>, ExecError> { assert_results_are_equal(args, AlphaEquality{}) },
+    ));
 }
 
 #[cfg(test)]

--- a/lib/src/metta/runner/stdlib/debug.rs
+++ b/lib/src/metta/runner/stdlib/debug.rs
@@ -117,12 +117,11 @@ fn assert_results_are_equal<'a, E: Equality<&'a Atom>>(args: &'a [Atom], cmp: E)
     match compare_vec_no_order(actual.iter(), expected.iter(), cmp).as_display() {
         None => unit_result(),
         Some(diff) => {
-            match args.get(3) {
-                None => {
-                    let msg = format!("{}\n{}", report, diff);
-                    Ok(vec![Atom::expr([ERROR_SYMBOL, assert.clone(), Atom::gnd(Str::from_string(msg))])])},
-                Some(m) => Ok(vec![Atom::expr([m.clone()])])
-            }
+            let msg = match args.get(3) {
+                None => format!("{}\n{}", report, diff),
+                Some(m) => atom_to_string(m),
+            };
+            Ok(vec![Atom::expr([ERROR_SYMBOL, assert.clone(), Atom::gnd(Str::from_string(msg))])])
         },
     }
 }

--- a/lib/src/metta/runner/stdlib/debug.rs
+++ b/lib/src/metta/runner/stdlib/debug.rs
@@ -172,12 +172,12 @@ pub(super) fn register_context_independent_tokens(tref: &mut Tokenizer) {
             ));
     tref.register_function(GroundedFunctionAtom::new(
         r"_assert-results-are-equal-msg".into(),
-        expr!("->" "Atom" "Atom" "Atom" "String" ("->")),
+        expr!("->" "Atom" "Atom" "Atom" "Atom" ("->")),
         |args: &[Atom]| -> Result<Vec<Atom>, ExecError> { assert_results_are_equal(args, DefaultEquality{}) },
     ));
     tref.register_function(GroundedFunctionAtom::new(
         r"_assert-results-are-alpha-equal-msg".into(),
-        expr!("->" "Atom" "Atom" "Atom" "String" ("->")),
+        expr!("->" "Atom" "Atom" "Atom" "Atom" ("->")),
         |args: &[Atom]| -> Result<Vec<Atom>, ExecError> { assert_results_are_equal(args, AlphaEquality{}) },
     ));
 }

--- a/lib/src/metta/runner/stdlib/stdlib.metta
+++ b/lib/src/metta/runner/stdlib/stdlib.metta
@@ -1052,7 +1052,7 @@
    (chain (context-space) $space
      (chain (metta (collapse $actual) %Undefined% $space) $actual-results
        (chain (metta (collapse $expected) %Undefined% $space) $expected-results
-         (_assert-results-are-equal-msg $actual-results $expected-results (assertEqualMsg $actual $expected $msg) $msg) ))))
+         (_assert-results-are-equal-msg $actual-results $expected-results (assertEqualMsg $actual $expected) $msg) ))))
 
 (@doc assertAlphaEqual
   (@desc "Compares (sets of) results of evaluation of two expressions using alpha equality")
@@ -1079,7 +1079,7 @@
    (chain (context-space) $space
      (chain (metta (collapse $actual) %Undefined% $space) $actual-results
        (chain (metta (collapse $expected) %Undefined% $space) $expected-results
-         (_assert-results-are-alpha-equal-msg $actual-results $expected-results (assertAlphaEqualMsg $actual $expected $msg) $msg) ))))
+         (_assert-results-are-alpha-equal-msg $actual-results $expected-results (assertAlphaEqualMsg $actual $expected) $msg) ))))
 
 (@doc assertEqualToResult
   (@desc "Same as assertEqual but it doesn't evaluate second argument. Second argument is considered as a set of values of the first argument's evaluation")
@@ -1104,7 +1104,7 @@
 (= (assertEqualToResultMsg $actual $expected-results $msg)
    (chain (context-space) $space
      (chain (metta (collapse $actual) %Undefined% $space) $actual-results
-       (_assert-results-are-equal-msg $actual-results $expected-results (assertEqualToResultMsg $actual $expected-results $msg) $msg) )))
+       (_assert-results-are-equal-msg $actual-results $expected-results (assertEqualToResultMsg $actual $expected-results) $msg) )))
 
 (@doc assertAlphaEqualToResult
   (@desc "Same as assertAlphaEqual but it doesn't evaluate second argument. Second argument is considered as a set of values of the first argument's evaluation")
@@ -1129,7 +1129,7 @@
 (= (assertAlphaEqualToResultMsg $actual $expected-results $msg)
    (chain (context-space) $space
      (chain (metta (collapse $actual) %Undefined% $space) $actual-results
-       (_assert-results-are-alpha-equal-msg $actual-results $expected-results (assertAlphaEqualToResult $actual $expected-results $msg) $msg) )))
+       (_assert-results-are-alpha-equal-msg $actual-results $expected-results (assertAlphaEqualToResultMsg $actual $expected-results) $msg) )))
 
 (@doc superpose
   (@desc "Turns a tuple (first argument) into a nondeterministic result")

--- a/lib/src/metta/runner/stdlib/stdlib.metta
+++ b/lib/src/metta/runner/stdlib/stdlib.metta
@@ -676,6 +676,12 @@
                 (Error (assertIncludes $atom $content) 
                   (assertIncludes error: $diff not included in result: $eval_atom))))))
 
+(: assert (-> Atom (->)))
+(= (assert $atom)
+    (chain (context-space) $space
+        (chain (metta $atom %Undefined% $space) $eval-atom
+            (unify $eval-atom True () (Error (assert $atom) ($atom not True))))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Documentation formatting functions
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1034,6 +1040,20 @@
        (chain (metta (collapse $expected) %Undefined% $space) $expected-results
          (_assert-results-are-equal $actual-results $expected-results (assertEqual $actual $expected)) ))))
 
+(@doc assertEqualMsg
+  (@desc "Compares (sets of) results of evaluation of two expressions")
+  (@params (
+    (@param "First expression")
+    (@param "Second expression")
+    (@param "Message to return on assert failure")))
+  (@return "Unit atom if both expressions after evaluation are equal, input message - otherwise"))
+(: assertEqualMsg (-> Atom Atom Atom (->)))
+(= (assertEqualMsg $actual $expected $msg)
+   (chain (context-space) $space
+     (chain (metta (collapse $actual) %Undefined% $space) $actual-results
+       (chain (metta (collapse $expected) %Undefined% $space) $expected-results
+         (_assert-results-are-equal-msg $actual-results $expected-results (assertEqualMsg $actual $expected $msg) $msg) ))))
+
 (@doc assertAlphaEqual
   (@desc "Compares (sets of) results of evaluation of two expressions using alpha equality")
   (@params (
@@ -1047,6 +1067,20 @@
        (chain (metta (collapse $expected) %Undefined% $space) $expected-results
          (_assert-results-are-alpha-equal $actual-results $expected-results (assertAlphaEqual $actual $expected)) ))))
 
+(@doc assertAlphaEqualMsg
+  (@desc "Compares (sets of) results of evaluation of two expressions using alpha equality")
+  (@params (
+    (@param "First expression")
+    (@param "Second expression")
+    (@param "Message to return on assert failure")))
+  (@return "Unit atom if both expressions after evaluation are alpha equal, input message - otherwise"))
+(: assertAlphaEqualMsg (-> Atom Atom Atom (->)))
+(= (assertAlphaEqualMsg $actual $expected $msg)
+   (chain (context-space) $space
+     (chain (metta (collapse $actual) %Undefined% $space) $actual-results
+       (chain (metta (collapse $expected) %Undefined% $space) $expected-results
+         (_assert-results-are-alpha-equal-msg $actual-results $expected-results (assertAlphaEqualMsg $actual $expected $msg) $msg) ))))
+
 (@doc assertEqualToResult
   (@desc "Same as assertEqual but it doesn't evaluate second argument. Second argument is considered as a set of values of the first argument's evaluation")
   (@params (
@@ -1059,6 +1093,19 @@
      (chain (metta (collapse $actual) %Undefined% $space) $actual-results
        (_assert-results-are-equal $actual-results $expected-results (assertEqualToResult $actual $expected-results)) )))
 
+(@doc assertEqualToResultMsg
+  (@desc "Same as assertEqualMsg but it doesn't evaluate second argument. Second argument is considered as a set of values of the first argument's evaluation")
+  (@params (
+    (@param "First expression (it will be evaluated)")
+    (@param "Second expression containing the expected evaluation results (it won't be evaluated)")
+    (@param "Message to return on assert failure")))
+  (@return "Unit atom if both expressions after evaluation of the first argument are equal, input message - otherwise"))
+(: assertEqualToResultMsg (-> Atom Atom Atom (->)))
+(= (assertEqualToResultMsg $actual $expected-results $msg)
+   (chain (context-space) $space
+     (chain (metta (collapse $actual) %Undefined% $space) $actual-results
+       (_assert-results-are-equal-msg $actual-results $expected-results (assertEqualToResultMsg $actual $expected-results $msg) $msg) )))
+
 (@doc assertAlphaEqualToResult
   (@desc "Same as assertAlphaEqual but it doesn't evaluate second argument. Second argument is considered as a set of values of the first argument's evaluation")
   (@params (
@@ -1070,6 +1117,19 @@
    (chain (context-space) $space
      (chain (metta (collapse $actual) %Undefined% $space) $actual-results
        (_assert-results-are-alpha-equal $actual-results $expected-results (assertAlphaEqualToResult $actual $expected-results)) )))
+
+(@doc assertAlphaEqualToResultMsg
+  (@desc "Same as assertAlphaEqualMsg but it doesn't evaluate second argument. Second argument is considered as a set of values of the first argument's evaluation")
+  (@params (
+    (@param "First expression (it will be evaluated)")
+    (@param "Second expression (it won't be evaluated)")
+    (@param "Message to return on assert failure")))
+  (@return "Unit atom if both expressions after evaluation of the first argument are alpha equal, input message - otherwise"))
+(: assertAlphaEqualToResultMsg (-> Atom Atom Atom (->)))
+(= (assertAlphaEqualToResultMsg $actual $expected-results $msg)
+   (chain (context-space) $space
+     (chain (metta (collapse $actual) %Undefined% $space) $actual-results
+       (_assert-results-are-alpha-equal-msg $actual-results $expected-results (assertAlphaEqualToResult $actual $expected-results $msg) $msg) )))
 
 (@doc superpose
   (@desc "Turns a tuple (first argument) into a nondeterministic result")

--- a/lib/tests/test_stdlib.metta
+++ b/lib/tests/test_stdlib.metta
@@ -49,3 +49,43 @@
 !(assertEqualToResult
    (id (noeval (+ 1 2)))
    (3))
+
+; assert
+
+!(assert True)
+!(assert (or True False))
+!(assertEqual (assert (and True False)) (Error (assert (and True False)) ((and True False) not True)))
+
+; asserts with custom messages
+; first part of tests is to check if asserts works as intended when assert should output [()].
+; So those tests are duplicate of tests for original asserts
+
+!(assertEqualToResultMsg
+   (noeval (+ 1 2))
+   ((+ 1 2))
+   "Test message")
+
+!(assertEqualToResultMsg
+   (= (f) (+ 1 2))
+   ((= (f) 3))
+   "Test message")
+
+(= (f1 $x) $x)
+(= (f2 $x) $x)
+
+!(assertEqualMsg (+ 1 2) 3 "Test message")
+!(assertAlphaEqualMsg (f1 $x) (f2 $x) "Test message")
+
+(= (f3) $x)
+!(assertAlphaEqualToResultMsg ((f3) (f3)) (($x $y)) "Test message")
+
+; next part of tests is to test if message is being output on assert failure
+
+!(assertEqual (assertEqualMsg (+ 1 2) 4 "Test message") ("Test message"))
+!(assertEqual (assertAlphaEqualMsg (f1 A) (f2 B) "Test message") ("Test message"))
+!(assertEqual (assertAlphaEqualToResultMsg ((foo) (foo)) (($x $x)) "Test message") ("Test message"))
+!(assertEqual (assertEqualToResultMsg
+                 (noeval (+ 1 2))
+                 ((+ 1 3))
+                 "Test message")
+              ("Test message"))

--- a/lib/tests/test_stdlib.metta
+++ b/lib/tests/test_stdlib.metta
@@ -81,11 +81,14 @@
 
 ; next part of tests is to test if message is being output on assert failure
 
-!(assertEqual (assertEqualMsg (+ 1 2) 4 "Test message") ("Test message"))
-!(assertEqual (assertAlphaEqualMsg (f1 A) (f2 B) "Test message") ("Test message"))
-!(assertEqual (assertAlphaEqualToResultMsg ((foo) (foo)) (($x $x)) "Test message") ("Test message"))
-!(assertEqual (assertEqualToResultMsg
-                 (noeval (+ 1 2))
-                 ((+ 1 3))
-                 "Test message")
-              ("Test message"))
+!(assertEqual (assertEqualMsg (+ 1 2) 4 "Test message")
+              (Error (assertEqualMsg (+ 1 2) 4) "Test message"))
+
+!(assertEqual (assertAlphaEqualMsg (f1 A) (f2 B) "Test message")
+              (Error (assertAlphaEqualMsg (f1 A) (f2 B)) "Test message"))
+
+!(assertEqual (assertAlphaEqualToResultMsg ((foo) (foo)) (($x $x)) "Test message")
+              (Error (assertAlphaEqualToResultMsg ((foo) (foo)) (($x $x))) "Test message"))
+
+!(assertEqual (assertEqualToResultMsg (noeval (+ 1 2)) ((+ 1 3)) "Test message")
+              (Error (assertEqualToResultMsg (noeval (+ 1 2)) ((+ 1 3))) "Test message"))


### PR DESCRIPTION
So, I've added `assert` as @ngeiswei  asked [here](https://github.com/trueagi-io/hyperon-experimental/issues/900) , please check if it is what you've asked.

I've also added some asserts with custom messages as @Necr0x0Der asked [here](https://github.com/trueagi-io/hyperon-experimental/issues/861) . Please also check if it is fine with you. 

One thing about asserts with custom message. Regular assert will stop program from further interpretation on failure, but -Msg asserts won't. I'm not sure about this behavior.  As an alternative, instead of just outputting custom message it could be wrapped into Error like regular output of assert. So some 
`!(assertEqualMsg (+ 1 2) 4 "Test message")` will output `(Error (assertEqualMsg (+ 1 2) 4 "Test message") "Test message")` instead of just ("Test message"). What behavior is preferable?
