### PR TITLE
[DAS] Bump module version to use `DAS v1.0.0`

### DIFF
--- a/docs/das_setup.md
+++ b/docs/das_setup.md
@@ -10,7 +10,7 @@ wget -O - http://45.77.4.33/apt-repo/setup.sh | sudo bash
 
 sudo apt -y install das-toolbox
 
-# >= 0.5.8
+# >= 1.0.0
 das-cli --version
 ```
 
@@ -19,7 +19,7 @@ You can also run `das-cli` from source, using python3 (other OS):
 git clone https://github.com/singnet/das-toolbox.git
 
 cd das-toolbox
-git checkout tags/0.5.8
+git checkout tags/1.0.0
 
 # Optional - Create a virtual env
 python3 -m venv .venv

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -30,7 +30,7 @@ hyperon-macros = { workspace = true }
 # das deps
 [dependencies.metta-bus-client]
 git = "https://github.com/singnet/das"
-tag = "0.11.14"
+tag = "1.0.0"
 package = "metta-bus-client"
 optional = true
 

--- a/lib/src/metta/runner/builtin_mods/das.rs
+++ b/lib/src/metta/runner/builtin_mods/das.rs
@@ -35,10 +35,10 @@ use crate::space::grounding::GroundingSpace;
 /// Execute !(help!) to get list of the standard library functions.
 /// > !(import! &self das)
 /// [()]
-/// > !(bind! &das (new-das! localhost:42000-42999 localhost:40002))
+/// > !(bind! &das (new-das! (localhost:52000-52099) (localhost:40002)))
 /// [()]
 /// > !(match &das (Similarity "human" $S) ($S))
-/// [(a408f6dd446cdd4fa56f82e77fe6c870), (3225ea795289574ceee32e091ad54ef4), (181a19436acef495c8039a610be59603)]
+/// [("ent"), ("chimp"), ("monkey")]
 /// >
 
 /// Loader to Initialize the "das" module


### PR DESCRIPTION
This PR sets the `metta-bus-client` to use the DAS `v1.0.0`

The `das-tests` workflow is green on this branch:
https://github.com/trueagi-io/hyperon-experimental/actions/runs/19569644809