### PR TITLE
Add string conversion

### DIFF
--- a/hyperon-atom/src/lib.rs
+++ b/hyperon-atom/src/lib.rs
@@ -785,6 +785,39 @@ impl Clone for Box<dyn GroundedAtom> {
     }
 }
 
+/// Converts serializable grounded atom into native Rust type `T`.
+/// Returning error from this serializer is not expected as usually it should
+/// just write data into a memory buffer for conversion. [Default] is required
+/// to instantiate it in [ConvertingSerializer::convert] method.
+pub trait ConvertingSerializer<T>: serial::Serializer + Default {
+    fn into_type(self) -> Option<T>;
+
+    /// Converts atom into Rust value using `Self::default()` instance.
+    /// First it checks whether the grounded atom is already an instance of `T`
+    /// and clones value if it the case. Otherwise it uses `Self` to convert
+    /// into `T` via serialization.
+    fn convert(atom: &Atom) -> Option<T>
+        where T: 'static + Clone
+    {
+        std::convert::TryInto::<&dyn GroundedAtom>::try_into(atom)
+            .ok()
+            .and_then(|gnd| {
+                gnd.as_any_ref()
+                    // TODO: it is not clear whether this step really improves performance.
+                    // On the other hand it requires `T` to be static and implement `Clone`.
+                    // It is better to do a performance test and check if first step should be
+                    // removed.
+                    .downcast_ref::<T>()
+                    .cloned()
+                    .or_else(|| {
+                        let mut serializer = Self::default();
+                        gnd.serialize(&mut serializer).ok()
+                            .and_then(|()| serializer.into_type())
+                    })
+            })
+    }
+}
+
 // Atom enum
 
 /// Atoms are main components of the atomspace. There are four meta-types of
@@ -1104,6 +1137,7 @@ mod test {
     #![allow(non_snake_case)]
 
     use super::*;
+    use crate::serial;
     use std::collections::HashMap;
 
     // Expected atom constructors to make test checks
@@ -1312,4 +1346,46 @@ mod test {
             Err("Atom is not an ExpressionAtom"));
     }
 
+    #[derive(Default)]
+    struct I64Serializer {
+        value: Option<i64>,
+    }
+
+    impl serial::Serializer for I64Serializer {
+        fn serialize_i64(&mut self, v: i64) -> serial::Result {
+            self.value = Some(v);
+            Ok(())
+        }
+    }
+
+    impl ConvertingSerializer<i64> for I64Serializer {
+        fn into_type(self) -> Option<i64> {
+            self.value
+        }
+    }
+
+    #[derive(PartialEq, Debug, Clone)]
+    struct I64Gnd(i64);
+
+    impl Display for I64Gnd {
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(f, "{}", self.0)
+        }
+    }
+
+    impl Grounded for I64Gnd {
+        fn type_(&self) -> Atom {
+            rust_type_atom::<Self>()
+        }
+
+        fn serialize(&self, serializer: &mut dyn serial::Serializer) -> serial::Result {
+            serializer.serialize_i64(self.0)
+        }
+    }
+
+    #[test]
+    fn test_converting_serializer() {
+        assert_eq!(I64Serializer::convert(&Atom::gnd(I64Gnd(42))), Some(42));
+        assert_eq!(I64Serializer::convert(&Atom::value("42")), None);
+    }
 }

--- a/lib/src/metta/runner/bool.rs
+++ b/lib/src/metta/runner/bool.rs
@@ -71,6 +71,10 @@ impl serial::Serializer for BoolSerializer {
 }
 
 impl ConvertingSerializer<Bool> for BoolSerializer {
+    fn check_type(gnd: &dyn GroundedAtom) -> bool {
+        gnd.type_() == ATOM_TYPE_BOOL
+    }
+
     fn into_type(self) -> Option<Bool> {
         self.value
     }

--- a/lib/src/metta/runner/bool.rs
+++ b/lib/src/metta/runner/bool.rs
@@ -1,6 +1,6 @@
 use hyperon_atom::*;
 use hyperon_atom::serial;
-use hyperon_atom::serial::ConvertingSerializer;
+use hyperon_atom::ConvertingSerializer;
 
 use std::fmt::Display;
 
@@ -70,7 +70,7 @@ impl serial::Serializer for BoolSerializer {
     }
 }
 
-impl serial::ConvertingSerializer<Bool> for BoolSerializer {
+impl ConvertingSerializer<Bool> for BoolSerializer {
     fn into_type(self) -> Option<Bool> {
         self.value
     }

--- a/lib/src/metta/runner/builtin_mods/json.rs
+++ b/lib/src/metta/runner/builtin_mods/json.rs
@@ -5,7 +5,7 @@ use crate::space::grounding::GroundingSpace;
 use crate::metta::text::SExprParser;
 use crate::metta::runner::{Metta, ModuleLoader, RunContext};
 use crate::metta::runner::modules::MettaMod;
-use crate::metta::runner::str::{atom_to_string, ATOM_TYPE_STRING};
+use crate::metta::runner::str::ATOM_TYPE_STRING;
 use crate::metta::runner::str::Str;
 use serde_json::Value;
 use hyperon_space::ATOM_TYPE_SPACE;
@@ -265,8 +265,8 @@ fn decode_array(arr: &Vec<Value>) -> Result<Atom, ExecError> {
 
 fn json_decode(args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
     let arg_error = || ExecError::from("json-decode expects string to decode as input");
-    let input = atom_to_string(args.get(0).ok_or_else(arg_error)?);
-    match &serde_json::from_str(&input) {
+    let input = args.get(0).and_then(Str::from_atom).ok_or_else(arg_error)?;
+    match &serde_json::from_str(input.as_str()) {
         Ok(decoded) => Ok(vec![decode_value(decoded)?]),
         Err(e) => Err(ExecError::from(format!("Failed to decode string. Reason: {}", e))),
     }

--- a/lib/src/metta/runner/number.rs
+++ b/lib/src/metta/runner/number.rs
@@ -1,6 +1,6 @@
 use hyperon_atom::*;
 use hyperon_atom::serial;
-use hyperon_atom::serial::ConvertingSerializer;
+use hyperon_atom::ConvertingSerializer;
 
 use std::fmt::Display;
 
@@ -148,7 +148,7 @@ impl serial::Serializer for NumberSerializer {
     }
 }
 
-impl serial::ConvertingSerializer<Number> for NumberSerializer {
+impl ConvertingSerializer<Number> for NumberSerializer {
     fn into_type(self) -> Option<Number> {
         self.value
     }

--- a/lib/src/metta/runner/number.rs
+++ b/lib/src/metta/runner/number.rs
@@ -149,6 +149,10 @@ impl serial::Serializer for NumberSerializer {
 }
 
 impl ConvertingSerializer<Number> for NumberSerializer {
+    fn check_type(gnd: &dyn GroundedAtom) -> bool {
+        gnd.type_() == ATOM_TYPE_NUMBER
+    }
+
     fn into_type(self) -> Option<Number> {
         self.value
     }

--- a/lib/src/metta/runner/stdlib/debug.rs
+++ b/lib/src/metta/runner/stdlib/debug.rs
@@ -118,10 +118,10 @@ fn assert_results_are_equal<'a, E: Equality<&'a Atom>>(args: &'a [Atom], cmp: E)
         None => unit_result(),
         Some(diff) => {
             let msg = match args.get(3) {
-                None => format!("{}\n{}", report, diff),
-                Some(m) => atom_to_string(m),
+                None => Atom::gnd(Str::from_string(format!("{}\n{}", report, diff))),
+                Some(m) => m.clone(),
             };
-            Ok(vec![Atom::expr([ERROR_SYMBOL, assert.clone(), Atom::gnd(Str::from_string(msg))])])
+            Ok(vec![Atom::expr([ERROR_SYMBOL, assert.clone(), msg])])
         },
     }
 }

--- a/lib/src/metta/runner/stdlib/string.rs
+++ b/lib/src/metta/runner/stdlib/string.rs
@@ -50,7 +50,7 @@ impl Grounded for FormatArgsOp {
 impl CustomExecute for FormatArgsOp {
     fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
         let arg_error = || ExecError::from("format-args expects format string as a first argument and expression as a second argument");
-        let format = atom_to_string(args.get(0).ok_or_else(arg_error)?);
+        let format = args.get(0).and_then(Str::from_atom).ok_or_else(arg_error)?;
         let args = TryInto::<&ExpressionAtom>::try_into(args.get(1).ok_or_else(arg_error)?)?;
         let args: Vec<String> = args.children().iter()
             .map(|atom| atom_to_string(atom))

--- a/lib/src/metta/runner/str.rs
+++ b/lib/src/metta/runner/str.rs
@@ -81,6 +81,10 @@ impl serial::Serializer for StrSerializer {
 }
 
 impl ConvertingSerializer<Str> for StrSerializer {
+    fn check_type(gnd: &dyn GroundedAtom) -> bool {
+        gnd.type_() == ATOM_TYPE_STRING
+    }
+
     fn into_type(self) -> Option<Str> {
         self.value
     }

--- a/lib/src/metta/runner/str.rs
+++ b/lib/src/metta/runner/str.rs
@@ -52,6 +52,12 @@ impl std::fmt::Display for Str {
     }
 }
 
+impl Into<String> for Str {
+    fn into(self) -> String {
+        self.as_str().into()
+    }
+}
+
 /// A utility function to return the part of a string in between starting and ending quotes
 pub fn strip_quotes(src: &str) -> &str {
     if let Some(first) = src.chars().next() {

--- a/lib/src/metta/runner/str.rs
+++ b/lib/src/metta/runner/str.rs
@@ -89,9 +89,7 @@ impl serial::ConvertingSerializer<Str> for StrSerializer {
 pub fn atom_to_string(atom: &Atom) -> String {
     match atom {
         Atom::Grounded(gnd) if gnd.type_() == ATOM_TYPE_STRING =>
-            // TODO: get string from internal representation using
-            // serialization like we do for Number
-            unescape(&atom.to_string()).unwrap(),
+            Str::from_atom(atom).unwrap().as_str().into(),
         _ => atom.to_string(),
     }
 }

--- a/lib/src/metta/runner/str.rs
+++ b/lib/src/metta/runner/str.rs
@@ -1,7 +1,7 @@
 use hyperon_atom::*;
 use hyperon_common::collections::ImmutableString;
 use hyperon_atom::serial;
-use hyperon_atom::serial::ConvertingSerializer;
+use hyperon_atom::ConvertingSerializer;
 use unescaper;
 
 /// String type
@@ -80,7 +80,7 @@ impl serial::Serializer for StrSerializer {
     }
 }
 
-impl serial::ConvertingSerializer<Str> for StrSerializer {
+impl ConvertingSerializer<Str> for StrSerializer {
     fn into_type(self) -> Option<Str> {
         self.value
     }

--- a/repl/src/metta_shim.rs
+++ b/repl/src/metta_shim.rs
@@ -274,9 +274,9 @@ pub mod metta_interface_mod {
     use hyperon_atom::ExpressionAtom;
     use hyperon_atom::Atom;
     use hyperon::metta::runner::{Metta, RunnerState, Environment, EnvBuilder};
+    use hyperon::metta::runner::str::Str;
     use hyperon_common::collections::VecDisplay;
     use super::{exec_state_prepare, exec_state_should_break};
-    use hyperon::metta::runner::str::atom_to_string;
 
     pub struct MettaShim {
         pub metta: Metta,
@@ -370,8 +370,9 @@ pub mod metta_interface_mod {
 
         pub fn get_config_string(&mut self, config_name: &str) -> Option<String> {
             let atom = self.get_config_atom(config_name)?;
-            //TODO: We need to do atom type checking here
-            Some(atom_to_string(&atom))
+            Some(Str::from_atom(&atom)
+                .expect(format!("String is expected as a value of {}", config_name).as_str())
+                .into())
         }
 
         pub fn get_config_expr_vec(&mut self, config_name: &str) -> Option<Vec<String>> {
@@ -380,8 +381,9 @@ pub mod metta_interface_mod {
                 Some(expr.into_children()
                     .into_iter()
                     .map(|atom| {
-                        //TODO: We need to do atom type checking here
-                        atom_to_string(&atom)
+                        Str::from_atom(&atom)
+                            .expect(format!("String is expected as a value of {}", config_name).as_str())
+                            .into()
                     })
                     .collect())
             } else {


### PR DESCRIPTION
Check the type of the grounded atom during its conversion into a Rust value. This fixes `format-args` accepts non string values as a first argument mentioned in #978.