### PR TITLE
Add panic throw function

### DIFF
--- a/c/src/atom.rs
+++ b/c/src/atom.rs
@@ -824,6 +824,16 @@ pub extern "C" fn exec_error_free(error: exec_error_t) {
     }
 }
 
+/// @brief Used to throw panic from C Api with message to prevent panics without any info
+/// @ingroup grounded_atom_group
+/// @param[in]  message  A human-readable error message which will be used to throw a panic
+/// @return ()
+
+#[no_mangle]
+pub extern "C" fn throw_panic_with_message(message: *const c_char) -> () {
+    panic!("{}", cstr_into_string(message))
+}
+
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 // Atom Vec Interface
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-

--- a/python/hyperonpy.cpp
+++ b/python/hyperonpy.cpp
@@ -219,11 +219,19 @@ bindings_set_t py_match_value(const struct gnd_t *_gnd, const atom_ref_t *_atom)
 bindings_set_t py_match_(const struct gnd_t *_gnd, const atom_ref_t *_atom) {
     py::object hyperon = py::module_::import("hyperon.atoms");
     py::function _priv_call_match_on_grounded_atom = hyperon.attr("_priv_call_match_on_grounded_atom");
-
     py::object pyobj = static_cast<GroundedObject const *>(_gnd)->pyobj;
     CAtom catom = atom_clone(_atom);
-    py::list results = _priv_call_match_on_grounded_atom(pyobj, catom);
-
+    py::list results;
+    try
+    {
+        results = _priv_call_match_on_grounded_atom(pyobj, catom);
+    }
+    catch (py::error_already_set &e)
+    {
+        std::string message = "Error while calling _priv_call_match_on_grounded_atom: ";
+        message += e.what();
+        throw_panic_with_message(message.c_str());
+    }
     struct bindings_set_t result_set = bindings_set_empty();
     for (py::handle result: results) {
         py::dict pybindings = result.cast<py::dict>();


### PR DESCRIPTION
So, to prevent some unnamed/unknown panics that could be thrown when calling Python-hyperon functions (#997), I've added panic throw function with custom message to CApi. So now, instead of 
```
thread '<unnamed>' panicked at library/core/src/panicking.rs:226:5:
panic in a function that cannot unwind
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread caused non-unwinding panic. aborting.
```

This will be outputted:
```
thread '<unnamed>' panicked at c/src/atom.rs:834:5:
Error while calling _priv_call_match_on_grounded_atom: TypeError: Cannot get Python object of unsupported non-C atom or

At:
  /home/daddywesker/SingularityNet/Metta/dw_fork/hyperon-experimental/python/hyperon/atoms.py(191): _priv_gnd_get_object
  /home/daddywesker/SingularityNet/Metta/dw_fork/hyperon-experimental/python/hyperon/atoms.py(162): get_object
  /home/daddywesker/SingularityNet/Metta/dw_fork/hyperon-experimental/test_value.py(18): match_
  /home/daddywesker/SingularityNet/Metta/dw_fork/hyperon-experimental/python/hyperon/atoms.py(241): _priv_call_match_on_grounded_atom
  /home/daddywesker/SingularityNet/Metta/dw_fork/hyperon-experimental/python/hyperon/runner.py(34): run_step
  (17): run_step

note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

thread '<unnamed>' panicked at library/core/src/panicking.rs:226:5:
panic in a function that cannot unwind
stack backtrace:
   0:     0x7b4e11a54252 - <std::sys::backtrace::BacktraceLock::print::DisplayBacktrace as core::fmt::Display>::fmt::h46a716bba2450163
   1:     0x7b4e11aa0af3 - core::fmt::write::h275e5980d7008551
   2:     0x7b4e11a48c33 - <unknown>
   3:     0x7b4e11a540a2 - <unknown>
   4:     0x7b4e11a57d7c - <unknown>
   5:     0x7b4e11a57b7f - std::panicking::default_hook::h3db1b505cfc4eb79
   6:     0x7b4e11a58792 - std::panicking::rust_panic_with_hook::h409da73ddef13937
   7:     0x7b4e11a58506 - <unknown>
   8:     0x7b4e11a54749 - std::sys::backtrace::__rust_end_short_backtrace::h5b56844d75e766fc
   9:     0x7b4e11a581cd - __rustc[4794b31dd7191200]::rust_begin_unwind
  10:     0x7b4e114294cd - core::panicking::panic_nounwind_fmt::hc3cf3432011a3c3f
  11:     0x7b4e11429562 - core::panicking::panic_nounwind::h0c59dc9f7f043ead
  12:     0x7b4e11429722 - core::panicking::panic_cannot_unwind::hb8732afd89555502
  13:     0x7b4e11406807 - throw_panic_with_message
  14:     0x7b4e113f58d8 - <unknown>
  15:     0x7b4e11470e9f - <unknown>
  16:     0x7b4e11a002d3 - <unknown>
  17:     0x7b4e119ffcf8 - hyperon_atom::matcher::match_atoms::h16d8c45c05262779
  18:     0x7b4e1151485e - <unknown>
  19:     0x7b4e11515007 - <unknown>
  20:     0x7b4e115154c5 - <unknown>
  21:     0x7b4e11515474 - <unknown>
  22:     0x7b4e115154c5 - <unknown>
  23:     0x7b4e1159e371 - <unknown>
  24:     0x7b4e1151f0e1 - <unknown>
  25:     0x7b4e1158a21a - <unknown>
  26:     0x7b4e1151f7b2 - <hyperon::space::grounding::GroundingSpace as hyperon_space::Space>::query::h9a8a06890e6f0c5f
  27:     0x7b4e11596590 - <unknown>
  28:     0x7b4e115961aa - hyperon::space::module::ModuleSpace::query::h0469e684a7eaf398
  29:     0x7b4e1159676a - <hyperon::space::module::ModuleSpace as hyperon_space::Space>::query::h1d138af85e182b90
  30:     0x7b4e114a5405 - <unknown>
  31:     0x7b4e114a42a4 - <unknown>
  32:     0x7b4e114a0bfb - hyperon::metta::interpreter::interpret_step::h4ec7defbb1637eb3
  33:     0x7b4e115730a8 - hyperon::metta::runner::RunContext::step::h5097c0ed64e1308d
  34:     0x7b4e1156e7be - hyperon::metta::runner::RunnerState::run_step::h2f672c970b6cd569
  35:     0x7b4e1147b42c - runner_state_step
  36:     0x7b4e11453cfa - <unknown>
  37:     0x7b4e11436755 - <unknown>
  38:     0x7b4e12e02fbe - cfunction_call
                               at /usr/local/src/conda/python-3.11.11/Objects/methodobject.c:542:18
  39:     0x7b4e12de0124 - _PyObject_MakeTpCall
                               at /usr/local/src/conda/python-3.11.11/Objects/call.c:214:18
  40:     0x7b4e12deb8a4 - _PyEval_EvalFrameDefault
                               at /usr/local/src/conda/python-3.11.11/Python/ceval.c:4769:23
  41:     0x7b4e12e14c46 - _PyEval_EvalFrame
                               at /usr/local/src/conda/python-3.11.11/Include/internal/pycore_ceval.h:73:16
  42:     0x7b4e12e14c46 - _PyEval_Vector
                               at /usr/local/src/conda/python-3.11.11/Python/ceval.c:6434:24
  43:     0x7b4e12e14c46 - _PyFunction_Vectorcall
                               at /usr/local/src/conda/python-3.11.11/Objects/call.c:393:16
  44:     0x56242ebb3309 - pyo3::types::any::PyAny::call::h48da8f4246f5524a
                               at /home/daddywesker/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/pyo3-0.19.2/src/types/any.rs:517:32
  45:     0x56242ebb33d9 - pyo3::types::any::PyAny::call1::h147c5f3afe949bf5
                               at /home/daddywesker/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/pyo3-0.19.2/src/types/any.rs:588:9
  46:     0x56242ebbe5be - metta_repl::metta_shim::metta_interface_mod::MettaShim::exec::{{closure}}::h314e67ccccd1beae
                               at /home/daddywesker/SingularityNet/Metta/dw_fork/hyperon-experimental/repl/src/metta_shim.rs:161:34
  47:     0x56242ebad3b4 - pyo3::marker::Python::with_gil::hefe8aea876506ab9
                               at /home/daddywesker/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/pyo3-0.19.2/src/marker.rs:429:9
  48:     0x56242ebbd904 - metta_repl::metta_shim::metta_interface_mod::MettaShim::exec::hd8691668581e6d64
                               at /home/daddywesker/SingularityNet/Metta/dw_fork/hyperon-experimental/repl/src/metta_shim.rs:157:31
  49:     0x56242eb9de93 - metta_repl::start_interactive_mode::h350f04f876c30ac9
                               at /home/daddywesker/SingularityNet/Metta/dw_fork/hyperon-experimental/repl/src/main.rs:161:17
  50:     0x56242eb9ca54 - metta_repl::main::h43152c69d2c3e3af
                               at /home/daddywesker/SingularityNet/Metta/dw_fork/hyperon-experimental/repl/src/main.rs:87:9
  51:     0x56242ebc5ebb - core::ops::function::FnOnce::call_once::hb978d575bae605fb
                               at /home/daddywesker/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
  52:     0x56242eb9579d - std::sys::backtrace::__rust_begin_short_backtrace::h476ed22c5ea1db6f
                               at /home/daddywesker/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/backtrace.rs:152:18
  53:     0x56242ebd01a1 - std::rt::lang_start::{{closure}}::hafdf63dac67eab43
                               at /home/daddywesker/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/rt.rs:199:18
  54:     0x56242f062284 - core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once::hb4b7cf0559a1a53b
                               at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/core/src/ops/function.rs:284:13
  55:     0x56242f062284 - std::panicking::try::do_call::h8e6004e979ada7de
                               at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/std/src/panicking.rs:589:40
  56:     0x56242f062284 - std::panicking::try::hc44a0c902e55fa8c
                               at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/std/src/panicking.rs:552:19
  57:     0x56242f062284 - std::panic::catch_unwind::h6a5f1ccd4faaed9e
                               at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/std/src/panic.rs:359:14
  58:     0x56242f062284 - std::rt::lang_start_internal::{{closure}}::h40fd26f9e7cfe6a7
                               at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/std/src/rt.rs:168:24
  59:     0x56242f062284 - std::panicking::try::do_call::h047dd894cf3f6fd1
                               at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/std/src/panicking.rs:589:40
  60:     0x56242f062284 - std::panicking::try::h921841e1eaed56ce
                               at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/std/src/panicking.rs:552:19
  61:     0x56242f062284 - std::panic::catch_unwind::h108064a50ee785ec
                               at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/std/src/panic.rs:359:14
  62:     0x56242f062284 - std::rt::lang_start_internal::ha8ef919ae4984948
                               at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/std/src/rt.rs:164:5
  63:     0x56242ebd0187 - std::rt::lang_start::h3149ecd77d831be8
                               at /home/daddywesker/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/rt.rs:198:5
  64:     0x56242eb9ecde - main
  65:     0x7b4e1282a578 - __libc_start_call_main
                               at ./csu/../sysdeps/nptl/libc_start_call_main.h:58:16
  66:     0x7b4e1282a63b - __libc_start_main_impl
                               at ./csu/../csu/libc-start.c:360:3
  67:     0x56242eb94b15 - _start
  68:                0x0 - <unknown>
thread caused non-unwinding panic. aborting.
Aborted (core dumped)
```