### PR TITLE
Fix equality for embedded grounded types

### DIFF
--- a/c/src/atom.rs
+++ b/c/src/atom.rs
@@ -15,7 +15,7 @@ use std::sync::atomic::{AtomicPtr, Ordering};
 
 use hyperon_atom::matcher::{Bindings, BindingsSet};
 use hyperon::metta::runner::bool::Bool;
-use hyperon::metta::runner::number::Number;
+use hyperon_atom::gnd::number::Number;
 
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 // Atom Interface

--- a/c/src/atom.rs
+++ b/c/src/atom.rs
@@ -14,7 +14,7 @@ use std::collections::HashSet;
 use std::sync::atomic::{AtomicPtr, Ordering};
 
 use hyperon_atom::matcher::{Bindings, BindingsSet};
-use hyperon::metta::runner::bool::Bool;
+use hyperon_atom::gnd::bool::Bool;
 use hyperon_atom::gnd::number::Number;
 
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-

--- a/c/src/metta.rs
+++ b/c/src/metta.rs
@@ -578,7 +578,7 @@ pub extern "C" fn atom_error_message(atom: *const atom_ref_t, buf: *mut c_char, 
 /// @return  The `atom_t` representing the atom
 /// @note The returned `atom_t` must be freed with `atom_free()`
 ///
-#[no_mangle] pub extern "C" fn ATOM_TYPE_NUMBER() -> atom_t { hyperon::metta::runner::number::ATOM_TYPE_NUMBER.into() }
+#[no_mangle] pub extern "C" fn ATOM_TYPE_NUMBER() -> atom_t { hyperon_atom::gnd::number::ATOM_TYPE_NUMBER.into() }
 
 /// @brief Creates an atom used to indicate that an atom's type is a Bool type.
 /// @ingroup metta_language_group

--- a/c/src/metta.rs
+++ b/c/src/metta.rs
@@ -592,7 +592,7 @@ pub extern "C" fn atom_error_message(atom: *const atom_ref_t, buf: *mut c_char, 
 /// @return  The `atom_t` representing the atom
 /// @note The returned `atom_t` must be freed with `atom_free()`
 ///
-#[no_mangle] pub extern "C" fn ATOM_TYPE_STRING() -> atom_t { hyperon::metta::runner::str::ATOM_TYPE_STRING.into() }
+#[no_mangle] pub extern "C" fn ATOM_TYPE_STRING() -> atom_t { hyperon_atom::gnd::str::ATOM_TYPE_STRING.into() }
 
 /// @brief Creates a Symbol atom for the special MeTTa symbol used to indicate empty results
 /// returned by function.

--- a/c/src/metta.rs
+++ b/c/src/metta.rs
@@ -585,7 +585,7 @@ pub extern "C" fn atom_error_message(atom: *const atom_ref_t, buf: *mut c_char, 
 /// @return  The `atom_t` representing the atom
 /// @note The returned `atom_t` must be freed with `atom_free()`
 ///
-#[no_mangle] pub extern "C" fn ATOM_TYPE_BOOL() -> atom_t { hyperon::metta::runner::bool::ATOM_TYPE_BOOL.into() }
+#[no_mangle] pub extern "C" fn ATOM_TYPE_BOOL() -> atom_t { hyperon_atom::gnd::bool::ATOM_TYPE_BOOL.into() }
 
 /// @brief Creates an atom used to indicate that an atom's type is a String type.
 /// @ingroup metta_language_group

--- a/hyperon-atom/Cargo.toml
+++ b/hyperon-atom/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 log = { workspace = true }
 smallvec = "1.10.0"
 bitset = "0.1.2"
+unescaper = "0.1.5"
 
 hyperon-common = { workspace = true }
 hyperon-macros = { workspace = true }

--- a/hyperon-atom/src/gnd/bool.rs
+++ b/hyperon-atom/src/gnd/bool.rs
@@ -17,13 +17,28 @@ impl Bool {
     }
 
     pub fn from_atom(atom: &Atom) -> Option<Self> {
-        BoolSerializer::convert(atom)
+        Bool::try_from(atom).ok()
     }
 }
 
 impl Into<Bool> for bool {
     fn into(self) -> Bool {
         Bool(self)
+    }
+}
+
+impl TryFrom<&Atom> for Bool {
+    type Error = &'static str;
+    fn try_from(value: &Atom) -> Result<Self, Self::Error> {
+        std::convert::TryInto::<&dyn GroundedAtom>::try_into(value)
+            .and_then(BoolSerializer::convert)
+    }
+}
+
+impl TryFrom<&dyn GroundedAtom> for Bool {
+    type Error = &'static str;
+    fn try_from(value: &dyn GroundedAtom) -> Result<Self, Self::Error> {
+        BoolSerializer::convert(value)
     }
 }
 

--- a/hyperon-atom/src/gnd/bool.rs
+++ b/hyperon-atom/src/gnd/bool.rs
@@ -1,6 +1,4 @@
-use hyperon_atom::*;
-use hyperon_atom::serial;
-use hyperon_atom::ConvertingSerializer;
+use crate::*;
 
 use std::fmt::Display;
 

--- a/hyperon-atom/src/gnd/mod.rs
+++ b/hyperon-atom/src/gnd/mod.rs
@@ -1,4 +1,5 @@
 pub mod str;
+pub mod number;
 
 use std::rc::Rc;
 

--- a/hyperon-atom/src/gnd/mod.rs
+++ b/hyperon-atom/src/gnd/mod.rs
@@ -85,26 +85,23 @@ use gnd::number::*;
 use gnd::bool::*;
 
 /// Compares two grounded atoms for equality
-pub fn gnd_eq(a: &Atom, b: &Atom) -> bool {
+pub fn gnd_eq(a: &dyn GroundedAtom, b: &dyn GroundedAtom) -> bool {
     // TODO: this function is a hack which is introduced for embedded grounded
     // types only. It should be replaced by some mechanism which allows defining
     // a single grounded atom equality procedure in a MeTTa module. This could
     // be done via defining a type class or equality function overloading.
-    let agnd = TryInto::<&dyn GroundedAtom>::try_into(a).expect("Grounded atom is expected");
-    let bgnd = TryInto::<&dyn GroundedAtom>::try_into(b).expect("Grounded atom is expected");
-
-    if agnd.eq_gnd(bgnd) {
+    if a.eq_gnd(b) {
         return true
     }
-    if agnd.type_() != bgnd.type_() {
+    if a.type_() != b.type_() {
         return false
     }
-    if agnd.type_() == ATOM_TYPE_STRING {
-        Str::from_atom(a) == Str::from_atom(b)
-    } else if agnd.type_() == ATOM_TYPE_NUMBER {
-        Number::from_atom(a) == Number::from_atom(b)
-    } else if agnd.type_() == ATOM_TYPE_BOOL {
-        Bool::from_atom(a) == Bool::from_atom(b)
+    if a.type_() == ATOM_TYPE_STRING {
+        Str::try_from(a).unwrap() == Str::try_from(b).unwrap()
+    } else if a.type_() == ATOM_TYPE_NUMBER {
+        Number::try_from(a).unwrap() == Number::try_from(b).unwrap()
+    } else if a.type_() == ATOM_TYPE_BOOL {
+        Bool::try_from(a).unwrap() == Bool::try_from(b).unwrap()
     } else {
         false
     }

--- a/hyperon-atom/src/gnd/mod.rs
+++ b/hyperon-atom/src/gnd/mod.rs
@@ -79,3 +79,33 @@ impl<T: GroundedFunction> CustomExecute for GroundedFunctionAtom<T> {
         self.0.func.execute(args)
     }
 }
+
+use gnd::str::*;
+use gnd::number::*;
+use gnd::bool::*;
+
+/// Compares two grounded atoms for equality
+pub fn gnd_eq(a: &Atom, b: &Atom) -> bool {
+    // TODO: this function is a hack which is introduced for embedded grounded
+    // types only. It should be replaced by some mechanism which allows defining
+    // a single grounded atom equality procedure in a MeTTa module. This could
+    // be done via defining a type class or equality function overloading.
+    let agnd = TryInto::<&dyn GroundedAtom>::try_into(a).expect("Grounded atom is expected");
+    let bgnd = TryInto::<&dyn GroundedAtom>::try_into(b).expect("Grounded atom is expected");
+
+    if agnd.eq_gnd(bgnd) {
+        return true
+    }
+    if agnd.type_() != bgnd.type_() {
+        return false
+    }
+    if agnd.type_() == ATOM_TYPE_STRING {
+        Str::from_atom(a) == Str::from_atom(b)
+    } else if agnd.type_() == ATOM_TYPE_NUMBER {
+        Number::from_atom(a) == Number::from_atom(b)
+    } else if agnd.type_() == ATOM_TYPE_BOOL {
+        Bool::from_atom(a) == Bool::from_atom(b)
+    } else {
+        false
+    }
+}

--- a/hyperon-atom/src/gnd/mod.rs
+++ b/hyperon-atom/src/gnd/mod.rs
@@ -1,5 +1,6 @@
 pub mod str;
 pub mod number;
+pub mod bool;
 
 use std::rc::Rc;
 

--- a/hyperon-atom/src/gnd/mod.rs
+++ b/hyperon-atom/src/gnd/mod.rs
@@ -1,3 +1,5 @@
+pub mod str;
+
 use std::rc::Rc;
 
 use super::*;

--- a/hyperon-atom/src/gnd/number.rs
+++ b/hyperon-atom/src/gnd/number.rs
@@ -56,6 +56,21 @@ impl Into<f64> for Number {
     }
 }
 
+impl TryFrom<&Atom> for Number {
+    type Error = &'static str;
+    fn try_from(value: &Atom) -> Result<Self, Self::Error> {
+        std::convert::TryInto::<&dyn GroundedAtom>::try_into(value)
+            .and_then(NumberSerializer::convert)
+    }
+}
+
+impl TryFrom<&dyn GroundedAtom> for Number {
+    type Error = &'static str;
+    fn try_from(value: &dyn GroundedAtom) -> Result<Self, Self::Error> {
+        NumberSerializer::convert(value)
+    }
+}
+
 impl Number {
     pub fn from_int_str(num: &str) -> Result<Self, String> {
         let n = num.parse::<i64>().map_err(|e| format!("Could not parse integer: '{num}', {e}"))?;
@@ -73,7 +88,7 @@ impl Number {
     }
 
     pub fn from_atom(atom: &Atom) -> Option<Self> {
-        NumberSerializer::convert(atom)
+        Number::try_from(atom).ok()
     }
 
     fn get_type(&self) -> NumberType {

--- a/hyperon-atom/src/gnd/number.rs
+++ b/hyperon-atom/src/gnd/number.rs
@@ -1,6 +1,4 @@
-use hyperon_atom::*;
-use hyperon_atom::serial;
-use hyperon_atom::ConvertingSerializer;
+use crate::*;
 
 use std::fmt::Display;
 

--- a/hyperon-atom/src/gnd/str.rs
+++ b/hyperon-atom/src/gnd/str.rs
@@ -24,7 +24,7 @@ impl Str {
     }
     /// Try to convert an atom into `Str` instance
     pub fn from_atom(atom: &Atom) -> Option<Self> {
-        StrSerializer::convert(atom)
+        Str::try_from(atom).ok()
     }
 }
 
@@ -53,6 +53,21 @@ impl std::fmt::Display for Str {
 impl Into<String> for Str {
     fn into(self) -> String {
         self.as_str().into()
+    }
+}
+
+impl TryFrom<&Atom> for Str {
+    type Error = &'static str;
+    fn try_from(value: &Atom) -> Result<Self, Self::Error> {
+        std::convert::TryInto::<&dyn GroundedAtom>::try_into(value)
+            .and_then(StrSerializer::convert)
+    }
+}
+
+impl TryFrom<&dyn GroundedAtom> for Str {
+    type Error = &'static str;
+    fn try_from(value: &dyn GroundedAtom) -> Result<Self, Self::Error> {
+        StrSerializer::convert(value)
     }
 }
 

--- a/hyperon-atom/src/gnd/str.rs
+++ b/hyperon-atom/src/gnd/str.rs
@@ -1,7 +1,5 @@
-use hyperon_atom::*;
+use crate::*;
 use hyperon_common::immutable_string::ImmutableString;
-use hyperon_atom::serial;
-use hyperon_atom::ConvertingSerializer;
 use unescaper;
 
 /// String type
@@ -112,7 +110,7 @@ pub fn unescape(str: &str) -> unescaper::Result<String> {
     })
 }
 
-pub(crate) fn expect_string_like_atom(atom: &Atom) -> Option<String> {
+pub fn expect_string_like_atom(atom: &Atom) -> Option<String> {
     match atom {
         Atom::Symbol(_) | Atom::Grounded(_) => Some(atom_to_string(atom)),
         _ => None,

--- a/hyperon-atom/src/lib.rs
+++ b/hyperon-atom/src/lib.rs
@@ -778,14 +778,6 @@ impl<T: CustomGroundedType> CustomGroundedTypeToAtom for &Wrap<T> {
     }
 }
 
-impl PartialEq for Box<dyn GroundedAtom> {
-    fn eq(&self, other: &Self) -> bool {
-        self.eq_gnd(&**other)
-    }
-}
-
-impl Eq for Box<dyn GroundedAtom> {}
-
 impl Clone for Box<dyn GroundedAtom> {
     fn clone(&self) -> Self {
         self.clone_gnd()
@@ -999,7 +991,7 @@ impl PartialEq for Atom {
             // because of strange compiler error which requires Copy trait
             // to be implemented. It prevents using constant atoms as patterns
             // for matching (see COMMA_SYMBOL in grounding.rs for instance).
-            (Atom::Grounded(gnd), Atom::Grounded(other)) => PartialEq::eq(gnd, other),
+            (Atom::Grounded(_), Atom::Grounded(_)) => gnd::gnd_eq(self, other),
             _ => false,
         }
     }

--- a/hyperon-atom/src/lib.rs
+++ b/hyperon-atom/src/lib.rs
@@ -796,29 +796,26 @@ pub trait ConvertingSerializer<T>: serial::Serializer + Default {
     /// First it checks whether the grounded atom is already an instance of `T`
     /// and clones value if it the case. Otherwise it uses `Self` to convert
     /// into `T` via serialization.
-    fn convert(atom: &Atom) -> Option<T>
+    fn convert(gnd: &dyn GroundedAtom) -> Result<T, &'static str>
         where T: 'static + Clone
     {
-        std::convert::TryInto::<&dyn GroundedAtom>::try_into(atom)
-            .ok()
-            .and_then(|gnd| {
-                gnd.as_any_ref()
-                    // TODO: it is not clear whether this step really improves performance.
-                    // On the other hand it requires `T` to be static and implement `Clone`.
-                    // It is better to do a performance test and check if first step should be
-                    // removed.
-                    .downcast_ref::<T>()
-                    .cloned()
-                    .or_else(|| {
-                        if Self::check_type(gnd) {
-                            let mut serializer = Self::default();
-                            gnd.serialize(&mut serializer).ok()
-                                .and_then(|()| serializer.into_type())
-                        } else {
-                            None
-                        }
-                    })
+        gnd.as_any_ref()
+            // TODO: it is not clear whether this step really improves performance.
+            // On the other hand it requires `T` to be static and implement `Clone`.
+            // It is better to do a performance test and check if first step should be
+            // removed.
+            .downcast_ref::<T>()
+            .cloned()
+            .or_else(|| {
+                if Self::check_type(gnd) {
+                    let mut serializer = Self::default();
+                    gnd.serialize(&mut serializer).ok()
+                        .and_then(|()| serializer.into_type())
+                } else {
+                    None
+                }
             })
+            .ok_or("Incorrect type")
     }
 }
 
@@ -987,11 +984,7 @@ impl PartialEq for Atom {
             (Atom::Symbol(sym), Atom::Symbol(other)) => PartialEq::eq(sym, other),
             (Atom::Expression(expr), Atom::Expression(other)) => PartialEq::eq(expr, other),
             (Atom::Variable(var), Atom::Variable(other)) => PartialEq::eq(var, other),
-            // TODO: PartialEq cannot be derived for the Box<dyn GroundedAtom>
-            // because of strange compiler error which requires Copy trait
-            // to be implemented. It prevents using constant atoms as patterns
-            // for matching (see COMMA_SYMBOL in grounding.rs for instance).
-            (Atom::Grounded(_), Atom::Grounded(_)) => gnd::gnd_eq(self, other),
+            (Atom::Grounded(gnd), Atom::Grounded(other)) => gnd::gnd_eq(&**gnd, &**other),
             _ => false,
         }
     }
@@ -1410,8 +1403,8 @@ mod test {
 
     #[test]
     fn test_converting_serializer() {
-        assert_eq!(I64Serializer::convert(&Atom::gnd(I64Gnd(42))), Some(42));
-        assert_eq!(I64Serializer::convert(&Atom::value("42")), None);
-        assert_eq!(I64Serializer::convert(&Atom::gnd(F64Gnd(42.0))), None);
+        assert_eq!(I64Serializer::convert(&CustomGroundedAtom(I64Gnd(42))), Ok(42));
+        assert_eq!(I64Serializer::convert(&AutoGroundedAtom("42")), Err("Incorrect type"));
+        assert_eq!(I64Serializer::convert(&CustomGroundedAtom(F64Gnd(42.0))), Err("Incorrect type"));
     }
 }

--- a/hyperon-atom/src/matcher.rs
+++ b/hyperon-atom/src/matcher.rs
@@ -1219,7 +1219,7 @@ fn atoms_are_equivalent_with_bindings<'a>(left: &'a Atom, right: &'a Atom,
             can_be_renamed(left_vars, left, right) &&
                 can_be_renamed(right_vars, right, left),
         (Atom::Symbol(left), Atom::Symbol(right)) => left == right,
-        (Atom::Grounded(left), Atom::Grounded(right)) => left == right,
+        (Atom::Grounded(_), Atom::Grounded(_)) => crate::gnd::gnd_eq(left, right),
         (Atom::Expression(left), Atom::Expression(right)) =>
             left.children().len() == right.children().len() &&
             left.children().iter().zip(right.children().iter())

--- a/hyperon-atom/src/matcher.rs
+++ b/hyperon-atom/src/matcher.rs
@@ -1219,7 +1219,7 @@ fn atoms_are_equivalent_with_bindings<'a>(left: &'a Atom, right: &'a Atom,
             can_be_renamed(left_vars, left, right) &&
                 can_be_renamed(right_vars, right, left),
         (Atom::Symbol(left), Atom::Symbol(right)) => left == right,
-        (Atom::Grounded(_), Atom::Grounded(_)) => crate::gnd::gnd_eq(left, right),
+        (Atom::Grounded(left), Atom::Grounded(right)) => crate::gnd::gnd_eq(&**left, &**right),
         (Atom::Expression(left), Atom::Expression(right)) =>
             left.children().len() == right.children().len() &&
             left.children().iter().zip(right.children().iter())

--- a/hyperon-macros/src/lib.rs
+++ b/hyperon-macros/src/lib.rs
@@ -318,7 +318,7 @@ impl PrinterBase {
 
     fn bool(&mut self, b: &str) {
         self.ident("hyperon_atom").punct("::").ident("Atom").punct("::").ident("gnd").group('(')
-            .ident("hyperon").punct("::").ident("metta").punct("::").ident("runner").punct("::").ident("bool").punct("::").ident("Bool").group('(')
+            .ident("hyperon_atom").punct("::").ident("gnd").punct("::").ident("bool").punct("::").ident("Bool").group('(')
             .ident(b)
             .group(')').group(')');
     }

--- a/hyperon-macros/src/lib.rs
+++ b/hyperon-macros/src/lib.rs
@@ -325,14 +325,14 @@ impl PrinterBase {
 
     fn integer(&mut self, n: i64) {
         self.ident("hyperon_atom").punct("::").ident("Atom").punct("::").ident("gnd").group('(')
-            .ident("hyperon").punct("::").ident("metta").punct("::").ident("runner").punct("::").ident("number").punct("::").ident("Number").punct("::").ident("Integer").group('(')
+            .ident("hyperon_atom").punct("::").ident("gnd").punct("::").ident("number").punct("::").ident("Number").punct("::").ident("Integer").group('(')
             .literal(Literal::i64_suffixed(n))
             .group(')').group(')');
     }
 
     fn float(&mut self, f: f64) {
         self.ident("hyperon_atom").punct("::").ident("Atom").punct("::").ident("gnd").group('(')
-            .ident("hyperon").punct("::").ident("metta").punct("::").ident("runner").punct("::").ident("number").punct("::").ident("Number").punct("::").ident("Float").group('(')
+            .ident("hyperon_atom").punct("::").ident("gnd").punct("::").ident("number").punct("::").ident("Number").punct("::").ident("Float").group('(')
             .literal(Literal::f64_suffixed(f))
             .group(')').group(')');
     }

--- a/hyperon-macros/src/lib.rs
+++ b/hyperon-macros/src/lib.rs
@@ -339,7 +339,7 @@ impl PrinterBase {
 
     fn str(&mut self, s: &str) {
         self.ident("hyperon_atom").punct("::").ident("Atom").punct("::").ident("gnd").group('(')
-            .ident("hyperon").punct("::").ident("metta").punct("::").ident("runner").punct("::").ident("str").punct("::").ident("Str").punct("::").ident("from_str").group('(')
+            .ident("hyperon_atom").punct("::").ident("gnd").punct("::").ident("str").punct("::").ident("Str").punct("::").ident("from_str").group('(')
             .literal(Literal::string(s))
             .group(')').group(')');
     }

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -13,7 +13,6 @@ im = "15.1.0"
 rand = "0.9.0"
 dyn-fmt = "0.4.0"
 itertools = "0.13.0"
-unescaper = "0.1.5"
 unicode_reader = "1.0.2"
 serde_json = { version="1.0.116", optional=true }
 

--- a/lib/examples/sorted_list.rs
+++ b/lib/examples/sorted_list.rs
@@ -1,6 +1,6 @@
 use hyperon_atom::*;
 use hyperon::metta::runner::*;
-use hyperon::metta::runner::number::Number;
+use hyperon_atom::gnd::number::Number;
 use hyperon::metta::text::SExprParser;
 
 fn main() -> Result<(), String> {

--- a/lib/src/metta/interpreter.rs
+++ b/lib/src/metta/interpreter.rs
@@ -15,7 +15,7 @@ use std::rc::Rc;
 use std::fmt::Write;
 use std::cell::RefCell;
 use itertools::Itertools;
-use crate::metta::runner::number::Number;
+use hyperon_atom::gnd::number::Number;
 
 macro_rules! match_atom {
     ($atom:tt ~ $pattern:tt => $succ:tt , _ => $error:tt) => {

--- a/lib/src/metta/mod.rs
+++ b/lib/src/metta/mod.rs
@@ -7,7 +7,7 @@ pub mod runner;
 
 use hyperon_atom::*;
 use hyperon_macros::*;
-use crate::metta::runner::str::atom_to_string;
+use hyperon_atom::gnd::str::atom_to_string;
 use crate::space::grounding::GroundingSpace;
 
 pub const ATOM_TYPE_UNDEFINED : Atom = metta_const!(%Undefined%);

--- a/lib/src/metta/runner/builtin_mods/fileio.rs
+++ b/lib/src/metta/runner/builtin_mods/fileio.rs
@@ -12,7 +12,7 @@ use crate::space::grounding::GroundingSpace;
 use crate::metta::text::SExprParser;
 use crate::metta::runner::{ModuleLoader, RunContext, DynSpace, Metta, MettaMod};
 use hyperon_atom::gnd::*;
-use crate::metta::runner::number::{Number, ATOM_TYPE_NUMBER};
+use hyperon_atom::gnd::number::{Number, ATOM_TYPE_NUMBER};
 
 pub static FILEIO_METTA: &'static str = include_str!("fileio.metta");
 pub const ATOM_TYPE_FILE_HANDLE: Atom = sym!("FileHandle");

--- a/lib/src/metta/runner/builtin_mods/fileio.rs
+++ b/lib/src/metta/runner/builtin_mods/fileio.rs
@@ -3,7 +3,7 @@ use std::fmt::{Display, Formatter};
 use hyperon_atom::{sym, Atom, ExecError, Grounded};
 use crate::metta::{ARROW_SYMBOL, UNIT_ATOM};
 use crate::metta::runner::stdlib::unit_result;
-use crate::metta::runner::str::{Str, ATOM_TYPE_STRING};
+use hyperon_atom::gnd::str::{Str, ATOM_TYPE_STRING};
 use std::fs;
 use std::fs::OpenOptions;
 use std::io::{Read, Seek, SeekFrom, Write};

--- a/lib/src/metta/runner/builtin_mods/json.rs
+++ b/lib/src/metta/runner/builtin_mods/json.rs
@@ -5,8 +5,8 @@ use crate::space::grounding::GroundingSpace;
 use crate::metta::text::SExprParser;
 use crate::metta::runner::{Metta, ModuleLoader, RunContext};
 use crate::metta::runner::modules::MettaMod;
-use crate::metta::runner::str::ATOM_TYPE_STRING;
-use crate::metta::runner::str::Str;
+use hyperon_atom::gnd::str::ATOM_TYPE_STRING;
+use hyperon_atom::gnd::str::Str;
 use serde_json::Value;
 use hyperon_space::ATOM_TYPE_SPACE;
 use crate::metta::runner::DynSpace;
@@ -325,7 +325,7 @@ mod tests {
         use hyperon_atom::Atom;
         use hyperon_space::DynSpace;
         use crate::space::grounding::*;
-        use crate::metta::runner::str::Str;
+        use hyperon_atom::gnd::str::Str;
         use super::super::json_encode;
 
         #[bench]

--- a/lib/src/metta/runner/builtin_mods/json.rs
+++ b/lib/src/metta/runner/builtin_mods/json.rs
@@ -11,7 +11,7 @@ use serde_json::Value;
 use hyperon_space::ATOM_TYPE_SPACE;
 use crate::metta::runner::DynSpace;
 use crate::metta::runner::bool::*;
-use crate::metta::runner::number::{Number, ATOM_TYPE_NUMBER};
+use hyperon_atom::gnd::number::{Number, ATOM_TYPE_NUMBER};
 use std::io::Write;
 
 pub static JSON_METTA: &'static str = include_str!("json.metta");

--- a/lib/src/metta/runner/builtin_mods/json.rs
+++ b/lib/src/metta/runner/builtin_mods/json.rs
@@ -10,7 +10,7 @@ use hyperon_atom::gnd::str::Str;
 use serde_json::Value;
 use hyperon_space::ATOM_TYPE_SPACE;
 use crate::metta::runner::DynSpace;
-use crate::metta::runner::bool::*;
+use hyperon_atom::gnd::bool::*;
 use hyperon_atom::gnd::number::{Number, ATOM_TYPE_NUMBER};
 use std::io::Write;
 

--- a/lib/src/metta/runner/builtin_mods/random.rs
+++ b/lib/src/metta/runner/builtin_mods/random.rs
@@ -2,7 +2,7 @@
 use hyperon_atom::*;
 use crate::metta::*;
 use crate::metta::text::SExprParser;
-use crate::metta::runner::number::*;
+use hyperon_atom::gnd::number::*;
 use crate::metta::runner::bool::*;
 
 use std::fmt::{Display, Formatter};

--- a/lib/src/metta/runner/builtin_mods/random.rs
+++ b/lib/src/metta/runner/builtin_mods/random.rs
@@ -3,7 +3,7 @@ use hyperon_atom::*;
 use crate::metta::*;
 use crate::metta::text::SExprParser;
 use hyperon_atom::gnd::number::*;
-use crate::metta::runner::bool::*;
+use hyperon_atom::gnd::bool::*;
 
 use std::fmt::{Display, Formatter};
 use std::cell::RefCell;

--- a/lib/src/metta/runner/environment.rs
+++ b/lib/src/metta/runner/environment.rs
@@ -450,8 +450,8 @@ fn git_catalog_from_cfg_atom(atom: &ExpressionAtom, env: &Environment) -> Result
     let refresh_time = refresh_time.ok_or_else(|| format!("Error in environment.metta. \"refreshTime\" property required for #gitCatalog"))?
         .parse::<u64>().map_err(|e| format!("Error in environment.metta.  Error parsing \"refreshTime\": {e}"))?;
 
-    let catalog_name = crate::metta::runner::str::strip_quotes(catalog_name);
-    let catalog_url = crate::metta::runner::str::strip_quotes(catalog_url);
+    let catalog_name = hyperon_atom::gnd::str::strip_quotes(catalog_name);
+    let catalog_url = hyperon_atom::gnd::str::strip_quotes(catalog_url);
     let mut managed_remote_catalog = LocalCatalog::new(caches_dir, catalog_name).unwrap();
     let remote_catalog = GitCatalog::new(caches_dir, env.fs_mod_formats.clone(), catalog_name, catalog_url, refresh_time).unwrap();
     managed_remote_catalog.push_upstream_catalog(Box::new(remote_catalog));
@@ -470,7 +470,7 @@ fn include_path_from_cfg_atom(atom: &ExpressionAtom, env: &Environment) -> Resul
     let path = <&hyperon_atom::SymbolAtom>::try_from(path_atom)?.name();
     // At this stage stdlib is not loaded and thus path is parsed as a symbol not string. 
     // This is why we should manuall stip quotes from the symbol's name.
-    let path = crate::metta::runner::str::strip_quotes(path);
+    let path = hyperon_atom::gnd::str::strip_quotes(path);
 
     //TODO-FUTURE: In the future we may want to replace dyn-fmt with strfmt, and do something a
     // little bit nicer than this

--- a/lib/src/metta/runner/mod.rs
+++ b/lib/src/metta/runner/mod.rs
@@ -96,7 +96,6 @@ use builtin_mods::*;
 
 pub mod bool;
 pub mod number;
-pub mod str;
 
 const EXEC_SYMBOL : Atom = sym!("!");
 

--- a/lib/src/metta/runner/mod.rs
+++ b/lib/src/metta/runner/mod.rs
@@ -95,7 +95,6 @@ mod builtin_mods;
 use builtin_mods::*;
 
 pub mod bool;
-pub mod number;
 
 const EXEC_SYMBOL : Atom = sym!("!");
 
@@ -1232,11 +1231,10 @@ pub fn run_program(program: &str) -> Result<Vec<Vec<Atom>>, String> {
 
 #[cfg(test)]
 mod tests {
-    use crate::metta::runner::number::Number;
+    use hyperon_atom::gnd::number::Number;
     use super::*;
     use super::bool::Bool;
     use hyperon_macros::metta;
-    use crate as hyperon;
 
     #[test]
     fn test_space() {

--- a/lib/src/metta/runner/mod.rs
+++ b/lib/src/metta/runner/mod.rs
@@ -94,8 +94,6 @@ use stdlib::CoreLibLoader;
 mod builtin_mods;
 use builtin_mods::*;
 
-pub mod bool;
-
 const EXEC_SYMBOL : Atom = sym!("!");
 
 // *-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*-=-*
@@ -1233,7 +1231,7 @@ pub fn run_program(program: &str) -> Result<Vec<Vec<Atom>>, String> {
 mod tests {
     use hyperon_atom::gnd::number::Number;
     use super::*;
-    use super::bool::Bool;
+    use hyperon_atom::gnd::bool::Bool;
     use hyperon_macros::metta;
 
     #[test]

--- a/lib/src/metta/runner/modules/mod.rs
+++ b/lib/src/metta/runner/modules/mod.rs
@@ -660,7 +660,7 @@ pub enum ResourceKey<'a> {
 #[cfg(test)]
 mod test {
     use hyperon_atom::gnd::GroundedFunctionAtom;
-    use crate::metta::runner::number::{Number, ATOM_TYPE_NUMBER};
+    use hyperon_atom::gnd::number::{Number, ATOM_TYPE_NUMBER};
     use super::*;
     use std::sync::Mutex;
     use std::sync::LazyLock;

--- a/lib/src/metta/runner/pkg_mgmt/git_catalog.rs
+++ b/lib/src/metta/runner/pkg_mgmt/git_catalog.rs
@@ -382,6 +382,6 @@ fn git_catalog_direct_test() {
     runner.display_loaded_modules();
 
     let result = runner.run(SExprParser::new("!(fact 5)"));
-    assert_eq!(result, Ok(vec![vec![expr!({crate::metta::runner::number::Number::Integer(120)})]]));
+    assert_eq!(result, Ok(vec![vec![expr!({hyperon_atom::gnd::number::Number::Integer(120)})]]));
 }
 

--- a/lib/src/metta/runner/stdlib/arithmetics.rs
+++ b/lib/src/metta/runner/stdlib/arithmetics.rs
@@ -3,7 +3,7 @@ use crate::metta::*;
 use crate::metta::text::Tokenizer;
 use super::regex;
 use hyperon_atom::gnd::number::*;
-use crate::metta::runner::bool::*;
+use hyperon_atom::gnd::bool::*;
 
 use std::fmt::Display;
 

--- a/lib/src/metta/runner/stdlib/arithmetics.rs
+++ b/lib/src/metta/runner/stdlib/arithmetics.rs
@@ -2,7 +2,7 @@ use hyperon_atom::*;
 use crate::metta::*;
 use crate::metta::text::Tokenizer;
 use super::regex;
-use crate::metta::runner::number::*;
+use hyperon_atom::gnd::number::*;
 use crate::metta::runner::bool::*;
 
 use std::fmt::Display;

--- a/lib/src/metta/runner/stdlib/atom.rs
+++ b/lib/src/metta/runner/stdlib/atom.rs
@@ -477,7 +477,7 @@ mod tests {
     use super::*;
     use crate::metta::text::SExprParser;
     use crate::metta::runner::EnvBuilder;
-    use crate::metta::runner::str::Str;
+    use hyperon_atom::gnd::str::Str;
     use crate::space::grounding::metta_space;
     use crate::metta::runner::run_program;
     use crate::metta::runner::Metta;

--- a/lib/src/metta/runner/stdlib/atom.rs
+++ b/lib/src/metta/runner/stdlib/atom.rs
@@ -5,7 +5,7 @@ use crate::metta::text::Tokenizer;
 use crate::metta::types::{AtomType, get_atom_types, get_meta_type};
 use hyperon_common::multitrie::{MultiTrie, TrieKey, TrieToken};
 use super::{grounded_op, regex};
-use crate::metta::runner::number::*;
+use hyperon_atom::gnd::number::*;
 
 use std::convert::TryInto;
 use std::hash::{DefaultHasher, Hasher};

--- a/lib/src/metta/runner/stdlib/core.rs
+++ b/lib/src/metta/runner/stdlib/core.rs
@@ -6,7 +6,7 @@ use crate::metta::text::Tokenizer;
 use hyperon_common::CachingMapper;
 use crate::metta::runner::Metta;
 use crate::metta::runner::PragmaSettings;
-use crate::metta::runner::bool::*;
+use hyperon_atom::gnd::bool::*;
 use hyperon_atom::gnd::GroundedFunctionAtom;
 use hyperon_atom::matcher::{Bindings, apply_bindings_to_atom_move};
 

--- a/lib/src/metta/runner/stdlib/core.rs
+++ b/lib/src/metta/runner/stdlib/core.rs
@@ -300,7 +300,7 @@ mod tests {
     use crate::metta::runner::run_program;
     use hyperon_atom::matcher::atoms_are_equivalent;
     use crate::space::grounding::metta_space;
-    use crate::metta::runner::number::Number;
+    use hyperon_atom::gnd::number::Number;
     use hyperon_common::{assert_eq_no_order, assert_eq_metta_results};
 
     use std::convert::TryFrom;

--- a/lib/src/metta/runner/stdlib/debug.rs
+++ b/lib/src/metta/runner/stdlib/debug.rs
@@ -5,7 +5,7 @@ use hyperon_common::collections::{SliceDisplay, Equality, DefaultEquality};
 use hyperon_common::assert::compare_vec_no_order;
 use hyperon_atom::matcher::atoms_are_equivalent;
 use crate::metta::runner::stdlib::{grounded_op, regex, unit_result};
-use crate::metta::runner::bool::*;
+use hyperon_atom::gnd::bool::*;
 use hyperon_atom::gnd::str::*;
 use hyperon_atom::gnd::GroundedFunctionAtom;
 

--- a/lib/src/metta/runner/stdlib/debug.rs
+++ b/lib/src/metta/runner/stdlib/debug.rs
@@ -6,7 +6,7 @@ use hyperon_common::assert::compare_vec_no_order;
 use hyperon_atom::matcher::atoms_are_equivalent;
 use crate::metta::runner::stdlib::{grounded_op, regex, unit_result};
 use crate::metta::runner::bool::*;
-use crate::metta::runner::str::*;
+use hyperon_atom::gnd::str::*;
 use hyperon_atom::gnd::GroundedFunctionAtom;
 
 use std::convert::TryInto;

--- a/lib/src/metta/runner/stdlib/math.rs
+++ b/lib/src/metta/runner/stdlib/math.rs
@@ -3,7 +3,7 @@ use crate::metta::*;
 use crate::metta::text::Tokenizer;
 use super::{grounded_op, regex};
 use hyperon_atom::gnd::number::*;
-use crate::metta::runner::bool::*;
+use hyperon_atom::gnd::bool::*;
 
 use std::convert::TryInto;
 

--- a/lib/src/metta/runner/stdlib/math.rs
+++ b/lib/src/metta/runner/stdlib/math.rs
@@ -2,7 +2,7 @@ use hyperon_atom::*;
 use crate::metta::*;
 use crate::metta::text::Tokenizer;
 use super::{grounded_op, regex};
-use crate::metta::runner::number::*;
+use hyperon_atom::gnd::number::*;
 use crate::metta::runner::bool::*;
 
 use std::convert::TryInto;

--- a/lib/src/metta/runner/stdlib/mod.rs
+++ b/lib/src/metta/runner/stdlib/mod.rs
@@ -138,7 +138,7 @@ mod tests {
     use super::*;
     use crate::metta::text::SExprParser;
     use crate::metta::runner::EnvBuilder;
-    use crate::metta::runner::str::Str;
+    use hyperon_atom::gnd::str::Str;
     use hyperon_atom::matcher::atoms_are_equivalent;
     use crate::metta::runner::bool::Bool;
     use crate::metta::runner::number::Number;

--- a/lib/src/metta/runner/stdlib/mod.rs
+++ b/lib/src/metta/runner/stdlib/mod.rs
@@ -141,13 +141,13 @@ mod tests {
     use hyperon_atom::gnd::str::Str;
     use hyperon_atom::matcher::atoms_are_equivalent;
     use crate::metta::runner::bool::Bool;
-    use crate::metta::runner::number::Number;
+    use hyperon_atom::gnd::number::Number;
     use crate::metta::runner::run_program;
     use hyperon_atom::gnd::GroundedFunctionAtom;
     use hyperon_common::assert_eq_metta_results;
 
     use std::fmt::Display;
-    use crate::metta::runner::number::Number::Integer;
+    use hyperon_atom::gnd::number::Number::Integer;
 
     #[test]
     fn metta_switch() {

--- a/lib/src/metta/runner/stdlib/mod.rs
+++ b/lib/src/metta/runner/stdlib/mod.rs
@@ -140,7 +140,7 @@ mod tests {
     use crate::metta::runner::EnvBuilder;
     use hyperon_atom::gnd::str::Str;
     use hyperon_atom::matcher::atoms_are_equivalent;
-    use crate::metta::runner::bool::Bool;
+    use hyperon_atom::gnd::bool::Bool;
     use hyperon_atom::gnd::number::Number;
     use crate::metta::runner::run_program;
     use hyperon_atom::gnd::GroundedFunctionAtom;

--- a/lib/src/metta/runner/stdlib/module.rs
+++ b/lib/src/metta/runner/stdlib/module.rs
@@ -5,7 +5,7 @@ use crate::metta::text::Tokenizer;
 use hyperon_common::shared::Shared;
 use crate::metta::runner::{Metta, RunContext, ResourceKey};
 use super::{grounded_op, regex, unit_result};
-use crate::metta::runner::str::expect_string_like_atom;
+use hyperon_atom::gnd::str::expect_string_like_atom;
 
 use regex::Regex;
 

--- a/lib/src/metta/runner/stdlib/package.rs
+++ b/lib/src/metta/runner/stdlib/package.rs
@@ -6,7 +6,7 @@ use crate::metta::runner::{Metta, RunContext,
                            git_catalog::ModuleGitLocation,
                            mod_name_from_url,
                            pkg_mgmt::UpdateMode};
-use crate::metta::runner::str::expect_string_like_atom;
+use hyperon_atom::gnd::str::expect_string_like_atom;
 
 /// Provides a way to access [Metta::load_module_at_path] from within MeTTa code
 #[derive(Clone, Debug)]

--- a/lib/src/metta/runner/stdlib/space.rs
+++ b/lib/src/metta/runner/stdlib/space.rs
@@ -231,7 +231,6 @@ mod tests {
     use crate::metta::runner::Metta;
     use hyperon_common::assert_eq_no_order;
     use hyperon_macros::metta;
-    use crate as hyperon;
 
     #[test]
     fn mod_space_op() {

--- a/lib/src/metta/runner/stdlib/string.rs
+++ b/lib/src/metta/runner/stdlib/string.rs
@@ -1,7 +1,7 @@
 use hyperon_atom::*;
 use crate::metta::*;
 use crate::metta::text::Tokenizer;
-use crate::metta::runner::str::*;
+use hyperon_atom::gnd::str::*;
 use super::{grounded_op, unit_result, regex};
 
 use std::convert::TryInto;

--- a/lib/src/metta/text.rs
+++ b/lib/src/metta/text.rs
@@ -871,7 +871,7 @@ mod tests {
         // contours can't be captured by a regex.
         let mut tokenizer = Tokenizer::new();
         tokenizer.register_fallible_token(Regex::new(r"[\-\+]?\d+.\d+").unwrap(),
-            |token| Ok(Atom::gnd(crate::metta::runner::number::Number::from_float_str(token)?))
+            |token| Ok(Atom::gnd(hyperon_atom::gnd::number::Number::from_float_str(token)?))
         );
         let mut parser = SExprParser::new("12345678901234567:8901234567890");
         assert!(parser.parse(&tokenizer).is_err());

--- a/lib/src/metta/types.rs
+++ b/lib/src/metta/types.rs
@@ -24,7 +24,7 @@ use hyperon_space::DynSpace;
 
 use std::fmt::{Display, Debug};
 use itertools::Itertools;
-use crate::metta::runner::number::Number;
+use hyperon_atom::gnd::number::Number;
 
 fn typeof_query(atom: &Atom, typ: &Atom) -> Atom {
     Atom::expr(vec![HAS_TYPE_SYMBOL, atom.clone(), typ.clone()])
@@ -671,7 +671,6 @@ pub fn validate_atom(space: &DynSpace, atom: &Atom) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate as hyperon;
     use hyperon_atom::matcher::atoms_are_equivalent;
     use crate::metta::runner::*;
     use crate::metta::text::SExprParser;

--- a/lib/tests/macros.rs
+++ b/lib/tests/macros.rs
@@ -2,7 +2,7 @@ use hyperon_atom::*;
 use hyperon_macros::metta;
 use hyperon_atom::gnd::number::*;
 use hyperon_atom::gnd::str::*;
-use hyperon::metta::runner::bool::*;
+use hyperon_atom::gnd::bool::*;
 
 #[test]
 fn macros_metta_literal() {

--- a/lib/tests/macros.rs
+++ b/lib/tests/macros.rs
@@ -1,7 +1,7 @@
 use hyperon_atom::*;
 use hyperon_macros::metta;
 use hyperon::metta::runner::number::*;
-use hyperon::metta::runner::str::*;
+use hyperon_atom::gnd::str::*;
 use hyperon::metta::runner::bool::*;
 
 #[test]

--- a/lib/tests/macros.rs
+++ b/lib/tests/macros.rs
@@ -1,6 +1,6 @@
 use hyperon_atom::*;
 use hyperon_macros::metta;
-use hyperon::metta::runner::number::*;
+use hyperon_atom::gnd::number::*;
 use hyperon_atom::gnd::str::*;
 use hyperon::metta::runner::bool::*;
 

--- a/lib/tests/metta.rs
+++ b/lib/tests/metta.rs
@@ -4,7 +4,7 @@ use hyperon_atom::gnd::*;
 use hyperon::metta::{UNIT_ATOM, ERROR_SYMBOL};
 use hyperon::metta::text::*;
 use hyperon::metta::runner::{Metta, EnvBuilder};
-use hyperon::metta::runner::str::atom_to_string;
+use hyperon_atom::gnd::str::atom_to_string;
 
 #[test]
 fn test_reduce_higher_order() {

--- a/lib/tests/types.rs
+++ b/lib/tests/types.rs
@@ -3,7 +3,7 @@ use hyperon::metta::*;
 use hyperon::metta::text::*;
 use hyperon::metta::runner::{Metta, EnvBuilder};
 use hyperon_atom::gnd::number::Number;
-use hyperon::metta::runner::bool::Bool;
+use hyperon_atom::gnd::bool::Bool;
 
 #[test]
 fn test_types_in_metta() {

--- a/lib/tests/types.rs
+++ b/lib/tests/types.rs
@@ -2,7 +2,7 @@ use hyperon_atom::*;
 use hyperon::metta::*;
 use hyperon::metta::text::*;
 use hyperon::metta::runner::{Metta, EnvBuilder};
-use hyperon::metta::runner::number::Number;
+use hyperon_atom::gnd::number::Number;
 use hyperon::metta::runner::bool::Bool;
 
 #[test]

--- a/repl/src/metta_shim.rs
+++ b/repl/src/metta_shim.rs
@@ -42,7 +42,7 @@ pub mod metta_interface_mod {
     use pyo3::types::{PyTuple, PyString, PyBool, PyList, PyDict};
     use hyperon_common::collections::VecDisplay;
     use super::{exec_state_prepare, exec_state_should_break};
-    use hyperon::metta::runner::str::unescape;
+    use hyperon_atom::gnd::str::unescape;
     use hyperon::metta::text::CharReader;
 
     /// Load the hyperon module, and get the "__version__" attribute
@@ -274,7 +274,7 @@ pub mod metta_interface_mod {
     use hyperon_atom::ExpressionAtom;
     use hyperon_atom::Atom;
     use hyperon::metta::runner::{Metta, RunnerState, Environment, EnvBuilder};
-    use hyperon::metta::runner::str::Str;
+    use hyperon_atom::gnd::str::Str;
     use hyperon_common::collections::VecDisplay;
     use super::{exec_state_prepare, exec_state_should_break};
 


### PR DESCRIPTION
Fixes #1033 replaces #1035 
`str.rs`, `number.rs` and `bool.rs` are moved into `hyperon_atom` module.
`gnd_eq` function is introduced to compare grounded atoms. Comprison via conversion for `String`, `Number` and `Bool` grounded types is hardcoded. This make comparison of Python strings slower because they are always converted into Rust string before comparison. On the other hand this is a bit faster than #1035 because it converts atoms according to their grounded types and in case of Rust data no conversion is made.