### PR TITLE
change behavior of atom_error_message fun

### DIFF
--- a/lib/src/metta/mod.rs
+++ b/lib/src/metta/mod.rs
@@ -6,6 +6,7 @@ pub mod types;
 pub mod runner;
 
 use hyperon_atom::*;
+use crate::metta::runner::str::atom_to_string;
 use crate::space::grounding::GroundingSpace;
 
 pub const ATOM_TYPE_UNDEFINED : Atom = sym!("%Undefined%");
@@ -73,7 +74,7 @@ pub fn atom_is_error(atom: &Atom) -> bool {
 /// Returns a message string from an error expression
 ///
 /// NOTE: this function will panic if the supported atom is not a valid error expression
-pub fn atom_error_message(atom: &Atom) -> &str {
+pub fn atom_error_message(atom: &Atom) -> String {
     const PANIC_STR: &str = "Atom is not error expression";
     match atom {
         Atom::Expression(expr) => {
@@ -82,8 +83,7 @@ pub fn atom_error_message(atom: &Atom) -> &str {
                 4 => expr.children().get(3).unwrap(),
                 _ => panic!("{}", PANIC_STR)
             };
-            let sym_atom = <&SymbolAtom>::try_from(sym_atom).expect(PANIC_STR);
-            sym_atom.name()
+            atom_to_string(sym_atom)
         },
         _ => panic!("{}", PANIC_STR)
     }


### PR DESCRIPTION
Fix behavior when rust panic was thrown on importing of metta script which contains assert which throws an error. 

Before:
```
!(import! &self assertErr)
[2025-08-08T05:55:02Z INFO  hyperon::metta::runner::pkg_mgmt::catalog] Found module: "assertErr" inside "Dir \"/home/daddywesker/SingularityNet/Metta/dw_fork/hyperon-experimental\""
[2025-08-08T05:55:02Z INFO  hyperon::metta::runner::pkg_mgmt::catalog] Preparing to load module: 'assertErr' as 'top:assertErr'

thread 'main' panicked at lib/src/metta/mod.rs:86:62:
Atom is not error expression: "Atom is not a SymbolAtom"
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

After:
```
!(import! &self assertErr)
[2025-08-08T06:52:49Z INFO  hyperon::metta::runner::pkg_mgmt::catalog] Found module: "assertErr" inside "Dir \"/home/daddywesker/SingularityNet/Metta/dw_fork/hyperon-experimental\""
[2025-08-08T06:52:49Z INFO  hyperon::metta::runner::pkg_mgmt::catalog] Preparing to load module: 'assertErr' as 'top:assertErr'
[(Error (import! ModuleSpace(GroundingSpace-top) assertErr) 
Expected: [1]
Got: [0]
Missed results: 1
Excessive results: 0)]
```

assertErr.metta:
`!(assertEqual 0 1)`