### PR TITLE
MeTTa runner doesn't read config dir by default

### DIFF
--- a/c/src/metta.rs
+++ b/c/src/metta.rs
@@ -1525,8 +1525,7 @@ pub extern "C" fn env_builder_set_working_dir(builder: *mut env_builder_t, path:
     *builder_arg_ref = builder.into();
 }
 
-/// @brief Sets the config directory for the environment.  A directory at the specified path
-/// will be created, and its contents populated with default values, if one does not already exist
+/// @brief Sets the config directory for the environment.
 /// @ingroup environment_group
 /// @param[in]  builder  A pointer to the in-process environment builder state
 /// @param[in]  path  A C-style string specifying a path to the config directory
@@ -1556,15 +1555,15 @@ pub extern "C" fn env_builder_create_config_dir(builder: *mut env_builder_t, sho
     *builder_arg_ref = builder.into();
 }
 
-/// @brief Configures the environment so that no config directory will be read nor created
+/// @brief Sets the default config directory for the environment.
 /// @ingroup environment_group
 /// @param[in]  builder  A pointer to the in-process environment builder state
 ///
 #[no_mangle]
-pub extern "C" fn env_builder_disable_config_dir(builder: *mut env_builder_t) {
+pub extern "C" fn env_builder_set_default_config_dir(builder: *mut env_builder_t) {
     let builder_arg_ref = unsafe{ &mut *builder };
     let builder = core::mem::replace(builder_arg_ref, env_builder_t::null()).into_inner();
-    let builder = builder.set_no_config_dir();
+    let builder = builder.set_default_config_dir();
     *builder_arg_ref = builder.into();
 }
 

--- a/lib/src/metta/runner/mod.rs
+++ b/lib/src/metta/runner/mod.rs
@@ -1426,4 +1426,9 @@ mod tests {
         assert_eq!(result, Ok(vec![vec![]]));
     }
 
+    #[test]
+    fn metta_no_config_dir_by_default() {
+        let metta = Metta::new(None);
+        assert_eq!(metta.environment().config_dir(), None);
+    }
 }

--- a/python/hyperon/exts/agents/agent_base.py
+++ b/python/hyperon/exts/agents/agent_base.py
@@ -144,7 +144,7 @@ class AgentObject:
         # the caller space is not directly accessible as a context,
         # except the case when _metta is set via get_agent_atom with parent MeTTa
         if self._include_paths is not None:
-            env_builder = Environment.custom_env(include_paths=self._include_paths)
+            env_builder = Environment.custom_env(include_paths=self._include_paths, config_dir="")
             metta = MeTTa(env_builder=env_builder)
         else:
             metta = MeTTa()

--- a/python/hyperon/metta.py
+++ b/python/hyperon/metta.py
@@ -31,7 +31,7 @@ def main():
     elif args.file:
         parent_dir = os.path.dirname(args.file)
         with open(args.file) as f: program = f.read()
-        metta = hyperon.MeTTa(env_builder=hyperon.Environment.custom_env(working_dir=parent_dir))
+        metta = hyperon.MeTTa(env_builder=hyperon.Environment.custom_env(working_dir=parent_dir, config_dir=""))
         for result in metta.run(program):
             print(result)
     else:

--- a/python/hyperonpy.cpp
+++ b/python/hyperonpy.cpp
@@ -1159,8 +1159,8 @@ PYBIND11_MODULE(hyperonpy, m) {
     m.def("env_builder_set_working_dir", [](EnvBuilder& builder, std::string path) { env_builder_set_working_dir(builder.ptr(), path.c_str()); }, "Sets the working dir in the environment");
     m.def("env_builder_set_config_dir", [](EnvBuilder& builder, std::string path) { env_builder_set_config_dir(builder.ptr(), path.c_str()); }, "Sets the config dir in the environment");
     m.def("env_builder_create_config_dir", [](EnvBuilder& builder, bool should_create) { env_builder_create_config_dir(builder.ptr(), should_create); }, "Creates the config dir if it doesn't exist");
-    m.def("env_builder_disable_config_dir", [](EnvBuilder& builder) { env_builder_disable_config_dir(builder.ptr()); }, "Disables the config dir in the environment");
-    m.def("env_builder_set_is_test", [](EnvBuilder& builder, bool is_test) { env_builder_set_is_test(builder.ptr(), is_test); }, "Disables the config dir in the environment");
+    m.def("env_builder_set_default_config_dir", [](EnvBuilder& builder) { env_builder_set_default_config_dir(builder.ptr()); }, "Sets default config directory location");
+    m.def("env_builder_set_is_test", [](EnvBuilder& builder, bool is_test) { env_builder_set_is_test(builder.ptr(), is_test); }, "Set true if this environment is used in unit test");
     m.def("env_builder_push_include_path", [](EnvBuilder& builder, std::string path) { env_builder_push_include_path(builder.ptr(), path.c_str()); }, "Adds an include path to the environment");
     m.def("env_builder_push_fs_module_format", [](EnvBuilder& builder, py::object interface) {
         //TODO. We end up leaking this object, but it's a non-issue in practice because environments usually live the life of the program.

--- a/python/tests/test_environment.py
+++ b/python/tests/test_environment.py
@@ -11,4 +11,4 @@ class HyperonTestCase(unittest.TestCase):
         self.assertTrue(Environment.init_common_env(config_dir = "/tmp/hyperon-test", create_config = True))
         self.assertEqual(Environment.config_dir(), "/tmp/hyperon-test")
 
-        self.assertFalse(Environment.init_common_env(disable_config = True))
+        self.assertFalse(Environment.init_common_env())

--- a/python/tests/test_extend.py
+++ b/python/tests/test_extend.py
@@ -13,7 +13,7 @@ class ExtendTest(unittest.TestCase):
         '''
         This test verifies that importing from a python-implemnted module along with @register_atoms and @register_tokens works
         '''
-        metta = MeTTa(env_builder=Environment.custom_env(working_dir=os.getcwd(), disable_config=True, is_test=True))
+        metta = MeTTa(env_builder=Environment.custom_env(working_dir=os.getcwd(), is_test=True))
         self.assertEqual(
             metta.run('''
               !(import! &self extension)
@@ -30,7 +30,7 @@ class ExtendTest(unittest.TestCase):
             [[ValueAtom(12)]])
 
     def test_grounded_noext(self):
-        metta = MeTTa(env_builder=Environment.custom_env(working_dir=os.getcwd(), disable_config=True, is_test=True))
+        metta = MeTTa(env_builder=Environment.custom_env(working_dir=os.getcwd(), is_test=True))
 
         @grounded(metta)
         def abs_dif(x, y):
@@ -47,7 +47,7 @@ class ExtendTestDirMod(unittest.TestCase):
         '''
         This test verifies that importing from a python module directory also works
         '''
-        metta = MeTTa(env_builder=Environment.custom_env(working_dir=os.getcwd(), disable_config=True, is_test=True))
+        metta = MeTTa(env_builder=Environment.custom_env(working_dir=os.getcwd(), is_test=True))
         self.assertEqual(
             metta.run('''
               !(import! &self ext_dir)
@@ -67,7 +67,7 @@ class ExtendTestDirMod(unittest.TestCase):
     #     '''
     #     This test verifies that importing from a module that imports its own sub-module also works
     #     '''
-    #     metta = MeTTa(env_builder=Environment.custom_env(working_dir=os.getcwd(), disable_config=True, is_test=True))
+    #     metta = MeTTa(env_builder=Environment.custom_env(working_dir=os.getcwd(), is_test=True))
     #     self.assertEqual(
     #         metta.run('''
     #           !(import! &self ext_sub)
@@ -84,7 +84,7 @@ class ExtendTestDirMod(unittest.TestCase):
         '''
         This test verifies that importing from a sub-module will cause the necessary parents to be imported as well
         '''
-        metta = MeTTa(env_builder=Environment.custom_env(working_dir=os.getcwd(), disable_config=True, is_test=True))
+        metta = MeTTa(env_builder=Environment.custom_env(working_dir=os.getcwd(), is_test=True))
         self.assertEqual(
             metta.run('''
               !(import! &self ext_recursive:level-2:ext_nested)
@@ -107,7 +107,7 @@ class ExtendGlobalTest(unittest.TestCase):
         from extension import g_object
         # Sanity check
         self.assertEqual(g_object, None)
-        metta = MeTTa(env_builder=Environment.custom_env(working_dir=os.getcwd(), disable_config=True, is_test=True))
+        metta = MeTTa(env_builder=Environment.custom_env(working_dir=os.getcwd(), is_test=True))
         metta.run('''
           !(import! &self extension)
           !(set-global! 42)
@@ -127,7 +127,7 @@ class ExtendErrorTest(unittest.TestCase):
         '''
         This test verifies that an error from a Python extension is properly propagated
         '''
-        metta = MeTTa(env_builder=Environment.custom_env(working_dir=os.getcwd(), disable_config=True, is_test=True))
+        metta = MeTTa(env_builder=Environment.custom_env(working_dir=os.getcwd(), is_test=True))
         result = metta.run("!(import! &self error_pyext)")
         self.assertEqual(S('Error'), result[0][0].get_children()[0])
 

--- a/python/tests/test_modules.py
+++ b/python/tests/test_modules.py
@@ -10,7 +10,7 @@ class ModulesTest(HyperonTestCase):
         Tests that a MeTTa module, implemented as a '.py', file will be correctly identified when the
         module system searches in the include directory, and then that it will be sucessfully loaded
         """
-        runner = MeTTa(env_builder=Environment.custom_env(working_dir=os.getcwd(), disable_config=True, is_test=True))
+        runner = MeTTa(env_builder=Environment.custom_env(working_dir=os.getcwd(), is_test=True))
 
         #Make sure the `import!` operation finds the pyfile_test_mod.py file, recognizes it as a
         # MeTTa module using the PythonFileModuleFormat, and loads the MeTTa module it sucessfully
@@ -24,7 +24,7 @@ class ModulesTest(HyperonTestCase):
         self.assertEqual(result[0].get_object().content, 3.14159)
 
     def test_include(self):
-        metta = MeTTa(env_builder=Environment.custom_env(working_dir=os.getcwd(), disable_config=True, is_test=True))
+        metta = MeTTa(env_builder=Environment.custom_env(working_dir=os.getcwd(), is_test=True))
         result = metta.run("""
             (three isprime)
             !(match &self ($x isprime) $x)
@@ -43,7 +43,7 @@ class PyOpsTest(HyperonTestCase):
         """
         Tests that a MeTTa module from exts can be imported
         """
-        runner = MeTTa(env_builder=Environment.custom_env())
+        runner = MeTTa(env_builder=Environment.custom_env(config_dir=""))
         runner.run("!(import! &self py_ops)")
         result = runner.run('!(* "a" 4)')
         self.assertEqual(result[0][0], ValueAtom('aaaa'))

--- a/repl/src/metta_shim.rs
+++ b/repl/src/metta_shim.rs
@@ -301,7 +301,7 @@ pub mod metta_interface_mod {
         pub fn init_common_env(working_dir: PathBuf, include_paths: Vec<PathBuf>) -> Result<MettaShim, String> {
             let mut builder = EnvBuilder::new()
                 .set_working_dir(Some(&working_dir))
-                .set_create_config_dir(true);
+                .set_default_config_dir();
 
             for path in include_paths.into_iter().rev() {
                 builder = builder.push_include_path(path);

--- a/repl/src/py_shim.py
+++ b/repl/src/py_shim.py
@@ -2,7 +2,7 @@
 from hyperon import *
 
 def init_metta(working_dir, include_paths):
-    return MeTTa(env_builder=Environment.custom_env(working_dir = working_dir, create_config = True, include_paths = include_paths))
+    return MeTTa(env_builder=Environment.custom_env(working_dir = working_dir, config_dir = "", include_paths = include_paths))
 
 def load_metta_module(metta, mod_path):
     metta.import_file(mod_path)


### PR DESCRIPTION
Fixes #1016 and expected to resolve nightly build random failures. Default behavior of `Environment` is changed:
- by default no configuration directory is expected and read as consequence no default git catalog is read
- REPL and `exts/agents.py` code is changed to read configuration from default configuration directory

`EnvBuilder::set_no_config_dir` is removed and `EnvBuilder::set_default_config_dir` is added instead. In Python API the default config dir is encoded as empty string. Originally I was going to write `EnvBuilder::default_config_dir()` method to return the default config dir, but as this call can fail the error processing makes callers code ugly (not mentioning passing resulting path to the caller via C API). Thus I decided to keep  `EnvBuilder::set_default_config_dir()` method instead.