### PR TITLE
fix issue 1037

### DIFF
--- a/lib/src/metta/interpreter.rs
+++ b/lib/src/metta/interpreter.rs
@@ -1334,6 +1334,9 @@ fn check_if_function_type_is_applicable_<'a>(expr: &'a Atom, op_type: Atom, mut 
                 _ => once((Err(error_atom(expr.clone(), INCORRECT_NUMBER_OF_ARGUMENTS_SYMBOL)), bindings)),
             }
         },
+        t if t <=  actual_args.len() => {
+            once((Err(error_atom(expr.clone(), INCORRECT_NUMBER_OF_ARGUMENTS_SYMBOL)), bindings))
+        },
         _ => {
             let formal_arg_type = arg_types.remove(0);
             let arg_types_len = arg_types.len();

--- a/lib/src/metta/runner/stdlib/mod.rs
+++ b/lib/src/metta/runner/stdlib/mod.rs
@@ -845,4 +845,20 @@ mod tests {
         assert_eq_metta_results!(metta.run(parser),
             Ok(vec![vec![]]));
     }
+
+    #[test]
+    fn test_incorrect_number_of_arguments_issue_1037() {
+        let metta = Metta::new(Some(EnvBuilder::test_env()));
+        let parser = SExprParser::new("
+            (: a A)
+            (: b B)
+            (: foo (-> A B))
+            !(assertEqual
+                (foo b c)
+                (Error (foo b c) IncorrectNumberOfArguments))
+        ");
+
+        assert_eq_metta_results!(metta.run(parser),
+            Ok(vec![vec![UNIT_ATOM]]));
+    }
 }


### PR DESCRIPTION
Fix for issue #1037 

So, as i understood, reason for this issue to be in the first place is the absence of checking if number of actual arguments exceeds number of expected arguments. There was no such check and I've added it as I understand it should look like. @vsbogd  please check if you agree with my solution. I've also added test for this case. 

Reason for incorrect index in the issue is this line
`let arg_id = TryInto::<&ExpressionAtom>::try_into(expr).unwrap().children().len() - arg_types_len;`

`expr` here is actual expr in the code. So, if user will write:
```
(: a A)
(: b B)
(: foo (-> A B))
!(foo b c)
```

expr will be `(foo b c)`. In the case `!(foo b c d)` expr will be `(foo b c d)`. And len of such epxr used to create id in the error. Though my understanding is that such case should be marked as incorrectnumberofarguments, not badargtype and because of that I've added check if actual arg len is exceeds expected one. 