### PR TITLE
Fix unique-atom: use alpha-equivalence to check equality between atoms to get unique-atom.

### DIFF
--- a/lib/src/metta/runner/stdlib/atom.rs
+++ b/lib/src/metta/runner/stdlib/atom.rs
@@ -3,6 +3,7 @@ use hyperon_space::*;
 use crate::metta::*;
 use crate::metta::text::Tokenizer;
 use crate::metta::types::{AtomType, get_atom_types, get_meta_type};
+use hyperon_atom::matcher::atoms_are_equivalent;
 use hyperon_common::multitrie::{MultiTrie, TrieKey, TrieToken};
 use super::{grounded_op, regex};
 use hyperon_atom::gnd::number::*;
@@ -25,21 +26,22 @@ impl Grounded for UniqueAtomOp {
     }
 }
 
-impl CustomExecute for UniqueAtomOp {
-    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {
-        let arg_error = || ExecError::from("unique expects single expression atom as an argument");
-        let expr = TryInto::<&ExpressionAtom>::try_into(args.get(0).ok_or_else(arg_error)?)?;
-
-        let mut atoms: Vec<Atom> = expr.children().into();
-        let mut set = GroundingSpace::new();
-        atoms.retain(|x| {
-            let not_contained = set.query(x).is_empty();
-            if not_contained { set.add(x.clone()) };
-            not_contained
-        });
-        Ok(vec![Atom::expr(atoms)])
-    }
+impl CustomExecute for UniqueAtomOp {    
+    fn execute(&self, args: &[Atom]) -> Result<Vec<Atom>, ExecError> {    
+        let arg_error = || ExecError::from("unique expects single expression atom as an argument");    
+        let expr = TryInto::<&ExpressionAtom>::try_into(args.get(0).ok_or_else(arg_error)?)?;    
+    
+        let mut atoms: Vec<Atom> = expr.children().into();    
+        let mut seen: Vec<Atom> = Vec::new();    
+        atoms.retain(|x| {    
+            let not_contained = !seen.iter().any(|seen_atom| atoms_are_equivalent(seen_atom, x));    
+            if not_contained { seen.push(x.clone()) };    
+            not_contained    
+        });    
+        Ok(vec![Atom::expr(atoms)])    
+    }    
 }
+
 
 #[derive(Clone, Debug)]
 pub struct UnionAtomOp {}
@@ -622,6 +624,31 @@ mod tests {
         )]).unwrap();
         assert_eq_no_order!(actual,
                    vec![expr!(("A" ("B" "C")) ("f" "g") "Z")]);
+    }
+
+     #[test]  
+    fn unique_op_() {  
+        let unique_op = UniqueAtomOp{};  
+        let yonas = VariableAtom::new("yonas");  
+        let tol = VariableAtom::new("tol");  
+        let name_var = VariableAtom::new("name");  
+    
+        // Build the input: ((name $yonas) (name $tol) ($name $tol))  
+        let input = Atom::expr([  
+            Atom::expr([Atom::sym("name"), Atom::Variable(yonas.clone())]),  
+            Atom::expr([Atom::sym("name"), Atom::Variable(tol.clone())]),  
+            Atom::expr([Atom::Variable(name_var.clone()), Atom::Variable(tol.clone())])  
+        ]);  
+    
+        let actual = unique_op.execute(&[input]).unwrap();  
+        // the old implementation was giving us only ((name $yonas)) which is incorrect but now it is fixed
+        // Expected: ((name $yonas) ($name $tol))  
+        let expected = vec![Atom::expr([  
+            Atom::expr([Atom::sym("name"), Atom::Variable(yonas.clone())]),  
+            Atom::expr([Atom::Variable(name_var.clone()), Atom::Variable(tol.clone())])  
+        ])];  
+    
+        assert_eq!(actual, expected);  
     }
 
     #[test]


### PR DESCRIPTION
Summary
-------
This PR fixes incorrect behavior in `unique-atom`  where atoms were treated as duplicates if they could be unified. 
`unique-atom` must consider atoms equal under alpha-equivalence (renaming of bound/used
variables), not unification, to avoid dropping distinct syntactic patterns.

Problem and reproduction
------------------------
The current implementation uses the grounding/query matcher (unification)
to decide uniqueness. As a result, atoms such as:

  (I $firstVar $yon)
  (I am $secondVar)

are considered duplicates because the matcher can unify them, even though
they are syntactically distinct and should both appear in the result of
`unique-atom`.

Example:
Input:
  !(unique-atom ((I yonas ayele) (I $firstVar $yon) (I am $secondVar) (I $firstVar tol)))
Observed (incorrect) output:
  ((I yonas ayele) (I am $secondVar))   -- several distinct patterns were lost

Expected output:
  All distinct atoms retained (alpha-equivalent atoms considered equal,
  but distinct syntactic atoms preserved).
  :- ((I yonas ayele) (I $firstVar $yon) (I am $secondVar) (I $firstVar tol)))

Root cause
----------
`unique-atom` relied on GroundingSpace.query() and its pattern matching
(unification). That matcher creates variable bindings and reports atoms as
non-empty/duplicate when they unify. However, `unique-atom` needs alpha-
equivalence, not unification equality.

What I changed
--------------
- Replace the unification-based equality check in `unique-atom` with an
  alpha-equivalence check using `atoms_are_equivalent` from
  `hyperon-atom/src/matcher.rs`.
- Keep all other behavior unchanged; only the equality notion used for
  uniqueness is altered.

Why this fix
------------
Alpha-equivalence is the correct equality notion for a `unique` operation
working on syntactic atoms containing variables: two atoms that only differ
by the names of their variables are treated as the same pattern, while
distinct syntactic patterns should be retained even if they could unify.

Testing & validation
--------------------
- Added/updated tests to cover:
  - Atoms that differ only by variable names (should be considered equal).
  - Atoms that are syntactically distinct (even if unifiable) should both
    appear in `unique-atom` results.

Related issues
--------------
- Fixes #1042