### PR TITLE
Fix DAS tests job

### DIFF
--- a/.github/workflows/ci-manual.yml
+++ b/.github/workflows/ci-manual.yml
@@ -28,11 +28,6 @@ on:
         required: true
         default: "[\"Debug\", \"Release\", \"RelWithDebInfo\", \"MinSizeRel\"]"
         type: string
-      run-das-tests:
-        description: 'Run DAS integration tests'
-        required: true
-        default: true
-        type: boolean
 
 jobs:
   ci-manual:
@@ -51,14 +46,3 @@ jobs:
       python-version: ${{ matrix.python-version }}
       cmake-version: ${{ matrix.cmake-version }}
       build-type: ${{ matrix.build-type }}
-
-  das-tests:
-    if: ${{ inputs.run-das-tests }}
-    strategy:
-      matrix:
-        os: ${{ fromJson(inputs.os) }}
-      max-parallel: 5
-    needs: ci-manual
-    uses: ./.github/workflows/das-tests.yml
-    with:
-      os: ${{ matrix.os }}

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -25,13 +25,5 @@ jobs:
       build-type: ${{ matrix.build-type }}
 
   das-tests:
-    if: github.repository == 'trueagi-io/hyperon-experimental'
-    needs: ci-nightly
-    strategy:
-      fail-fast: false
-      matrix:
-        os:  ["ubuntu-22.04", "ubuntu-24.04", "macos-13", "macos-14", "macos-15", "windows-latest"]
-      max-parallel: 5
+    if: ${{ github.event_name != 'schedule' || github.repository == 'trueagi-io/hyperon-experimental' }}
     uses: ./.github/workflows/das-tests.yml
-    with:
-      os: ${{ matrix.os }}

--- a/.github/workflows/das-tests.yml
+++ b/.github/workflows/das-tests.yml
@@ -70,8 +70,9 @@ jobs:
           cd das-cli/src
           # TODO: should be a part of das-cli/setup.py file
           python3 -m pip install -r requirements.txt
-          python3 -m pip install .
-          rm -rf "$TEMP_DIR"
+          # TODO: -e should not be needed and temporary dir could be cleaned
+          # up after installation
+          python3 -m pip install -e .
           cd "$GITHUB_WORKSPACE"
 
       - name: das-toolbox - DAS configuration

--- a/.github/workflows/das-tests.yml
+++ b/.github/workflows/das-tests.yml
@@ -68,6 +68,8 @@ jobs:
           cd das-toolbox
           git checkout tags/0.5.0
           cd das-cli/src
+          # TODO: should be a part of das-cli/setup.py file
+          python3 -m pip install -r requirements.txt
           python3 -m pip install .
           rm -rf "$TEMP_DIR"
           cd "$GITHUB_WORKSPACE"

--- a/.github/workflows/das-tests.yml
+++ b/.github/workflows/das-tests.yml
@@ -53,38 +53,48 @@ jobs:
         with:
           python-version: "3.13"
 
+      - name: das-toolbox - create Python venv
+        shell: bash
+        run: |
+          python3 -m venv dastoolbox
+
       - name: das-toolbox - install
         shell: bash
         run: |
+          source ./dastoolbox/bin/activate
           TEMP_DIR=$(mktemp -d)
           cd "$TEMP_DIR"
           git clone https://github.com/singnet/das-toolbox.git
           cd das-toolbox
           git checkout tags/0.5.0
           cd das-cli/src
-          sudo pip3 install -e .
-          sudo rm -rf "$TEMP_DIR"
+          python3 -m pip install -e .
+          rm -rf "$TEMP_DIR"
           cd "$GITHUB_WORKSPACE"
 
       - name: das-toolbox - DAS configuration
         shell: bash
         run: |
+          source ./dastoolbox/bin/activate
           # Configure DAS with default settings
           echo -e "\n\n\n\n\n\n\n37007\n\n\n\n\n\n\n\n\n\n\n" | das-cli config set
 
       - name: das-toolbox - start databases
         shell: bash
         run: |
+          source ./dastoolbox/bin/activate
           das-cli db start
 
       - name: das-toolbox - load knowledge base
         shell: bash
         run: |
+          source ./dastoolbox/bin/activate
           das-cli metta load integration_tests/das/animals.metta
 
       - name: das-toolbox - start services
         shell: bash
         run: |
+          source ./dastoolbox/bin/activate
           # Attention Broker
           das-cli ab start
           # Query Agent
@@ -93,12 +103,14 @@ jobs:
       - name: Run DAS module tests
         shell: bash
         run: |
+          source ./dastoolbox/bin/activate
           timeout 60s ./target/release/metta-repl integration_tests/das/test.metta || true
 
       - name: das-toolbox - cleanup services
         if: always()
         shell: bash
         run: |
+          source ./dastoolbox/bin/activate
           das-cli qa stop || true
           das-cli ab stop || true
           das-cli db stop || true

--- a/.github/workflows/das-tests.yml
+++ b/.github/workflows/das-tests.yml
@@ -92,7 +92,7 @@ jobs:
         shell: bash
         run: |
           source ./dastoolbox/bin/activate
-          das-cli metta load integration_tests/das/animals.metta
+          das-cli metta load ${GITHUB_WORKSPACE}/integration_tests/das/animals.metta
 
       - name: das-toolbox - start services
         shell: bash
@@ -107,7 +107,7 @@ jobs:
         shell: bash
         run: |
           source ./dastoolbox/bin/activate
-          timeout 60s ./target/release/metta-repl integration_tests/das/test.metta || true
+          timeout 60s ./target/release/metta-repl ./integration_tests/das/test.metta || true
 
       - name: das-toolbox - cleanup services
         if: always()

--- a/.github/workflows/das-tests.yml
+++ b/.github/workflows/das-tests.yml
@@ -89,7 +89,7 @@ jobs:
         shell: bash
         run: |
           source ./dastoolbox/bin/activate
-          timeout 60s ./target/release/metta-repl ./integration_tests/das/test.metta || true
+          timeout 60s ./target/release/metta-repl ./integration_tests/das/test.metta
 
       - name: das-toolbox - cleanup services
         if: always()

--- a/.github/workflows/das-tests.yml
+++ b/.github/workflows/das-tests.yml
@@ -19,7 +19,7 @@ on:
         type: string
 
 jobs:
-  setup-and-test:
+  das-tests:
     runs-on: ${{ inputs.os }}
 
     steps:

--- a/.github/workflows/das-tests.yml
+++ b/.github/workflows/das-tests.yml
@@ -68,7 +68,7 @@ jobs:
           cd das-toolbox
           git checkout tags/0.5.0
           cd das-cli/src
-          python3 -m pip install -e .
+          python3 -m pip install .
           rm -rf "$TEMP_DIR"
           cd "$GITHUB_WORKSPACE"
 

--- a/.github/workflows/das-tests.yml
+++ b/.github/workflows/das-tests.yml
@@ -4,23 +4,11 @@ name: das-tests
 
 on:
   workflow_call:
-    inputs:
-      os:
-        description: "A container which is used to make a build"
-        default: "ubuntu-22.04"
-        required: false
-        type: string
   workflow_dispatch:
-    inputs:
-      os:
-        description: "A container which is used to make a build"
-        default: "ubuntu-22.04"
-        required: false
-        type: string
 
 jobs:
   das-tests:
-    runs-on: ${{ inputs.os }}
+    runs-on: "ubuntu-24.04"
 
     steps:
       - name: Check out repository code
@@ -35,14 +23,8 @@ jobs:
       - name: Install protobuf-compiler (required by Das)
         shell: bash
         run: |
-          if [[ "${{ inputs.os }}" == *"ubuntu"* ]]; then
-            sudo apt-get update
-            sudo apt-get install -y protobuf-compiler
-          elif [[ "${{ inputs.os }}" == *"macos"* ]]; then
-            brew install protobuf
-          elif [[ "${{ inputs.os }}" == *"windows"* ]]; then
-            choco install protoc -y
-          fi
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
 
       - name: Build
         shell: bash

--- a/.github/workflows/das-tests.yml
+++ b/.github/workflows/das-tests.yml
@@ -10,6 +10,13 @@ on:
         default: "ubuntu-22.04"
         required: false
         type: string
+  workflow_dispatch:
+    inputs:
+      os:
+        description: "A container which is used to make a build"
+        default: "ubuntu-22.04"
+        required: false
+        type: string
 
 jobs:
   setup-and-test:


### PR DESCRIPTION
Allow passing Python environment version. Fix `das-cli` setup to use this version and virtual environment.
@arturgontijo I have some questions about it:
1. job fails with Python 3.8 (https://github.com/vsbogd/hyperon-experimental/actions/runs/17214743919) what is the minimal version of Python supported by DAS cli?
2. DAS cli requires manual requirements installation (`python3 -m pip install -r requirements.txt`) (see https://github.com/vsbogd/hyperon-experimental/actions/runs/17214573397/job/48834855776) but one would expect `python3 -m pip install .` should be enough.
3. Job still fails after all fixes (https://github.com/vsbogd/hyperon-experimental/actions/runs/17214801060/job/48835629376) not sure why
4. I think the approach with the separate job is not efficient, it requires rebuilding hyperon-experimental before running DAS tests, thus I think it make sense to make this test a separate reusable action and include it into a `common.yml` with "run-das-tests" flag.