### PR TITLE
[Fix][DAS] Avoid port range intersection in `test.metta`

### DIFF
--- a/integration_tests/das/test.metta
+++ b/integration_tests/das/test.metta
@@ -1,6 +1,6 @@
 !(import! &self das)
 
-!(bind! &das (new-das! (0.0.0.0:42000-42499) (0.0.0.0:40002)))
+!(bind! &das (new-das! (localhost:52000-52099) (localhost:40002)))
 
 ; Check if pattern_matching service is ready, giving it some seconds for handshaking
 !(das-service-status! pattern_matching_query)


### PR DESCRIPTION
The `das_test` should be fixed now:
https://github.com/trueagi-io/hyperon-experimental/actions/runs/19332895222