### PR TITLE
Prefix expressions with size in atomspace index to recognize them faster

### DIFF
--- a/hyperon-space/src/index/trie.rs
+++ b/hyperon-space/src/index/trie.rs
@@ -508,7 +508,7 @@ const TK_STORE_INDEX: usize = 0b10 << BITS_PER_ID;
 const TK_MATCH_EXACT: usize = 0b00 << BITS_PER_ID;
 const TK_MATCH_CUSTOM: usize = 0b01 << BITS_PER_ID;
 
-const TK_MAX_EXPRESSION_SIZE: usize = 2048;
+const TK_MAX_EXPRESSION_SIZE: usize = 1 << 10;
 
 /// Compact representation of the atom from the trie. It represents each
 /// atom using single [usize] value. It keeps value of the key, key matching


### PR DESCRIPTION
PR changes the format of the key of the atom index trie. Before expressions are represented in a form: `START_EXPR <atom>* END_EXPR`. After this PR expressions are represented in a form: `START_EXPR(size) <atom>{size}`. This allows keeping expressions of different length in different branches of the trie. And thus prevents for example comparing function atoms for function calls with different arity (for instance `(foo)` and `(foo arg)`) like happens in issue https://github.com/trueagi-io/hyperon-experimental/issues/997. This change makes atomspace a bit more compact (smaller number of tokens) and search a bit faster (separate results earlier).

The change adds a restriction on a maximum expression size. In this PR it is set to 2^10 items. There is no technical restriction to make this number bigger though. It just should be significantly less than 2^62 (the max number of unique atoms in atomspace).