### PR TITLE
Fix return type check

### DIFF
--- a/lib/src/metta/runner/builtin_mods/fileio.rs
+++ b/lib/src/metta/runner/builtin_mods/fileio.rs
@@ -143,7 +143,7 @@ impl ModuleLoader for FileioModLoader {
 
         tref.register_function(GroundedFunctionAtom::new(
             r"file-read-exact!".into(),
-            Atom::expr([ARROW_SYMBOL, ATOM_TYPE_FILE_HANDLE, ATOM_TYPE_NUMBER, UNIT_ATOM]),
+            Atom::expr([ARROW_SYMBOL, ATOM_TYPE_FILE_HANDLE, ATOM_TYPE_NUMBER, ATOM_TYPE_STRING]),
             file_read_exact));
 
         tref.register_function(GroundedFunctionAtom::new(

--- a/lib/src/metta/runner/stdlib/math.rs
+++ b/lib/src/metta/runner/stdlib/math.rs
@@ -358,7 +358,7 @@ grounded_op!(IsNanMathOp, "isnan-math");
 
 impl Grounded for IsNanMathOp {
     fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_NUMBER, ATOM_TYPE_NUMBER])
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_NUMBER, ATOM_TYPE_BOOL])
     }
 
     fn as_execute(&self) -> Option<&dyn CustomExecute> {
@@ -385,7 +385,7 @@ grounded_op!(IsInfMathOp, "isinf-math");
 
 impl Grounded for IsInfMathOp {
     fn type_(&self) -> Atom {
-        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_NUMBER, ATOM_TYPE_NUMBER])
+        Atom::expr([ARROW_SYMBOL, ATOM_TYPE_NUMBER, ATOM_TYPE_BOOL])
     }
 
     fn as_execute(&self) -> Option<&dyn CustomExecute> {


### PR DESCRIPTION
Fixes return type checking when function is called from the body of another function. It also for free stops evaluation in a case when `Atom` or `Expression` is returned. 

As at the moment according to the specification only `Atom` stops evaluation case with expression is handled by special condition in code. Old implementation from https://github.com/trueagi-io/hyperon-experimental/commit/99dd9911f85cbbd76acbc8390a54d35e2210d42c is removed by reverting this commit.

Some standard library changes are required because `file-read-exact!`, `isnan-math` and `isinf-math` has incorrect return types.

Better review each commit.