### PR TITLE
Allow returning bindings from executable grounded atoms

### DIFF
--- a/hyperon-atom/src/matcher.rs
+++ b/hyperon-atom/src/matcher.rs
@@ -1046,7 +1046,7 @@ impl BindingsSet {
 /// Iterator over atom matching results. Each result is an instance of [Bindings].
 //TODO: A situation where a MatchResultIter returns an unbounded (infinite) number of results
 // will hang this implementation, on account of `.collect()`
-pub type MatchResultIter = Box<dyn Iterator<Item=Bindings>>;
+pub type MatchResultIter = BoxedIter<'static, Bindings>;
 
 /// Matches two atoms and returns an iterator over results. Atoms are
 /// treated symmetrically.

--- a/lib/tests/test_stdlib.metta
+++ b/lib/tests/test_stdlib.metta
@@ -112,3 +112,8 @@
 !(assertEqual (overlap-857 (a b c) (b c d)) ((a) (c b) (d)))
 
 !(assertEqual (let $f_hyps ((⟨wff⟩ ⟨P⟩) (⟨wff⟩ ⟨Q⟩)) (map-atom $f_hyps $f_hyp (let ($typecode $mvar) $f_hyp $mvar))) (⟨P⟩ ⟨Q⟩))
+
+; Test match function (see issue 911)
+(issue911 A B)
+(= (isa911 $x $y) (match &self (issue911 $x $y) True))
+!(assertEqual ((isa911 $a B) $a) (True A))


### PR DESCRIPTION
Adding new execute_bindings method into the CustomExecute trait in order to allow returning variable bindings if function is able doing it. Default implementation falls back to the call of CustomExecute::execute method. Modify interpreter to call CustomExecute::execute_bindings. Modify MatchOp implementation to return variable bindings. Fixes #911 