### PR TITLE
Use real type of the value inside (StateMonad $t) type

### DIFF
--- a/lib/src/metta/runner/stdlib/stdlib.metta
+++ b/lib/src/metta/runner/stdlib/stdlib.metta
@@ -1009,6 +1009,11 @@
   (@params (
     (@param "Atom to be wrapped")))
   (@return "Returns (State $value) where $value is an argument to a new-state"))
+(: new-state (-> $t (StateMonad $t)))
+(= (new-state $x)
+   (chain (context-space) $space
+     (let $t (collapse (get-type-space $space $x))
+       (_new-state $x $t))))
 
 (@doc change-state!
   (@desc "Changes input state's wrapped atom to another value (second argument). E.g. (change-state! (State 5) 6) -> (State 6)")

--- a/python/tests/scripts/e2_states.metta
+++ b/python/tests/scripts/e2_states.metta
@@ -2,6 +2,10 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; State atoms
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; assign the specific type to the (A B) pair
+(: (A B) PairAB)
+
 ; `new-state` creates a new state atom wrapping the initial value (A B).
 ; Then it binds this state atom to the token `&state-token`,
 ; which is replaced by the corresponding atom at parse-time.
@@ -42,10 +46,10 @@
 !(assertEqual
   (let $v (new-state 1) (get-type $v))
   (StateMonad Number))
-; atm, meta-types for states of non-grounded types are used
+; type of the value is used as part of the state type
 !(assertEqual
   (get-type &state-token)
-  (StateMonad Expression))
+  (StateMonad PairAB))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -55,7 +59,7 @@
 ; it cannot be changed to int
 !(assertEqual
   (change-state! &state-token 1)
-  (Error (change-state! &state-token 1) (BadArgType 2 Expression Number)))
+  (Error (change-state! &state-token 1) (BadArgType 2 PairAB Number)))
 
 ; the new state here is int, so it cannot be changed to string
 !(assertEqual


### PR DESCRIPTION
This PR fixes BadType error which happens when REPL is started. The error is introduced by https://github.com/trueagi-io/hyperon-experimental/pull/1034 because `State` atom doesn't have real type new type check fails on such values returned.